### PR TITLE
perf: 解决ts文件通过alias引入vue文件后, vscode调转不到正确vue文件路径

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
     "lokalise.i18n-ally",
     "antfu.iconify",
     "mikestead.dotenv",
-    "heybourn.headwind"
+    "heybourn.headwind",
+    "vue.vscode-typescript-vue-plugin"
   ]
 }


### PR DESCRIPTION
![before](https://github.com/vbenjs/vue-vben-admin/assets/24707417/d7b7462a-9b79-4ce7-8953-f47d14e6e34a)

可以看到vscode未正确解析 **/@/**这样的路径。

引入 [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin) 这个vscode扩展可以解决此问题

安装该扩展后

![after](https://github.com/vbenjs/vue-vben-admin/assets/24707417/3deeaf71-3a60-4884-9b0e-0105fd44273f)

鼠标点击可以进行正常调整
