### PR TITLE
fix(routeHelper.ts): Route name may be undefined

### DIFF
--- a/src/router/helper/routeHelper.ts
+++ b/src/router/helper/routeHelper.ts
@@ -78,7 +78,11 @@ export function transformObjToRoute<T = AppRouteModule>(routeList: AppRouteModul
       } else {
         route.children = [cloneDeep(route)];
         route.component = LAYOUT;
-        route.name = `${route.name}Parent`;
+         //某些情况下如果name如果没有值， 多个一级路由菜单会导致页面404
+        if (!route.name || !route.menuName) {
+          warn('找不到菜单对应的name或menuName, 请检查数据!');
+        }
+        route.name = `${route.name || route.menuName}Parent`;
         route.path = '';
         const meta = route.meta || {};
         meta.single = true;


### PR DESCRIPTION
修复transformObjToRoute方法，在某些情况下name可能没有值，此时路由name值为undefinedParent，会导致 多个一级路由菜单会页面404


