### PR TITLE
fix: clean script execution failure problem

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -7,21 +7,23 @@
     "url": "https://github.com/anncwb"
   },
   "scripts": {
+    "bootstrap": "pnpm install",
     "dev": "vite",
     "build": "cross-env NODE_ENV=production vite build && esno ./scripts/post-build.ts",
     "build:test": "cross-env vite build --mode test && esno ./scripts/post-build.ts",
-    "build:no-cache": "pnpm clean:cache && npm run build",
-    "report": "cross-env REPORT=true npm run build",
+    "build:no-cache": "pnpm clean:cache && pnpm build",
+    "report": "cross-env REPORT=true pnpm build",
     "type:check": "vue-tsc --noEmit --skipLibCheck",
-    "preview": "npm run build && vite preview",
+    "preview": "pnpm build && vite preview",
     "preview:dist": "vite preview",
+    "clean": "pnpm clean:lib",
     "clean:cache": "rimraf node_modules/.cache/ && rimraf node_modules/.vite",
     "clean:lib": "rimraf node_modules",
     "test": "vitest",
     "test:unit": "vitest",
     "server:gzip": "npx http-server dist --cors --gzip -c-1",
     "server:br": "npx http-server dist --cors --brotli -c-1",
-    "reinstall": "rimraf pnpm-lock.yaml && rimraf package.lock.json && rimraf node_modules && npm run bootstrap",
+    "reinstall": "pnpm clean && pnpm bootstrap",
     "gen:icon": "esno ./scripts/generate-icon.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,16 @@
   },
   "scripts": {
     "bootstrap": "pnpm install",
-    "dev": "pnpm run -C admin dev",
-    "build": "pnpm run -C admin build",
+    "dev": "pnpm -C admin dev",
+    "build": "pnpm -C admin build",
     "log": "conventional-changelog -p angular -i CHANGELOG.md -s",
-    "clean": "npm run clean:dist && npm run clean -r --stream",
-    "clean:all": "npm run clean:dist && npm lib clean:dist  && npm run clean -r --stream",
+    "clean": "pnpm clean:dist && pnpm clean:lib",
     "clean:dist": "rimraf dist",
     "clean:lib": "rimraf node_modules",
     "lint:eslint": "eslint --cache --max-warnings 0  \"{packages,admin}/**/*.{vue,ts,tsx}\" --fix",
     "lint:prettier": "prettier --write  \"{packages,admin}/**/*.{js,json,ts,tsx,css,less,scss,vue,html,md}\"",
     "lint:stylelint": "stylelint --fix \"**/*.{vue,less,postcss,css,scss}\"",
-    "reinstall": "rimraf pnpm-lock.yaml && rimraf package.lock.json && rimraf yarn.lock && npm run clean:all && npm run bootstrap",
+    "reinstall": "rimraf pnpm-lock.yaml && pnpm clean && pnpm bootstrap",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
The following error occurred when I ran `pnpm reinstall`, I made this PR to solve this problem

```
➜  vue-vben-admin git:(next) ✗ pnpm reinstall

> @admin/root@3.0.0-alpha.3 reinstall /Users/xxx/vue-vben-admin
> rimraf pnpm-lock.yaml && rimraf package.lock.json && rimraf yarn.lock && npm run clean:all && npm run bootstrap


> @admin/root@3.0.0-alpha.3 clean:all
> npm run clean:dist && npm lib clean:dist  && npm run clean -r --stream


> @admin/root@3.0.0-alpha.3 clean:dist
> rimraf dist

Unknown command: "lib"

To see a list of supported npm commands, run:
  npm help
 ELIFECYCLE  Command failed with exit code 1.
```