### PR TITLE
fix(breadcrumb): 修复面包屑跳转外链时，导致当前页面404问题

### DIFF
--- a/src/hooks/web/usePage.ts
+++ b/src/hooks/web/usePage.ts
@@ -5,6 +5,8 @@ import { unref } from 'vue';
 
 import { useRouter } from 'vue-router';
 import { REDIRECT_NAME } from '@/router/constant';
+import { isHttpUrl } from '@/utils/is';
+import { openWindow } from '@/utils';
 
 export type PathAsPageEnum<T> = T extends { path: string } ? T & { path: PageEnum } : T;
 export type RouteLocationRawEx = PathAsPageEnum<RouteLocationRaw>;
@@ -21,6 +23,13 @@ export function useGo(_router?: Router) {
   function go(opt: RouteLocationRawEx = PageEnum.BASE_HOME, isReplace = false) {
     if (!opt) {
       return;
+    }
+    let path = unref(opt) as string;
+    if (path[0] === '/') {
+      path = path.slice(1);
+    }
+    if (isHttpUrl(path)) {
+      return openWindow(path);
     }
     isReplace ? replace(opt).catch(handleError) : push(opt).catch(handleError);
   }


### PR DESCRIPTION

fix(breadcrumb): 修复面包屑跳转外链时，导致当前页面404问题 https://github.com/vbenjs/vue-vben-admin/issues/3336#issue-2009164377

在点击面包屑时判断path是否为http协议，如果是http协议直接另开窗口打开，当前页面路由不做操作