### PR TITLE
feat(Form): 为fieldMapToTime的映射类型增加时间戳转换

### DIFF
--- a/src/components/Form/src/hooks/useFormValues.ts
+++ b/src/components/Form/src/hooks/useFormValues.ts
@@ -115,12 +115,21 @@ export function useFormValues({
 
       const [startTimeFormat, endTimeFormat] = Array.isArray(format) ? format : [format, format];
 
-      values[startTimeKey] = dateUtil(startTime).format(startTimeFormat);
-      values[endTimeKey] = dateUtil(endTime).format(endTimeFormat);
+      values[startTimeKey] = formatTime(startTime, startTimeFormat);
+      values[endTimeKey] = formatTime(endTime, endTimeFormat);
       Reflect.deleteProperty(values, field);
     }
 
     return values;
+  }
+
+  function formatTime(time: string, format: string) {
+    if (format === 'timestamp') {
+      return dateUtil(time).unix();
+    } else if (format === 'timestampStartDay') {
+      return dateUtil(time).startOf('day').unix();
+    }
+    return dateUtil(time).format(format);
   }
 
   function initDefault() {


### PR DESCRIPTION
为fieldMapToTime的第三个参数增加 timestamp 和 timestampStartDay 选项

- timestamp的作用: 将映射的时间格式转为时间戳
- timestampStartDay的作用： 将映射的时间格式转为当天0点开始的时间戳


增加 timestampStartDay 是必要的，因为 Antd 日期选择器组件即使在禁用时间功能时，输出的值仍包含组件创建时的时分秒。通过添加 timestampStartDay 选项，可以确保输出值只包含组件创建时的日期部分。

ElementUI的日期选择器没有这样的问题，可能是我用惯它了 😆 