### PR TITLE
解决表格开启表格功能时，无法使用Customrender

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,13 +84,13 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit"
   },
   "[vue]": {
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true,
-      "source.fixAll.stylelint": true
+      "source.fixAll.eslint": "explicit",
+      "source.fixAll.stylelint": "explicit"
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/src/components/Table/src/componentMap.ts
+++ b/src/components/Table/src/componentMap.ts
@@ -12,6 +12,7 @@ import {
 } from 'ant-design-vue';
 import type { ComponentType } from './types/componentType';
 import { ApiSelect, ApiTreeSelect, RadioButtonGroup, ApiRadioGroup } from '@/components/Form';
+import { ImageUpload } from '@/components/Upload';
 
 const componentMap = new Map<ComponentType, Component>();
 
@@ -28,6 +29,7 @@ componentMap.set('TimePicker', TimePicker);
 componentMap.set('RadioGroup', Radio.Group);
 componentMap.set('RadioButtonGroup', RadioButtonGroup);
 componentMap.set('ApiRadioGroup', ApiRadioGroup);
+componentMap.set('ImageUpload', ImageUpload);
 
 export function add(compName: ComponentType, component: Component) {
   componentMap.set(compName, component);

--- a/src/components/Table/src/components/editable/index.ts
+++ b/src/components/Table/src/components/editable/index.ts
@@ -43,7 +43,10 @@ export function renderEditCell(column: BasicColumn) {
       }
       return true;
     };
-
+    // Non editable, displaying unitComponent
+    if (!record.editable && column.unitComponent) {
+      return column.unitComponent({ text: value, record, index });
+    }
     return h(EditableCell, {
       value,
       record,

--- a/src/components/Table/src/types/componentType.ts
+++ b/src/components/Table/src/types/componentType.ts
@@ -9,6 +9,7 @@ export type ComponentType =
   | 'Switch'
   | 'DatePicker'
   | 'TimePicker'
+  | 'ImageUpload'
   | 'RadioGroup'
   | 'RadioButtonGroup'
   | 'ApiRadioGroup';

--- a/src/components/Table/src/types/table.ts
+++ b/src/components/Table/src/types/table.ts
@@ -446,6 +446,8 @@ export interface BasicColumn extends ColumnProps<Recordable> {
 
   format?: CellFormat;
 
+  // Same as Customrender, but not affected by Editable
+  unitComponent?: Function;
   // Editable
   edit?: boolean;
   editRow?: boolean;

--- a/src/views/demo/table/EditRowTable.vue
+++ b/src/views/demo/table/EditRowTable.vue
@@ -10,7 +10,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-  import { ref } from 'vue';
+  import { h, ref } from 'vue';
   import {
     BasicTable,
     useTable,
@@ -25,6 +25,8 @@
   import { treeOptionsListApi } from '@/api/demo/tree';
   import { cloneDeep } from 'lodash-es';
   import { useMessage } from '@/hooks/web/useMessage';
+  import { uploadApi } from '@/api/sys/upload';
+  import { Image } from 'ant-design-vue';
 
   const columns: BasicColumn[] = [
     {
@@ -77,6 +79,19 @@
           width: 150,
         },
       ],
+    },
+    {
+      title: '图片',
+      dataIndex: 'imgs',
+      width: 200,
+      unitComponent: ({ text }) => h(Image, { src: text, width: 70 }), // 显示自定义组件
+      editRow: true,
+      editComponent: 'ImageUpload',
+      editComponentProps: {
+        api: uploadApi,
+        accept: ['png', 'jpeg', 'jpg'],
+        maxNumber: 1,
+      },
     },
     {
       title: '下拉框',


### PR DESCRIPTION
表格编辑时，不展示Customrender
常用场景，如商品的规格，想要展示图片，同时又能上传
添加unitComponent，与Customrender一样，
在表格中添加上传ImageUpload图片上传组件 - 用框架自带封装好的
