### PR TITLE
perf: 指令权限v-auth支持并显示按钮权限

### DIFF
--- a/src/hooks/web/usePermission.ts
+++ b/src/hooks/web/usePermission.ts
@@ -75,6 +75,14 @@ export function usePermission() {
     if (PermissionModeEnum.BACK === permMode) {
       const allCodeList = permissionStore.getPermCodeList as string[];
       if (!isArray(value)) {
+        const splits = ['||', '&&'];
+        const splitName = splits.find((item) => value.includes(item));
+        if (splitName) {
+          const splitCodes = value.split(splitName);
+          return splitName === splits[0]
+            ? intersection(splitCodes, allCodeList).length > 0
+            : intersection(splitCodes, allCodeList).length === splitCodes.length;
+        }
         return allCodeList.includes(value);
       }
       return (intersection(value, allCodeList) as string[]).length > 0;


### PR DESCRIPTION
目前看，按钮权限是数组，满足数组中一个的话，就会显示按钮权限。但没有全部满足才展示的判断，有时候需要组合判断，
如v-auth="'checked&&unchecked'"。