### PR TITLE
🐞 fix(Tree): 调整checkedKeys属性的类型

### DIFF
--- a/src/components/Tree/src/types/tree.ts
+++ b/src/components/Tree/src/types/tree.ts
@@ -100,7 +100,7 @@ export const treeProps = buildProps({
   },
 
   checkedKeys: {
-    type: Array as PropType<CheckKeys>,
+    type: [Array, Object] as PropType<CheckKeys>,
     default: () => [],
   },
 


### PR DESCRIPTION
使用Tree组件时, 如果设置checkStrictly为true, 控制台会打印props类型异常警告

通过调整checkedKeys属性类型定义解决警告问题