### PR TITLE
fix: 修复EditCellTable 可编辑单元格当columns.ellipsis=true时，回调中取不到key的值。

### DIFF
--- a/src/components/Table/src/components/editable/EditableCell.vue
+++ b/src/components/Table/src/components/editable/EditableCell.vue
@@ -265,7 +265,7 @@
               result = await beforeEditSubmit({
                 record: pick(record, keys),
                 index,
-                key: key as string,
+                key: dataKey as string,
                 value,
               });
             } catch (e) {
@@ -281,7 +281,7 @@
 
         set(record, dataKey, value);
         //const record = await table.updateTableData(index, dataKey, value);
-        needEmit && table.emit?.('edit-end', { record, index, key, value });
+        needEmit && table.emit?.('edit-end', { record, index, key: dataKey, value });
         isEdit.value = false;
       }
 


### PR DESCRIPTION
修复EditCellTable组件 可编辑单元格当columns.ellipsis=false时，回调中取不到key的值。
![image](https://user-images.githubusercontent.com/3828820/149925988-78f7611b-eb0c-4b88-9be9-dc774a36e16c.png)
