### PR TITLE
fix: 修复页面缓存不生效的问题

### DIFF
--- a/src/layouts/page/index.vue
+++ b/src/layouts/page/index.vue
@@ -15,13 +15,9 @@
         appear
       >
         <keep-alive v-if="openCache" :include="getCaches">
-          <div :key="route.name">
-            <component :is="Component" :key="route.fullPath" />
-          </div>
-        </keep-alive>
-        <div v-else :key="route.name">
           <component :is="Component" :key="route.fullPath" />
-        </div>
+        </keep-alive>
+        <component v-else :is="Component" :key="route.fullPath" />
       </transition>
     </template>
   </RouterView>

--- a/src/views/form-design/index.vue
+++ b/src/views/form-design/index.vue
@@ -1,8 +1,11 @@
 <template>
-  <VFormDesign />
+  <PageWrapper dense contentFullHeight fixedHeight>
+    <VFormDesign />
+  </PageWrapper>
 </template>
 
 <script lang="ts" setup>
+  import { PageWrapper } from '/@/components/Page';
   import VFormDesign from './components/VFormDesign/index.vue';
 </script>
 


### PR DESCRIPTION
1. 修复页面不能缓存的bug
2. 此更新为破坏性更新，页面不支持多标签使用
3. 将表单设计模块多标签改成单标签
