### PR TITLE
fix(Header): 顶部菜单混合模式下，头部导航栏样式错位 #3021

### DIFF
--- a/src/layouts/default/header/index.less
+++ b/src/layouts/default/header/index.less
@@ -3,7 +3,7 @@
 @breadcrumb-prefix-cls: ~'@{namespace}-layout-breadcrumb';
 @logo-prefix-cls: ~'@{namespace}-app-logo';
 
-.@{header-prefix-cls} {
+.ant-layout .@{header-prefix-cls} {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/layouts/default/header/index.vue
+++ b/src/layouts/default/header/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <Layout.Header :class="getHeaderClass" style="height: auto; padding-inline: 0">
+  <Layout.Header :class="getHeaderClass">
     <!-- left start -->
     <div :class="`${prefixCls}-left`">
       <!-- logo -->


### PR DESCRIPTION
antdv4的ant-layout-header css会携带父选择器 导致vben-layout-header 设定的line-height失效


antdv3的css

![image](https://github.com/vbenjs/vue-vben-admin/assets/24707417/3cad9dfd-eecf-44ff-8cb7-c15b38db977a)

antdv4的css

![image](https://github.com/vbenjs/vue-vben-admin/assets/24707417/38c4efc5-4574-408a-b1ef-43a013c5d8de)
