### PR TITLE
fix: 修复rule validator type默认为string

### DIFF
--- a/src/components/Form/src/components/FormItem.vue
+++ b/src/components/Form/src/components/FormItem.vue
@@ -220,10 +220,6 @@
             rule.required = false;
           }
           if (component) {
-            if (!Reflect.has(rule, 'type')) {
-              rule.type = component === 'InputNumber' ? 'number' : 'string';
-            }
-
             rule.message = rule.message || defaultMsg;
 
             if (component.includes('Input') || component.includes('Textarea')) {

--- a/src/components/Form/src/helper.ts
+++ b/src/components/Form/src/helper.ts
@@ -40,6 +40,9 @@ export function setComponentRuleType(
   component: ComponentType,
   valueFormat: string,
 ) {
+  if (Reflect.has(rule, 'type')) {
+    return;
+  }
   if (['DatePicker', 'MonthPicker', 'WeekPicker', 'TimePicker'].includes(component)) {
     rule.type = valueFormat ? 'string' : 'object';
   } else if (['RangePicker', 'Upload', 'CheckboxGroup', 'TimePicker'].includes(component)) {


### PR DESCRIPTION
修复rule validator类型默认为string，导致 radio 等组件在 setFormValues 时，如果值不是string类型，提示校验错误