### PR TITLE
fix: 修复#2030改动引起的可展开table失效

### DIFF
--- a/src/views/demo/table/ExpandTable.vue
+++ b/src/views/demo/table/ExpandTable.vue
@@ -4,11 +4,11 @@
     content="不可与scroll共用。TableAction组件可配置stopButtonPropagation来阻止操作按钮的点击事件冒泡，以便配合Table组件的expandRowByClick"
   >
     <BasicTable @register="registerTable">
+      <template #expandedRowRender="{ record }">
+        <span>No: {{ record.no }} </span>
+      </template>
       <template #bodyCell="{ column, record }">
-        <template v-if="column.key === 'no'">
-          <span>No: {{ record.no }} </span>
-        </template>
-        <template v-else-if="column.key === 'action'">
+        <template v-if="column.key === 'action'">
           <TableAction
             stopButtonPropagation
             :actions="[


### PR DESCRIPTION
[#2030 ](https://github.com/vbenjs/vue-vben-admin/pull/2030)改动后，ExpandTable demo页面达不到预期了。

此pr修改前
<img width="695" alt="image" src="https://user-images.githubusercontent.com/45651308/177359040-2d03cc8e-85f9-4241-9c23-65544e0d7be5.png">
此pr修改后
<img width="772" alt="image" src="https://user-images.githubusercontent.com/45651308/177359189-701cf284-e61d-4e38-8795-63cafb7dc69a.png">

控制台也没有slot的警告，因为这个不属于column.slots

### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
