### PR TITLE
# fix: stylelint 检查 less 内置函数 function-no-unknown

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
   customSyntax: 'postcss-html',
   rules: {
-    'selector-class-pattern': null,
+    'function-no-unknown': null,
     'selector-class-pattern': null,
     'selector-pseudo-class-no-unknown': [
       true,


### PR DESCRIPTION
### 问题描述
运行 `npm run lint:stylelint ` 命令时，less 内置函数会报 `function-no-unknown` 的错误