### PR TITLE
fix: #2767 #2884 #2868

### DIFF
--- a/src/components/CardList/src/CardList.vue
+++ b/src/components/CardList/src/CardList.vue
@@ -61,7 +61,7 @@
 
               <CardMeta>
                 <template #title>
-                  <TypographyText :content="item.name" :ellipsis="{ tooltip: item.address }" />
+                  <TypographyParagraph :content="item.name" :ellipsis="{ tooltip: item.address }" />
                 </template>
                 <template #avatar>
                   <Avatar :src="item.avatar" />
@@ -93,7 +93,7 @@
 
   const ListItem = List.Item;
   const CardMeta = Card.Meta;
-  const TypographyText = Typography.Text;
+  const TypographyParagraph = Typography.Paragraph;
   // 获取slider属性
   const sliderProp = computed(() => useSlider(4));
   // 组件接收参数

--- a/src/components/Form/src/hooks/useFormEvents.ts
+++ b/src/components/Form/src/hooks/useFormEvents.ts
@@ -94,9 +94,7 @@ export function useFormEvents({
           formModel[field] = defaultValueObj![field];
         });
       }
-      const isInput = schema?.component && defaultValueComponents.includes(schema.component);
-      const defaultValue = cloneDeep(defaultValueRef.value[key]);
-      formModel[key] = isInput ? defaultValue || '' : defaultValue;
+      formModel[key] = getDefaultValue(schema, defaultValueRef, key);
     });
     nextTick(() => clearValidate());
 
@@ -406,4 +404,30 @@ export function useFormEvents({
     setFieldsValue,
     scrollToField,
   };
+}
+
+function getDefaultValue(
+  schema: FormSchema | undefined,
+  defaultValueRef: UseFormActionContext['defaultValueRef'],
+  key: string,
+) {
+  let defaultValue = cloneDeep(defaultValueRef.value[key]);
+  const isInput = checkIsInput(schema);
+  if (isInput) {
+    return defaultValue || '';
+  }
+  if (!defaultValue && schema && checkIsRangeSlider(schema)) {
+    defaultValue = [0, 0];
+  }
+  return defaultValue;
+}
+
+function checkIsRangeSlider(schema: FormSchema) {
+  if (schema.component === 'Slider' && schema.componentProps && schema.componentProps.range) {
+    return true;
+  }
+}
+
+function checkIsInput(schema?: FormSchema) {
+  return schema?.component && defaultValueComponents.includes(schema.component);
 }

--- a/src/views/form-design/components/VFormDesign/modules/FormComponentPanel.vue
+++ b/src/views/form-design/components/VFormDesign/modules/FormComponentPanel.vue
@@ -131,15 +131,16 @@
     }
 
     .draggable-box {
+      height: calc(100vh - 200px);
       // width: 100%;
+      overflow: auto;
+
       .drag-move {
         min-height: 62px;
         cursor: move;
       }
 
       .list-main {
-        height: 100%;
-        overflow: auto;
         // 列表动画
         .list-enter-active {
           transition: all 0.5s;


### PR DESCRIPTION
-  修复了重置后的 range slider 组件的默认值为**数组**。
- 对获取组件默认值的函数进行了重构。
-  Typography.Text 的 ellipsis 属性只接受布尔类型的值，**删除ellipsis属性**或**换成Paragraph组件**就不再有闪烁了
- 修复表单设计页面容器的问题：当容器内的内容超过页面高度时，没有出现垂直滚动条