### PR TITLE
fix: defaultValue类型为number时的bug

### DIFF
--- a/src/components/Form/src/helper.ts
+++ b/src/components/Form/src/helper.ts
@@ -61,9 +61,17 @@ export function processDateValue(attr: Recordable, component: string) {
   }
 }
 
+export const defaultValueComponents = [
+  'Input',
+  'InputPassword',
+  'InputNumber',
+  'InputSearch',
+  'InputTextArea',
+];
+
 export function handleInputNumberValue(component?: ComponentType, val?: any) {
   if (!component) return val;
-  if (['Input', 'InputPassword', 'InputSearch', 'InputTextArea'].includes(component)) {
+  if (defaultValueComponents.includes(component)) {
     return val && isNumber(val) ? `${val}` : val;
   }
   return val;
@@ -73,8 +81,6 @@ export function handleInputNumberValue(component?: ComponentType, val?: any) {
  * 时间字段
  */
 export const dateItemType = genType();
-
-export const defaultValueComponents = ['Input', 'InputPassword', 'InputSearch', 'InputTextArea'];
 
 // TODO 自定义组件封装会出现验证问题，因此这里目前改成手动触发验证
 export const NO_AUTO_LINK_COMPONENTS: ComponentType[] = [


### PR DESCRIPTION
### `General`
fix: defaultValue类型为number时, 点击编辑 setFieldsValue的值会被覆盖掉  #3274

closes #3274 

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
