### PR TITLE
fix(tree): remove expandedKeys prop default value

### DIFF
--- a/src/components/Tree/src/types/tree.ts
+++ b/src/components/Tree/src/types/tree.ts
@@ -91,7 +91,6 @@ export const treeProps = buildProps({
 
   expandedKeys: {
     type: Array as PropType<KeyType[]>,
-    default: () => [],
   },
 
   selectedKeys: {


### PR DESCRIPTION
修复路由`comp/tree/basic`页面第二个默认展开案例的bug。


参照文档[antdv](https://antdv.com/components/tree-cn/#Tree)，如果有`expandedKeys prop`（即源码中的不为`undefined`），`defaultExpandAll prop`会失效。

```js
// components/vc-tree/Tree.tsx
if (
  props.expandedKeys !== undefined ||
  (init && newAutoExpandParent !== oldAutoExpandParent)
) {
  // ...
} else if (!init && props.defaultExpandAll) {
 // ....
}
```