### PR TITLE
chore: 设定权限列columns宽度，消除演示表格错位问题. close #3085

### DIFF
--- a/src/views/demo/table/AuthColumn.vue
+++ b/src/views/demo/table/AuthColumn.vue
@@ -71,32 +71,38 @@
     {
       title: '姓名',
       dataIndex: 'name',
-      width: 200,
+      minWidth: 200,
       auth: 'test', // 根据权限控制是否显示: 无权限，不显示
     },
     {
       title: '状态',
       dataIndex: 'status',
+      width: 100,
     },
     {
       title: '状态1',
       dataIndex: 'status1',
+      width: 100,
     },
     {
       title: '状态2',
       dataIndex: 'status2',
+      width: 100,
     },
     {
       title: '状态3',
       dataIndex: 'status3',
+      width: 100,
     },
     {
       title: '状态4',
       dataIndex: 'status4',
+      width: 100,
     },
     {
       title: '状态5',
       dataIndex: 'status5',
+      width: 100,
     },
     {
       title: '地址',


### PR DESCRIPTION
![image](https://github.com/vbenjs/vue-vben-admin/assets/24707417/c0431f40-0f3d-4da2-81b6-5d73c444e982)

因为**TableAction**为固定列，所以导致部分情况下会有表头错位的问题， 按**antdv**说的给**column**加个 **width**就能解决