### PR TITLE
fix: 重置表单时移除URL中的参数

### DIFF
--- a/src/components/Form/src/hooks/useFormValues.ts
+++ b/src/components/Form/src/hooks/useFormValues.ts
@@ -76,7 +76,12 @@ export function useFormValues({
       }
       // Remove spaces
       if (isString(value)) {
-        value = value.trim();
+        // remove params from URL
+        if(value === '') {
+          value = undefined;
+        }else {
+          value = value.trim();
+        }
       }
       if (!tryDeconstructArray(key, value, res) && !tryDeconstructObject(key, value, res)) {
         // 没有解构成功的，按原样赋值


### PR DESCRIPTION
按照条件筛选表格数据，点击重置后请求的接口会带上某个筛选数据的字段，如 `xxx/info?page=1&pageSize=10&customParams=`, 而不是`xxx/info?page=1&pageSize=10`
原因是当 reset form后，default value 是 empty string，导致带上了参数