### PR TITLE
fix(vite-plugin-styleImport): fix ATextarea 直接引用出现样式导入错误的问题

### DIFF
--- a/build/vite/plugin/styleImport.ts
+++ b/build/vite/plugin/styleImport.ts
@@ -49,6 +49,7 @@ export function configStyleImportPlugin(_isBuild: boolean) {
           // 这里是需要额外引入样式的子组件列表
           // 单独引入子组件时需引入组件样式，否则会在打包后导致子组件样式丢失
           const replaceList = {
+            textarea: 'input',
             'typography-text': 'typography',
             'typography-title': 'typography',
             'typography-paragraph': 'typography',


### PR DESCRIPTION
直接引用 `ATextarea ` 会导致样式 import 报错
```js
import { Textarea } from 'ant-design-vue';
```

![image](https://user-images.githubusercontent.com/11679819/201454574-8dd8284d-686f-43f8-a2b1-e90200c6d105.png)

最小复现案例在 https://github.com/hunshcn/vue-vben-admin/tree/reproduce/textarea-style-import 

### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
