### PR TITLE
解决设置分页条数会被重置的问题

### DIFF
--- a/CHANGELOG.zh_CN.md
+++ b/CHANGELOG.zh_CN.md
@@ -11,6 +11,7 @@
   - 修复`inset`属性不起作用的问题
   - 修复`useTable`与`BasicTable`实例的`reload`方法`await`表现不一致的问题
   - 修复`clickToRowSelect`会无视行选择框 disabled 状态的问题
+  - 修复`BasicTable`在某些情况下，分页会被重置的问题
 - **BasicModal**
   - 修复点击遮罩、按下`Esc`键都不能关闭`Modal`的问题
   - 修复点击关闭按钮、最大化按钮旁边的空白区域也会导致`Modal`关闭的问题

--- a/mock/demo/table-demo.ts
+++ b/mock/demo/table-demo.ts
@@ -12,7 +12,7 @@ function getRandomPics(count = 10): string[] {
 
 const demoList = (() => {
   const result: any[] = [];
-  for (let index = 0; index < 60; index++) {
+  for (let index = 0; index < 200; index++) {
     result.push({
       id: `${index}`,
       beginTime: '@datetime',

--- a/src/components/Table/src/hooks/usePagination.tsx
+++ b/src/components/Table/src/hooks/usePagination.tsx
@@ -1,6 +1,6 @@
 import type { PaginationProps } from '../types/pagination';
 import type { BasicTableProps } from '../types/table';
-import { computed, unref, ref, ComputedRef, watchEffect } from 'vue';
+import { computed, unref, ref, ComputedRef, watch } from 'vue';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons-vue';
 import { isBoolean } from '/@/utils/is';
 import { PAGE_SIZE, PAGE_SIZE_OPTIONS } from '../const';
@@ -27,15 +27,17 @@ export function usePagination(refProps: ComputedRef<BasicTableProps>) {
   const configRef = ref<PaginationProps>({});
   const show = ref(true);
 
-  watchEffect(() => {
-    const { pagination } = unref(refProps);
-    if (!isBoolean(pagination) && pagination) {
-      configRef.value = {
-        ...unref(configRef),
-        ...(pagination ?? {}),
-      };
-    }
-  });
+  watch(
+    () => unref(refProps).pagination,
+    (pagination) => {
+      if (!isBoolean(pagination) && pagination) {
+        configRef.value = {
+          ...unref(configRef),
+          ...(pagination ?? {}),
+        };
+      }
+    },
+  );
 
   const getPaginationInfo = computed((): PaginationProps | boolean => {
     const { pagination } = unref(refProps);

--- a/src/views/demo/table/FetchTable.vue
+++ b/src/views/demo/table/FetchTable.vue
@@ -22,6 +22,7 @@
         title: '远程加载示例',
         api: demoListApi,
         columns: getBasicColumns(),
+        pagination: { pageSize: 10 },
       });
       function handleReloadCurrent() {
         reload();


### PR DESCRIPTION
复现步骤：
1. useTable中设置了pagination
2. 表格加载完毕后，在页面上切换分页条数
3. 在页面上切换页码，分页条数会被重置

问题的原因：
切换页码的时候，表格的onChange事件会去设置pagination，但由于错误的使用了watchEffect，导致pagination此时会被重置。
如果没有手动设置pagination，不会有问题，但如果设置了pagination则会被重置。
![image](https://user-images.githubusercontent.com/11787429/136641438-2407a25c-f505-4da6-a1f7-67407c1dfda6.png)

![image](https://user-images.githubusercontent.com/11787429/136641418-ab71f00c-44a1-4c4c-ae59-1006d821193c.png)


### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
