### PR TITLE
feat: 对BaseTree组件新增treeWrapperClassName属性

### DIFF
--- a/src/components/Tree/src/BasicTree.vue
+++ b/src/components/Tree/src/BasicTree.vue
@@ -437,7 +437,7 @@
                 {extendSlots(slots)}
               </TreeHeader>
             )}
-            <Spin spinning={unref(props.loading)} tip="加载中...">
+            <Spin wrapperClassName={unref(props.treeWrapperClassName)} spinning={unref(props.loading)} tip="加载中...">
               <ScrollContainer style={scrollStyle} v-show={!unref(getNotFound)}>
                 <Tree {...unref(getBindValues)} showIcon={false} treeData={treeData.value} />
               </ScrollContainer>

--- a/src/components/Tree/src/types/tree.ts
+++ b/src/components/Tree/src/types/tree.ts
@@ -134,6 +134,7 @@ export const treeProps = buildProps({
     type: Boolean,
     default: false,
   },
+  treeWrapperClassName: String
 });
 
 export type TreeProps = ExtractPropTypes<typeof treeProps>;

--- a/src/views/demo/system/account/DeptTree.vue
+++ b/src/views/demo/system/account/DeptTree.vue
@@ -4,6 +4,7 @@
       title="部门列表"
       toolbar
       search
+      treeWrapperClassName="h-[calc(100%-35px)] overflow-auto"
       :clickRowToExpand="false"
       :treeData="treeData"
       :fieldNames="{ key: 'id', title: 'deptName' }"


### PR DESCRIPTION
背景：目前BaseTree缺少对外层的样式控制，导致DeptTree.vue中的tree在窗口小的情况下无法添加滚动条样式。
方案：在BaseTree.vue的440行的使用spin组件wrapperClassName的属性，使其样式自定义，其值从BaseTree组件props获取。
