### PR TITLE
From default value

### DIFF
--- a/src/components/Form/src/BasicForm.vue
+++ b/src/components/Form/src/BasicForm.vue
@@ -117,15 +117,18 @@
       const getSchema = computed((): FormSchema[] => {
         const schemas: FormSchema[] = unref(schemaRef) || (unref(getProps).schemas as any);
         for (const schema of schemas) {
-          const { defaultValue, component, isHandleDateDefaultValue = true } = schema;
+          const { defaultValue, component, componentProps,isHandleDateDefaultValue = true } = schema;
           // handle date type
           if (isHandleDateDefaultValue && defaultValue && dateItemType.includes(component)) {
+              const valueFormat =componentProps ? componentProps['valueFormat'] : null;
             if (!Array.isArray(defaultValue)) {
-              schema.defaultValue = dateUtil(defaultValue);
+              schema.defaultValue =  valueFormat
+                  ? dateUtil(defaultValue).format(valueFormat)
+                  : dateUtil(defaultValue);
             } else {
               const def: any[] = [];
               defaultValue.forEach((item) => {
-                def.push(dateUtil(item));
+                def.push(valueFormat ? dateUtil(item).format(valueFormat) : dateUtil(item));
               });
               schema.defaultValue = def;
             }

--- a/src/components/Form/src/hooks/useFormValues.ts
+++ b/src/components/Form/src/hooks/useFormValues.ts
@@ -4,7 +4,6 @@ import { unref } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
 import type { FormProps, FormSchema } from '../types/form';
 import { cloneDeep, set } from 'lodash-es';
-import { dateItemType } from '../helper';
 
 interface UseFormValuesContext {
   defaultValueRef: Ref<any>;

--- a/src/components/Form/src/hooks/useFormValues.ts
+++ b/src/components/Form/src/hooks/useFormValues.ts
@@ -4,6 +4,7 @@ import { unref } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
 import type { FormProps, FormSchema } from '../types/form';
 import { cloneDeep, set } from 'lodash-es';
+import { dateItemType } from '../helper';
 
 interface UseFormValuesContext {
   defaultValueRef: Ref<any>;
@@ -132,7 +133,27 @@ export function useFormValues({
         obj[item.field] = defaultValue;
 
         if (formModel[item.field] === undefined) {
-          formModel[item.field] = defaultValue;
+          if (dateItemType.includes(item.component)) {
+            const valueFormat = item.componentProps ? item.componentProps['valueFormat'] : null;
+            if (Array.isArray(defaultValue)) {
+              const arr: any[] = [];
+              for (const ele of defaultValue) {
+                arr.push(
+                  ele ? (valueFormat ? dateUtil(ele).format(valueFormat) : dateUtil(ele)) : null,
+                );
+              }
+              formModel[item.field] = arr;
+            } else {
+              formModel[item.field] = defaultValue
+                ? valueFormat
+                  ? dateUtil(defaultValue).format(valueFormat)
+                  : dateUtil(defaultValue)
+                : null;
+            }
+          } else {
+            formModel[item.field] = defaultValue;
+          }
+          // formModel[item.field] = defaultValue;
         }
       }
     });

--- a/src/components/Form/src/hooks/useFormValues.ts
+++ b/src/components/Form/src/hooks/useFormValues.ts
@@ -133,27 +133,7 @@ export function useFormValues({
         obj[item.field] = defaultValue;
 
         if (formModel[item.field] === undefined) {
-          if (dateItemType.includes(item.component)) {
-            const valueFormat = item.componentProps ? item.componentProps['valueFormat'] : null;
-            if (Array.isArray(defaultValue)) {
-              const arr: any[] = [];
-              for (const ele of defaultValue) {
-                arr.push(
-                  ele ? (valueFormat ? dateUtil(ele).format(valueFormat) : dateUtil(ele)) : null,
-                );
-              }
-              formModel[item.field] = arr;
-            } else {
-              formModel[item.field] = defaultValue
-                ? valueFormat
-                  ? dateUtil(defaultValue).format(valueFormat)
-                  : dateUtil(defaultValue)
-                : null;
-            }
-          } else {
-            formModel[item.field] = defaultValue;
-          }
-          // formModel[item.field] = defaultValue;
+          formModel[item.field] = defaultValue;
         }
       }
     });


### PR DESCRIPTION
```
//src\components\Form\src\hooks\useFormValues.ts
 function initDefault() {
    const schemas = unref(getSchema);
    const obj: Recordable = {};
    schemas.forEach((item) => {
      const { defaultValue } = item;
      if (!isNullOrUnDef(defaultValue)) {
        obj[item.field] = defaultValue;

        if (formModel[item.field] === undefined) {
          formModel[item.field] = defaultValue;//====>初始化时未对时间相关字段进行格式化处理
        }
      }
    });
    defaultValueRef.value = cloneDeep(obj);
  }

  return { handleFormValues, initDefault };
}
```
```
//src\components\Form\src\BasicForm.vue
      const getSchema = computed((): FormSchema[] => {
        const schemas: FormSchema[] = unref(schemaRef) || (unref(getProps).schemas as any);
        for (const schema of schemas) {
          const { defaultValue, component } = schema;
          // handle date type
          if (defaultValue && dateItemType.includes(component)) {
            if (!Array.isArray(defaultValue)) {
              schema.defaultValue = dateUtil(defaultValue); //====>将初始值格式化为dayjs对象
            } else {
              const def: any[] = [];
              defaultValue.forEach((item) => {
                def.push(dateUtil(item));
              });
              schema.defaultValue = def;
            }
          }
        }
        if (unref(getProps).showAdvancedButton) {
          return cloneDeep(
            schemas.filter((schema) => schema.component !== 'Divider') as FormSchema[],
          );
        } else {
          return cloneDeep(schemas as FormSchema[]);
        }
      });
```
由于初始化时未对时间相关组件的defaultValue进行格式处理，而是直接实例化为一个dayjs对象；在值发生变动时根据组件的valueFormat对值进行格式化，但当值从不变动时则直接输出个初始的dayjs对象
