### PR TITLE
Revert "feat: table搜索表单值发生改变可以触发reload (#3378)"

### DIFF
--- a/src/components/Form/src/components/FormItem.vue
+++ b/src/components/Form/src/components/FormItem.vue
@@ -24,7 +24,6 @@
   import { cloneDeep, upperFirst } from 'lodash-es';
   import { useItemLabelWidth } from '../hooks/useLabelWidth';
   import { useI18n } from '@/hooks/web/useI18n';
-  import { useDebounceFn } from '@vueuse/core';
 
   export default defineComponent({
     name: 'BasicFormItem',
@@ -271,8 +270,6 @@
           component,
           field,
           changeEvent = 'change',
-          watchEventNames = ['search', 'change'],
-          enableWatchEvent = true,
           valueField,
         } = props.schema;
 
@@ -280,27 +277,6 @@
 
         const eventKey = `on${upperFirst(changeEvent)}`;
 
-        const { autoSetPlaceHolder, size, watchEvent } = props.formProps;
-        let eventNames = {};
-        if (watchEvent && enableWatchEvent) {
-          // table search 开启才触发事件
-          let immediateEvents = ['search']; // 立即执行的事件
-          watchEventNames.forEach((item) => {
-            let timer: number = 500;
-            if (immediateEvents.includes(item)) {
-              timer = 0;
-            }
-            eventNames[`on${upperFirst(item)}`] = useDebounceFn(
-              (...args: Nullable<Recordable<any>>[]) => {
-                // todo 后续需要优化input中文输入的问题
-                console.log(args);
-                const { reload = () => {} } = props.tableAction || {};
-                reload();
-              },
-              timer,
-            );
-          });
-        }
         const on = {
           [eventKey]: (...args: Nullable<Recordable<any>>[]) => {
             const [e] = args;
@@ -314,6 +290,7 @@
         };
         const Comp = componentMap.get(component) as ReturnType<typeof defineComponent>;
 
+        const { autoSetPlaceHolder, size } = props.formProps;
         const propsData: Recordable<any> = {
           allowClear: true,
           size,
@@ -338,7 +315,6 @@
         const compAttr: Recordable<any> = {
           ...propsData,
           ...on,
-          ...eventNames,
           ...bindValue,
         };
 

--- a/src/components/Form/src/props.ts
+++ b/src/components/Form/src/props.ts
@@ -100,7 +100,4 @@ export const basicProps = {
   labelAlign: propTypes.string,
 
   rowProps: Object as PropType<RowProps>,
-
-  // table 开启监听表单监听事件，触发table reload
-  watchEvent: propTypes.bool.def(false),
 };

--- a/src/components/Form/src/types/form.ts
+++ b/src/components/Form/src/types/form.ts
@@ -124,7 +124,6 @@ export interface FormProps {
   submitFunc?: () => Promise<void>;
   transformDateFunc?: (date: any) => string;
   colon?: boolean;
-  watchEvent?: boolean;
 }
 export type RenderOpts = {
   disabled: boolean;
@@ -224,11 +223,6 @@ interface BaseFormSchema {
   dynamicReadonly?: boolean | ((renderCallbackParams: RenderCallbackParams) => boolean);
 
   dynamicRules?: (renderCallbackParams: RenderCallbackParams) => Rule[];
-
-  watchEventNames?: string[];
-
-  // 禁用事件监听触发reload
-  enableWatchEvent?: boolean;
 }
 export interface ComponentFormSchema extends BaseFormSchema {
   // render component

--- a/src/views/demo/table/tableData.tsx
+++ b/src/views/demo/table/tableData.tsx
@@ -259,45 +259,6 @@ export function getFormConfig(): Partial<FormProps> {
           xxl: 8,
         },
       },
-      {
-        field: `field12`,
-        label: `input值改变`,
-        component: 'InputSearch',
-        enableWatchEvent: true,
-        componentProps: {
-          placeholder: '需要开启watchEvent',
-        },
-        colProps: {
-          xl: 12,
-          xxl: 8,
-        },
-      },
-      {
-        field: 'field13',
-        component: 'Select',
-        label: 'select值改变',
-        componentProps: {
-          placeholder: '需要开启watchEvent',
-          options: [
-            {
-              label: '公开',
-              value: '1',
-            },
-            {
-              label: '部分公开',
-              value: '2',
-            },
-            {
-              label: '不公开',
-              value: '3',
-            },
-          ],
-        },
-        colProps: {
-          xl: 12,
-          xxl: 8,
-        },
-      },
     ],
   };
 }


### PR DESCRIPTION
This reverts commit 1ca3f7c2c0c0c00e8395e26c59796c875d34e12c.

[#3378](https://github.com/vbenjs/vue-vben-admin/pull/3378), 之前提交的这个PR, 存在以下问题

- reload的时候没有带上参数
- change会覆盖changeEvent事件，导致点搜索无法带上参数

另外发现submitOnChange=true就可以实现值改变的时候触发table重新请求，所以请求回滚代码。

### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [ ] My code follows the style guidelines of this project
- [ ] Is the code format correct
- [ ] Is the git submission information standard?
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
