### PR TITLE
perf: useRefs函数接收泛型类型

### DIFF
--- a/packages/hooks/src/useRefs.ts
+++ b/packages/hooks/src/useRefs.ts
@@ -1,17 +1,17 @@
 import type { Ref } from 'vue';
 import { onBeforeUpdate, shallowRef } from 'vue';
 
-function useRefs(): {
-  refs: Ref<HTMLElement[]>;
-  setRefs: (index: number) => (el: HTMLElement) => void;
+function useRefs<T = HTMLElement>(): {
+  refs: Ref<T[]>;
+  setRefs: (index: number) => (el: T) => void;
 } {
-  const refs = shallowRef([]) as Ref<HTMLElement[]>;
+  const refs = shallowRef([]) as Ref<T[]>;
 
   onBeforeUpdate(() => {
     refs.value = [];
   });
 
-  const setRefs = (index: number) => (el: HTMLElement) => {
+  const setRefs = (index: number) => (el: T) => {
     refs.value[index] = el;
   };
 


### PR DESCRIPTION
useRefs函数目前只接收el:HTMLElement类型，可不可以转换成泛型去接收类型。
例如使用在组件模版上，把组件类型传入useRefs，这样在后续使用中就可以获取到准确的组件类型，例如：
```
<template>
  <MyModal 
    :ref="setRefs(index)"
    v-for="(item, index) in searchResult"
    :key="item.path"
 />
</template>
<script setup lang="ts">
 import { useRefs } from '@vben/hooks';
import MyModal from './MyModal.vue'
const { refs, setRefs } = useRefs<InstanceType<typeof MyModal>>();
</script>
```