### PR TITLE
fix: ColumnSetting mistake when use setColumns

### DIFF
--- a/src/components/Table/src/components/settings/ColumnSetting.vue
+++ b/src/components/Table/src/components/settings/ColumnSetting.vue
@@ -113,7 +113,6 @@
   import { getPopupContainer as getParentContainer } from '@/utils';
   import { cloneDeep } from 'lodash-es';
   import Sortablejs from 'sortablejs';
-  import type Sortable from 'sortablejs';
 
   // 列表设置缓存
   import { useTableSettingStore } from '@/store/modules/tableSetting';
@@ -251,10 +250,6 @@
     } as CheckboxChangeEvent);
     // 重置默认值
     columnOptions.value = cloneDeep(defaultColumnOptions);
-    // 重置排序
-    sortableOrder = defaultSortableOrder;
-    // 排序
-    sortable?.sort(defaultSortableOrder);
     // 更新表单状态
     formUpdate();
   };
@@ -306,11 +301,6 @@
     }
     return false;
   };
-
-  // sortable 实例
-  let sortable: Sortable;
-  // 排序
-  let sortableOrder: string[] = [];
 
   // 获取数据列
   const getTableColumns = () => {
@@ -365,7 +355,7 @@
     if (columnOptionsRef.value) {
       // 注册排序实例
       const el = (columnOptionsRef.value as InstanceType<typeof Checkbox.Group>).$el;
-      sortable = Sortablejs.create(unref(el), {
+      Sortablejs.create(unref(el), {
         animation: 500,
         delay: 400,
         delayOnTouchOnly: true,
@@ -397,9 +387,6 @@
           columnOptionsSave();
         },
       });
-
-      // 从缓存恢复
-      sortable.sort(sortableOrder);
     }
   };
 
@@ -473,10 +460,6 @@
   const isColumnAllSelectedUpdate = () => {
     isColumnAllSelected.value = columnOptions.value.length === columnCheckedOptions.value.length;
   };
-  // 从 列可选项 更新 排序
-  const sortableOrderUpdateByOptions = (options: ColumnOptionsType[]) => {
-    sortableOrder = options.map((o) => o.value);
-  };
   // 更新 showIndexColumn
   const showIndexColumnUpdate = (showIndexColumn) => {
     isInnerChange = true;
@@ -505,9 +488,6 @@
     // 从 列可选项 更新 全选状态
     isColumnAllSelectedUpdate();
 
-    // 从 列可选项 更新 排序
-    sortableOrderUpdateByOptions(columnOptions.value);
-
     // 更新 showIndexColumn
     showIndexColumnUpdate(isIndexColumnShow.value);
 
@@ -523,12 +503,9 @@
   let defaultIsRowSelectionShow: boolean = false;
   let defaultRowSelection: TableRowSelection<Recordable<any>>;
   let defaultColumnOptions: ColumnOptionsType[] = [];
-  let defaultSortableOrder: string[] = [];
 
   const init = async () => {
     if (!isRestored) {
-      await sortableFix();
-
       // 获取数据列
       const columns = getTableColumns();
 
@@ -559,9 +536,6 @@
         });
       }
 
-      // 默认值 缓存，浮窗出现的时候使用
-      defaultSortableOrder = options.map((o) => o.value);
-
       // 默认值 缓存
       defaultIsIndexColumnShow = table.getBindValues.value.showIndexColumn || false;
       defaultRowSelection = table.getRowSelection();
@@ -587,7 +561,12 @@
   };
 
   // 初始化
-  init();
+  const once = async () => {
+    // 仅执行一次
+    await sortableFix();
+    init();
+  };
+  once();
 
   // 外部列改变
   const getColumns = computed(() => {


### PR DESCRIPTION
### `General`

> 关于反馈：动态调整列（setColumns）会导致错误；以及我发现执行多次 setColumns 会导致严重错误；还有 Sortablejs 的实例 sort 方法执行后出现无法理解的排序异常。特别地赶紧修复一波，思路是：Sortablejs 的实例实际由缓存记录的 ref 实例化（浮窗再次显示不会再次实例化），初始排序已经是符合预期的，无需使用 Sortablejs 的实例 sort 方法、无需记录排序。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
