### PR TITLE
chore: fix type:check error

### DIFF
--- a/src/components/CardList/src/CardList.vue
+++ b/src/components/CardList/src/CardList.vue
@@ -39,8 +39,7 @@
                 </div>
               </template>
               <template #actions>
-                <!--              <SettingOutlined key="setting" />-->
-                <EditOutlined key="edit" />
+                <EditOutlined />
                 <Dropdown
                   :trigger="['hover']"
                   :dropMenuList="[
@@ -55,7 +54,7 @@
                   ]"
                   popconfirm
                 >
-                  <EllipsisOutlined key="ellipsis" />
+                  <EllipsisOutlined />
                 </Dropdown>
               </template>
 

--- a/src/components/Form/src/components/ApiTree.vue
+++ b/src/components/Form/src/components/ApiTree.vue
@@ -9,7 +9,7 @@
 <script lang="ts">
   import { type Recordable, type AnyFunction } from '@vben/types';
   import { type PropType, computed, defineComponent, watch, ref, onMounted, unref } from 'vue';
-  import { Tree } from 'ant-design-vue';
+  import { Tree, TreeProps } from 'ant-design-vue';
   import { isArray, isFunction } from '/@/utils/is';
   import { get } from 'lodash-es';
   import { propTypes } from '/@/utils/propTypes';
@@ -25,7 +25,9 @@
       immediate: { type: Boolean, default: true },
       resultField: propTypes.string.def(''),
       afterFetch: { type: Function as PropType<AnyFunction> },
-      value: [Array, Object, String, Number],
+      value: {
+        type: Array as PropType<TreeProps['selectedKeys']>,
+      },
     },
     emits: ['options-change', 'change', 'update:value'],
     setup(props, { attrs, emit }) {

--- a/src/components/Menu/src/BasicMenu.vue
+++ b/src/components/Menu/src/BasicMenu.vue
@@ -20,7 +20,7 @@
 <script lang="ts">
   import type { MenuState } from './types';
   import { computed, defineComponent, unref, reactive, watch, toRefs, ref } from 'vue';
-  import { Menu } from 'ant-design-vue';
+  import { Menu, MenuProps } from 'ant-design-vue';
   import BasicSubMenuItem from './components/BasicSubMenuItem.vue';
   import { MenuModeEnum, MenuTypeEnum } from '/@/enums/menuEnum';
   import { useOpenKeys } from './useOpenKeys';
@@ -117,7 +117,7 @@
           },
         );
 
-      async function handleMenuClick({ key }: { key: string; keyPath: string[] }) {
+      const handleMenuClick: MenuProps['onClick'] = async ({ key }) => {
         const { beforeClickFn } = props;
         if (beforeClickFn && isFunction(beforeClickFn)) {
           const flag = await beforeClickFn(key);
@@ -127,7 +127,7 @@
 
         isClickGo.value = true;
         menuState.selectedKeys = [key];
-      }
+      };
 
       async function handleMenuChange(route?: RouteLocationNormalizedLoaded) {
         if (unref(isClickGo)) {

--- a/src/components/Menu/src/props.ts
+++ b/src/components/Menu/src/props.ts
@@ -4,6 +4,7 @@ import type { PropType } from 'vue';
 import { MenuModeEnum, MenuTypeEnum } from '/@/enums/menuEnum';
 import { ThemeEnum } from '/@/enums/appEnum';
 import { propTypes } from '/@/utils/propTypes';
+import type { Key } from './types';
 import type { MenuTheme } from 'ant-design-vue';
 import type { MenuMode } from 'ant-design-vue/lib/menu/src/interface';
 
@@ -35,7 +36,7 @@ export const basicProps = {
   isHorizontal: propTypes.bool,
   accordion: propTypes.bool.def(true),
   beforeClickFn: {
-    type: Function as PropType<(key: string) => Promise<boolean>>,
+    type: Function as PropType<(key: Key) => Promise<boolean>>,
   },
 };
 

--- a/src/components/Menu/src/types.ts
+++ b/src/components/Menu/src/types.ts
@@ -1,25 +1,17 @@
-// import { ComputedRef } from 'vue';
-// import { ThemeEnum } from '/@/enums/appEnum';
-// import { MenuModeEnum } from '/@/enums/menuEnum';
+export type Key = string | number;
 export interface MenuState {
   // 默认选中的列表
-  defaultSelectedKeys: string[];
-
-  // 模式
-  // mode: MenuModeEnum;
-
-  // // 主题
-  // theme: ComputedRef<ThemeEnum> | ThemeEnum;
+  defaultSelectedKeys: Key[];
 
   // 缩进
   inlineIndent?: number;
 
   // 展开数组
-  openKeys: string[];
+  openKeys: Key[];
 
   // 当前选中的菜单项 key 数组
-  selectedKeys: string[];
+  selectedKeys: Key[];
 
   // 收缩状态下展开的数组
-  collapsedOpenKeys: string[];
+  collapsedOpenKeys: Key[];
 }

--- a/src/components/Menu/src/useOpenKeys.ts
+++ b/src/components/Menu/src/useOpenKeys.ts
@@ -1,6 +1,6 @@
 import { MenuModeEnum } from '/@/enums/menuEnum';
 import type { Menu as MenuType } from '/@/router/types';
-import type { MenuState } from './types';
+import type { MenuState, Key } from './types';
 import { computed, Ref, toRaw, unref } from 'vue';
 import { useTimeoutFn } from '@vben/hooks';
 import { uniq } from 'lodash-es';
@@ -53,13 +53,13 @@ export function useOpenKeys(
     menuState.openKeys = [];
   }
 
-  function handleOpenChange(openKeys: string[]) {
+  function handleOpenChange(openKeys: Key[]) {
     if (unref(mode) === MenuModeEnum.HORIZONTAL || !unref(accordion) || unref(getIsMixSidebar)) {
       menuState.openKeys = openKeys;
     } else {
       // const menuList = toRaw(menus.value);
       // getAllParentPath(menuList, path);
-      const rootSubMenuKeys: string[] = [];
+      const rootSubMenuKeys: Key[] = [];
       for (const { children, path } of unref(menus)) {
         if (children && children.length > 0) {
           rootSubMenuKeys.push(path);

--- a/src/components/Scrollbar/src/Scrollbar.vue
+++ b/src/components/Scrollbar/src/Scrollbar.vue
@@ -3,7 +3,7 @@
     <div
       ref="wrap"
       :class="[wrapClass, 'scrollbar__wrap', native ? '' : 'scrollbar__wrap--hidden-default']"
-      :style="style"
+      :style="wrapStyle"
       @scroll="handleScroll"
     >
       <component :is="tag" ref="resize" :class="['scrollbar__view', viewClass]" :style="viewStyle">
@@ -19,7 +19,6 @@
 <script lang="ts">
   import { addResizeListener, removeResizeListener } from '/@/utils/event';
   import componentSetting from '/@/settings/componentSetting';
-  import { toObject } from './util';
   import {
     defineComponent,
     ref,
@@ -27,10 +26,11 @@
     onBeforeUnmount,
     nextTick,
     provide,
-    computed,
     unref,
     watch,
+    type PropType,
   } from 'vue';
+  import type { StyleValue } from '/@/utils/types';
   import Bar from './bar';
 
   const { scrollbar } = componentSetting;
@@ -45,7 +45,7 @@
         default: scrollbar?.native ?? false,
       },
       wrapStyle: {
-        type: [String, Array],
+        type: [String, Array, Object] as PropType<StyleValue>,
         default: '',
       },
       wrapClass: {
@@ -80,13 +80,6 @@
       const resize = ref();
 
       provide('scroll-bar-wrap', wrap);
-
-      const style = computed(() => {
-        if (Array.isArray(props.wrapStyle)) {
-          return toObject(props.wrapStyle);
-        }
-        return props.wrapStyle;
-      });
 
       const handleScroll = () => {
         if (!props.native) {
@@ -137,7 +130,6 @@
         moveY,
         sizeWidth,
         sizeHeight,
-        style,
         wrap,
         resize,
         update,

--- a/src/components/Table/src/hooks/useCustomRow.ts
+++ b/src/components/Table/src/hooks/useCustomRow.ts
@@ -3,10 +3,11 @@ import type { BasicTableProps } from '../types/table';
 import { unref } from 'vue';
 import { ROW_KEY } from '../const';
 import { isString, isFunction } from '/@/utils/is';
+import type { Key } from 'ant-design-vue/lib/table/interface';
 
 interface Options {
-  setSelectedRowKeys: (keys: string[]) => void;
-  getSelectRowKeys: () => string[];
+  setSelectedRowKeys: (keys: Key[]) => void;
+  getSelectRowKeys: () => Key[];
   clearSelectedRowKeys: () => void;
   emit: EmitType;
   getAutoCreateKey: ComputedRef<boolean | undefined>;


### PR DESCRIPTION
#### 1. 修复了`pnpm run type:check`执行后的部分错误

#### 2. 移除了 `src/components/Scrollbar/src/Scrollbar.vue`下面这段代码

- `wrapStyle`本身就可以直接赋给组件上的`style`属性，额外的计算开销。
- `style`不支持`wrapStyle = [{ background: 'red' }, 'fontSize: 16px']`。
```js
const style = computed(() => {
  // 例 wrapStyle = [ { background: 'red' }, { background: 'green' } ]
  // style和wrapStyle 效果一致
  if (Array.isArray(props.wrapStyle)) {
    return toObject(props.wrapStyle);
  }
  return props.wrapStyle;
});
```
