### PR TITLE
feat: make fields key of form deconstructable

### DIFF
--- a/src/views/demo/form/index.vue
+++ b/src/views/demo/form/index.vue
@@ -531,6 +531,22 @@
       },
     },
     {
+      field: 'divider-deconstruct',
+      component: 'Divider',
+      label: '字段解构',
+      helpMessage: ['如果组件的值是 array 或者 object', '可以根据 ES6 的解构语法分别取值'],
+    },
+    {
+      field: '[startTime, endTime]',
+      label: '时间范围',
+      component: 'RangePicker',
+      componentProps: {
+        format: 'YYYY-MM-DD HH:mm:ss',
+        placeholder: ['开始时间', '结束时间'],
+        showTime: { format: 'HH:mm:ss' },
+      },
+    },
+    {
       field: 'divider-others',
       component: 'Divider',
       label: '其它',
@@ -602,6 +618,7 @@
           keyword.value = '';
         },
         handleSubmit: (values: any) => {
+          console.log('values', values);
           createMessage.success('click search,values:' + JSON.stringify(values));
         },
         check,


### PR DESCRIPTION
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

添加对表单字段解构赋值的支持。某些表单组件的 value 值是 array 或者 object 类型，但是我们使用的时候却往往需要展开取值。如 RangePicker 返回 ['2012-12-1', '2022-1-2']， 而我们传给后端的往往是
`{ startTime: '2012-12-1'， endTime: '2022-1-2' }`。需要前端写很多难看的转换代码。

字段解构赋值可以在 field 字段声明如何解构和赋值。
```javascript
const schema = [
     {
       field: '[startTime, endTime]',
       label: '时间范围',
       component: 'RangePicker',
     },
      {
       field: '{ name, level }',
       label: '人员等级',
       component: 'CustomPickerObjectValue',
     },
]

// getFormValue 得到的就是
const form = {
   startTime: '',
   endTime: '',
   name: '',
   level: ''
}
```


