### PR TITLE
fix: 修复VITE_GLOB_APP_TITLE中不能存在-的问题#1522

### DIFF
--- a/internal/vite-config/src/plugins/appConfig.ts
+++ b/internal/vite-config/src/plugins/appConfig.ts
@@ -28,7 +28,7 @@ async function createAppConfigPlugin({
     name: PLUGIN_NAME,
     async configResolved(_config) {
       let appTitle = _config?.env?.VITE_GLOB_APP_TITLE ?? '';
-      appTitle = appTitle.replace(/\s/g, '_');
+      appTitle = appTitle.replace(/\s/g, '_').replace(/-/g, '_');
       publicPath = _config.base;
       source = await getConfigSource(appTitle);
     },

--- a/src/hooks/setting/index.ts
+++ b/src/hooks/setting/index.ts
@@ -10,7 +10,7 @@ export const useGlobSetting = (): Readonly<GlobConfig> => {
   const glob: Readonly<GlobConfig> = {
     title: VITE_GLOB_APP_TITLE,
     apiUrl: VITE_GLOB_API_URL,
-    shortName: VITE_GLOB_APP_TITLE.replace(/\s/g, '_'),
+    shortName: VITE_GLOB_APP_TITLE.replace(/\s/g, '_').replace(/-/g, '_'),
     urlPrefix: VITE_GLOB_API_URL_PREFIX,
     uploadUrl: VITE_GLOB_UPLOAD_URL,
   };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,7 +2,7 @@ import type { GlobEnvConfig } from '/#/config';
 import pkg from '../../package.json';
 
 const getVariableName = (title: string) => {
-  return `__PRODUCTION__${title.replace(/\s/g, '_') || '__APP'}__CONF__`
+  return `__PRODUCTION__${title.replace(/\s/g, '_').replace(/-/g, '_') || '__APP'}__CONF__`
     .toUpperCase()
     .replace(/\s/g, '');
 };


### PR DESCRIPTION
#1522 
bug: `.env`中的配置项`VITE_GLOB_APP_TITLE(全称)`若出现了`-`则无法加载进登陆界面, console报错`Cannot destructure property 'VITE_GLOB_APP_TITLE' of 'C' as it is undefined.`

why: 查看文档以及代码发现`VITE_GLOB_APP_SHORT_NAME(简称)`项被定义但未被使用, 代码中所有需要用到`VITE_GLOB_APP_SHORT_NAME(简称)`的地方全都是replace得到的: `VITE_GLOB_APP_TITLE.replace(/\s/g, '_')`
代码中只替换了空格, 而未替换`-`, 所以造成了使用`VITE_GLOB_APP_SHORT_NAME(简称)`的地方可能会出现`-`导致无法加载的问题

本pr修复了该问题, 使得可以在`VITE_GLOB_APP_TITLE(全称)`中使用`-`

---
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [ ] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
