### PR TITLE
feat: IconPicker could allowClear and readonly for form

### DIFF
--- a/src/components/Icon/src/IconPicker.vue
+++ b/src/components/Icon/src/IconPicker.vue
@@ -1,11 +1,12 @@
 <template>
   <Input
-    readonly
     :style="{ width }"
     :placeholder="t('component.icon.placeholder')"
     :class="prefixCls"
     v-model:value="currentSelect"
     @click="triggerPopover"
+    :allowClear="props.allowClear"
+    :readonly="props.readonly"
   >
     <template #addonAfter>
       <Popover
@@ -103,6 +104,8 @@
     pageSize?: number;
     copy?: boolean;
     mode?: 'svg' | 'iconify';
+    allowClear?: boolean;
+    readonly?: boolean;
   }
 
   const props = withDefaults(defineProps<Props>(), {
@@ -111,6 +114,8 @@
     pageSize: 140,
     copy: false,
     mode: 'iconify',
+    allowClear: true,
+    readonly: false,
   });
 
   // Don't inherit FormItem disabled、placeholder...


### PR DESCRIPTION
### `General`

> 图标选择器理应可以 allowClear，附带 readonly 也应该可以设置，尤其在作为 Form -> FormItem -> Component 的时候。否则选择图标之后，就完全没有办法清除值了，非 required 的时候就出问题了。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
