### PR TITLE
fix: 修复 当窗口过窄时，表格中的删除确认框样式错乱 的问题

### DIFF
--- a/src/views/demo/system/account/index.vue
+++ b/src/views/demo/system/account/index.vue
@@ -24,6 +24,7 @@
               tooltip: '删除此账号',
               popConfirm: {
                 title: '是否确认删除',
+                placement: 'left',
                 confirm: handleDelete.bind(null, record),
               },
             },

--- a/src/views/demo/system/dept/index.vue
+++ b/src/views/demo/system/dept/index.vue
@@ -16,6 +16,7 @@
               color: 'error',
               popConfirm: {
                 title: '是否确认删除',
+                placement: 'left',
                 confirm: handleDelete.bind(null, record),
               },
             },

--- a/src/views/demo/system/menu/index.vue
+++ b/src/views/demo/system/menu/index.vue
@@ -16,6 +16,7 @@
               color: 'error',
               popConfirm: {
                 title: '是否确认删除',
+                placement: 'left',
                 confirm: handleDelete.bind(null, record),
               },
             },

--- a/src/views/demo/system/role/index.vue
+++ b/src/views/demo/system/role/index.vue
@@ -16,6 +16,7 @@
               color: 'error',
               popConfirm: {
                 title: '是否确认删除',
+                placement: 'left',
                 confirm: handleDelete.bind(null, record),
               },
             },


### PR DESCRIPTION
当窗口宽度过小时，表格删除确认框会出现样式错乱
