### PR TITLE
fix(ApiTreeSelect):  ApiTreeSelect组件首次调用会重复请求(#2940)

### DIFF
--- a/src/components/Form/src/components/ApiTreeSelect.vue
+++ b/src/components/Form/src/components/ApiTreeSelect.vue
@@ -60,10 +60,6 @@
         emit('change', ...args);
       }
 
-      watchEffect(() => {
-        props.immediate && fetch();
-      });
-
       watch(
         () => props.params,
         () => {
@@ -85,7 +81,7 @@
 
       async function fetch() {
         const { api } = props;
-        if (!api || !isFunction(api)) return;
+        if (!api || !isFunction(api) || loading.value) return;
         loading.value = true;
         treeData.value = [];
         let result;


### PR DESCRIPTION
由于watchEffect，onMounted会立即执行，所以导致重复请求。
并且 watch函数和watchEffect监听的依赖重复了，故删去
