### PR TITLE
fix(ApiSelect):  ApiSelect首次选择值时仍然提示校验, fix #3065

### DIFF
--- a/src/components/Form/src/components/ApiSelect.vue
+++ b/src/components/Form/src/components/ApiSelect.vue
@@ -144,6 +144,7 @@
       }
 
       function handleChange(_, ...args) {
+        emit('change', args[0] ? args[0].value : undefined);
         emitData.value = args;
       }
 

--- a/src/components/Form/src/helper.ts
+++ b/src/components/Form/src/helper.ts
@@ -78,7 +78,6 @@ export const NO_AUTO_LINK_COMPONENTS: ComponentType[] = [
   'Upload',
   'ApiTransfer',
   'ApiTree',
-  'ApiSelect',
   'ApiTreeSelect',
   'ApiRadioGroup',
   'ApiCascader',


### PR DESCRIPTION
问题是出在ApiSelect change事件没有主动触发外部的change事件，导致首次Form.Item收集不到change的值

其次
https://github.com/vbenjs/vue-vben-admin/blob/1cf2a81f2a407ed73f9e22daa752600c5017801e/src/components/Form/src/components/FormItem.vue#L359
```
 // TODO 自定义组件验证会出现问题，因此这里框架默认将自定义组件设置手动触发验证，如果其他组件还有此问题请手动设置autoLink=false
  if (NO_AUTO_LINK_COMPONENTS.includes(component)) {
    props.schema &&
      (props.schema.itemProps! = {
        autoLink: false,
        ...props.schema.itemProps,
      });
  }
```

再看下autoLink属性的作用 ApiSelect组件本就是单一元素节点，所以**NO_AUTO_LINK_COMPONENTS**的设置有些多余，故删去

![image](https://github.com/vbenjs/vue-vben-admin/assets/24707417/b034c93f-3f4b-4a46-8faa-6a7522d033ce)
