### PR TITLE
style(Drawer): antdv4版本 drawer要使用rootClassName来来配置最外层元素样式

### DIFF
--- a/src/components/Drawer/src/BasicDrawer.vue
+++ b/src/components/Drawer/src/BasicDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <Drawer :class="prefixCls" @close="onClose" v-bind="getBindValues">
+  <Drawer :rootClassName="prefixCls" @close="onClose" v-bind="getBindValues">
     <template #title v-if="!$slots.title">
       <DrawerHeader
         :title="getMergeProps.title"
@@ -94,7 +94,7 @@
             opt.width = '100%';
           }
           const detailCls = `${prefixCls}__detail`;
-          opt.class = wrapClassName ? `${wrapClassName} ${detailCls}` : detailCls;
+          opt.rootClassName = wrapClassName ? `${wrapClassName} ${detailCls}` : detailCls;
 
           if (!getContainer) {
             // TODO type error?

--- a/src/components/Drawer/src/typing.ts
+++ b/src/components/Drawer/src/typing.ts
@@ -134,6 +134,7 @@ export interface DrawerProps extends DrawerFooterProps {
    */
   wrapClassName?: string;
   class?: string;
+  rootClassName?: string;
   /**
    * Style of wrapper element which **contains mask** compare to `drawerStyle`
    * @type object


### PR DESCRIPTION

![image](https://github.com/vbenjs/vue-vben-admin/assets/24707417/7878d574-cc42-48a1-99b9-9a7b3fbc7b06)

因为v4版本配置外层class的属性变更，导致详情页模式下的 drawer组件会全屏覆盖