### PR TITLE
fix: FormItem下有多个受控组件控制台显示错误提示的bug

### DIFF
--- a/src/views/demo/form/CustomerForm.vue
+++ b/src/views/demo/form/CustomerForm.vue
@@ -23,7 +23,7 @@
   import { BasicForm, FormSchema, useForm } from '/@/components/Form/index';
   import { CollapseContainer } from '/@/components/Container/index';
   import { useMessage } from '/@/hooks/web/useMessage';
-  import { Input, FormItem, Select } from 'ant-design-vue';
+  import { Input, FormItem, FormItemRest, Select } from 'ant-design-vue';
   import { PageWrapper } from '/@/components/Page';
 
   const custom_typeKey2typeValueRules = (model) => {
@@ -145,7 +145,13 @@
               <Select.Option value="测试名称">测试名称</Select.Option>
             </Select>
             <FormItem name="typeValue2" class="local_typeValue" rules={[{ required: true }]}>
-              <Input placeholder="请输入" v-model:value={model['typeValue2']} disabled={disabled} />
+              <FormItemRest>
+                <Input
+                  placeholder="请输入"
+                  v-model:value={model['typeValue2']}
+                  disabled={disabled}
+                />
+              </FormItemRest>
             </FormItem>
           </Input.Group>
         );
@@ -183,12 +189,14 @@
                 <Select.Option value="公司名称">公司名称</Select.Option>
                 <Select.Option value="产品名称">产品名称</Select.Option>
               </Select>
-              <Input
-                style="width: calc(100% - 120px); margin-left: -1px;"
-                placeholder="请输入"
-                v-model:value={model['typeValue']}
-                disabled={disabled}
-              />
+              <FormItemRest>
+                <Input
+                  style="width: calc(100% - 120px); margin-left: -1px;"
+                  placeholder="请输入"
+                  v-model:value={model['typeValue']}
+                  disabled={disabled}
+                />
+              </FormItemRest>
             </Input.Group>
           </FormItem>
         );

--- a/src/views/demo/form/CustomerForm.vue
+++ b/src/views/demo/form/CustomerForm.vue
@@ -30,10 +30,10 @@
     return [
       {
         required: true,
-        validator: (rule, value, callback) => {
-          if (!model.typeKey) return callback('请选择类型');
-          if (!model.typeValue) return callback('请输入数据');
-          callback();
+        validator: async () => {
+          if (!model.typeKey) return Promise.reject('请选择类型');
+          if (!model.typeValue) return Promise.reject('请输入数据');
+          Promise.resolve();
         },
       },
     ];


### PR DESCRIPTION
```
      renderColContent({ model, field }, { disabled }) {
        return (
          <FormItem
            name="typeKey"
            label="复合field renderColContent"
            rules={custom_typeKey2typeValueRules(model)}
          >
            <Input.Group compact>
              <Select
                allowClear
                disabled={disabled}
                style="width: 120px"
                v-model:value={model[field]}
              >
                <Select.Option value="公司名称">公司名称</Select.Option>
                <Select.Option value="产品名称">产品名称</Select.Option>
              </Select>
              <FormItemRest>
                <Input
                  style="width: calc(100% - 120px); margin-left: -1px;"
                  placeholder="请输入"
                  v-model:value={model['typeValue']}
                  disabled={disabled}
                />
              </FormItemRest>
            </Input.Group>
          </FormItem>
        );
      }
```
这么写可以避免控制台展示一下提示

```
index.ts:41 Warning: [ant-design-vue: Form.Item] FormItem can only collect one field item, you haved set `ASelect`, `AInput` 2 field items.
        You can set not need to be collected fields into `a-form-item-rest`
```