### PR TITLE
修复BasicForm使用componentProps函数返回valueFormat时DatePicker无法正确格式化的问题 

### DIFF
--- a/src/components/Form/src/BasicForm.vue
+++ b/src/components/Form/src/BasicForm.vue
@@ -63,6 +63,7 @@
   import { basicProps } from './props';
   import { useDesign } from '@/hooks/web/useDesign';
   import { cloneDeep } from 'lodash-es';
+  import { TableActionType } from '@/components/Table';
 
   defineOptions({ name: 'BasicForm' });
 
@@ -119,12 +120,17 @@
     };
   });
 
-  const getBindValue = computed(() => ({ ...attrs, ...props, ...unref(getProps) }) as AntFormProps);
+  const getBindValue = computed(() => ({ ...attrs, ...props, ...unref(getProps) } as AntFormProps));
 
   const getSchema = computed((): FormSchema[] => {
     const schemas: FormSchema[] = unref(schemaRef) || (unref(getProps).schemas as any);
     for (const schema of schemas) {
-      const { defaultValue, component, componentProps, isHandleDateDefaultValue = true } = schema;
+      const {
+        defaultValue,
+        component,
+        componentProps = {},
+        isHandleDateDefaultValue = true,
+      } = schema;
       // handle date type
       if (
         isHandleDateDefaultValue &&
@@ -132,7 +138,17 @@
         component &&
         dateItemType.includes(component)
       ) {
-        const valueFormat = componentProps ? componentProps['valueFormat'] : null;
+        let opt = {
+          schema,
+          tableAction: props.tableAction ?? ({} as TableActionType),
+          formModel,
+          formActionType: {} as FormActionType,
+        };
+        const valueFormat = componentProps
+          ? typeof componentProps === 'function'
+            ? componentProps(opt)['valueFormat']
+            : componentProps['valueFormat']
+          : null;
         if (!Array.isArray(defaultValue)) {
           schema.defaultValue = valueFormat
             ? dateUtil(defaultValue).format(valueFormat)
@@ -290,7 +306,7 @@
   };
 
   const getFormActionBindProps = computed(
-    () => ({ ...getProps.value, ...advanceState }) as InstanceType<typeof FormAction>['$props'],
+    () => ({ ...getProps.value, ...advanceState } as InstanceType<typeof FormAction>['$props']),
   );
 
   defineExpose({

--- a/src/components/Form/src/BasicForm.vue
+++ b/src/components/Form/src/BasicForm.vue
@@ -120,7 +120,7 @@
     };
   });
 
-  const getBindValue = computed(() => ({ ...attrs, ...props, ...unref(getProps) } as AntFormProps));
+  const getBindValue = computed(() => ({ ...attrs, ...props, ...unref(getProps) }) as AntFormProps);
 
   const getSchema = computed((): FormSchema[] => {
     const schemas: FormSchema[] = unref(schemaRef) || (unref(getProps).schemas as any);
@@ -138,7 +138,7 @@
         component &&
         dateItemType.includes(component)
       ) {
-        let opt = {
+        const opt = {
           schema,
           tableAction: props.tableAction ?? ({} as TableActionType),
           formModel,
@@ -306,7 +306,7 @@
   };
 
   const getFormActionBindProps = computed(
-    () => ({ ...getProps.value, ...advanceState } as InstanceType<typeof FormAction>['$props']),
+    () => ({ ...getProps.value, ...advanceState }) as InstanceType<typeof FormAction>['$props'],
   );
 
   defineExpose({


### PR DESCRIPTION
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


当DatePicker使用箭头函数返回配置数据时无法正常显示日期 

```
    {
      field: 'field3',
      component: 'DatePicker',
      label: '字段3',
      defaultValue: '2023-11-28',
      colProps: {
        span: 8,
      },
      // componentProps: {
      //   valueFormat: 'YYYY-MM-DD',
      //   format: 'YYYY-MM-DD',
      // },
      componentProps: (opt) => {
        return {
          valueFormat: 'YYYY-MM-DD',
          format: 'YYYY-MM-DD',
        };
      },
    },
```


![image](https://github.com/vbenjs/vue-vben-admin/assets/52393675/986feefa-790a-481a-a701-bf49e0c5dd27)
