### PR TITLE
fix(table): 修复表格背景颜色再深色模式下会被穿透问题

### DIFF
--- a/build/vite/plugin/theme.ts
+++ b/build/vite/plugin/theme.ts
@@ -66,7 +66,7 @@ export function configThemePlugin(isBuild: boolean): Plugin[] {
         'border-color-base': '#303030',
         // 'border-color-split': '#30363d',
         'item-active-bg': '#111b26',
-        'app-content-background': 'rgb(255 255 255 / 4%)',
+        'app-content-background': '#1e1e1e',
         'tree-node-selected-bg': '#11263c',
 
         'alert-success-border-color': '#274916',

--- a/src/components/Table/src/BasicTable.vue
+++ b/src/components/Table/src/BasicTable.vue
@@ -334,6 +334,13 @@
 
   @prefix-cls: ~'@{namespace}-basic-table';
 
+  [data-theme='dark'] {
+    .ant-table-tbody > tr:hover.ant-table-row-selected > td,
+    .ant-table-tbody > tr.ant-table-row-selected td {
+      background-color: #262626;
+    }
+  }
+
   .@{prefix-cls} {
     max-width: 100%;
 


### PR DESCRIPTION
暗色模式下表格固定列背景会被穿透

![image](https://user-images.githubusercontent.com/50100681/130944553-3ebbc429-b7d0-4ef0-aa5e-6d686b35b697.png)

![image](https://user-images.githubusercontent.com/50100681/130944645-edae9c0e-eba8-4ab9-a954-7d7f15487b6b.png)
