### PR TITLE
fix: async validator

### DIFF
--- a/src/views/demo/form/RuleForm.vue
+++ b/src/views/demo/form/RuleForm.vue
@@ -192,10 +192,12 @@
           message: '请输入数据',
         },
         {
+          trigger: 'blur',
           validator(_, value) {
             return new Promise((resolve, reject) => {
+              if (!value) return resolve();
               isAccountExist(value)
-                .then(() => resolve())
+                .then(resolve)
                 .catch((err) => {
                   reject(err.message || '验证失败');
                 });

--- a/src/views/demo/system/account/account.data.ts
+++ b/src/views/demo/system/account/account.data.ts
@@ -89,10 +89,12 @@ export const accountFormSchema: FormSchema[] = [
         message: '请输入用户名',
       },
       {
+        trigger: 'blur',
         validator(_, value) {
           return new Promise((resolve, reject) => {
+            if (!value) return resolve();
             isAccountExist(value)
-              .then(() => resolve())
+              .then(resolve)
               .catch((err) => {
                 reject(err.message || '验证失败');
               });


### PR DESCRIPTION
之前每次输入都触发，由于是请求接口，不保证接口的响应顺序，因此输入过快时可能不会触发校验（比如内容为`admi`的接口响应比内容为`admin`慢）