### PR TITLE
fix: EditableCell about checked/unChecked Value, getDisable, rowKey m…

### DIFF
--- a/src/components/Table/src/components/editable/EditableCell.vue
+++ b/src/components/Table/src/components/editable/EditableCell.vue
@@ -66,13 +66,23 @@
 
       const getComponentProps = computed(() => {
         const isCheckValue = unref(getIsCheckComp);
+        let compProps = props.column?.editComponentProps ?? ({} as any);
+        const { checkedValue, unCheckedValue } = compProps;
 
         const valueField = isCheckValue ? 'checked' : 'value';
         const val = unref(currentValueRef);
 
-        const value = isCheckValue ? (isNumber(val) || isBoolean(val) ? val : !!val) : val;
+        let value = val;
+        if (isCheckValue) {
+          if (typeof checkedValue !== 'undefined') {
+            value = val === checkedValue ? checkedValue : unCheckedValue;
+          } else if (typeof unCheckedValue !== 'undefined') {
+            value = val === unCheckedValue ? unCheckedValue : checkedValue;
+          } else {
+            value = isNumber(val) || isBoolean(val) ? val : !!val;
+          }
+        }
 
-        let compProps = props.column?.editComponentProps ?? ({} as any);
         const { record, column, index } = props;
 
         if (isFunction(compProps)) {
@@ -114,7 +124,7 @@
         }
         if (isFunction(editDynamicDisabled)) {
           const { record } = props;
-          disabled = editDynamicDisabled({ record });
+          disabled = editDynamicDisabled({ record, currentValue: currentValueRef.value });
         }
         return disabled;
       });
@@ -170,7 +180,7 @@
       });
 
       function handleEdit() {
-        if (unref(getRowEditable) || unref(props.column?.editRow)) return;
+        if (unref(getRowEditable) || unref(props.column?.editRow) || unref(getDisable)) return;
         ruleMessage.value = '';
         isEdit.value = true;
         nextTick(() => {
@@ -248,17 +258,19 @@
         if (!record.editable) {
           const { getBindValues } = table;
 
-          const { beforeEditSubmit, columns } = unref(getBindValues);
+          const { beforeEditSubmit, columns, rowKey } = unref(getBindValues);
+          const rowKeyValue = typeof rowKey === 'string' ? rowKey : rowKey ? rowKey(record) : '';
 
           if (beforeEditSubmit && isFunction(beforeEditSubmit)) {
             spinning.value = true;
             const keys: string[] = columns
               .map((_column) => _column.dataIndex)
               .filter((field) => !!field) as string[];
+
             let result: any = true;
             try {
               result = await beforeEditSubmit({
-                record: pick(record, keys),
+                record: pick(record, [rowKeyValue, ...keys]),
                 index,
                 key: dataKey as string,
                 value,
@@ -391,6 +403,7 @@
         handleEnter,
         handleSubmitClick,
         spinning,
+        getDisable,
       };
     },
     render() {
@@ -408,10 +421,13 @@
                     record: this.record as Recordable,
                     column: this.column,
                     index: this.index,
+                    currentValue: this.currentValueRef,
                   })
                 : this.getValues ?? '\u00A0'}
             </div>
-            {!this.column.editRow && <FormOutlined class={`${this.prefixCls}__normal-icon`} />}
+            {!this.column.editRow && !this.getDisable && (
+              <FormOutlined class={`${this.prefixCls}__normal-icon`} />
+            )}
           </div>
           {this.isEdit && (
             <Spin spinning={this.spinning}>

--- a/src/components/Table/src/types/table.ts
+++ b/src/components/Table/src/types/table.ts
@@ -472,6 +472,7 @@ export interface BasicColumn extends ColumnProps<Recordable> {
     record: Recordable;
     column: BasicColumn;
     index: number;
+    currentValue: string | number | boolean | Recordable;
   }) => VNodeChild | JSX.Element;
   // 动态 Disabled
   editDynamicDisabled?: boolean | ((record: Recordable) => boolean);


### PR DESCRIPTION
…issing for updating

### `General`

> 使用 EditableCell 遇到以下问题（场景）：
1、当 editComponent 为 switch 的时候，设置 editComponentProps 的 checkedValue 和 unCheckedValue 无效。
2、假如存在多列均可以 edit，列A 受 列B 的值影响，列A 在 列B 为某个值的时候应该被禁用，此时 editDynamicDisabled 获得参数 record 中 列B 的值是旧值，没有变化，导致 列A 无法动态变成禁止 edit 状态。
3、禁用状的 EditableCell，”禁用“的表达应该提前，应该不允许点击切换至 editable 状态，无需用表单的禁用表达。
4、table 列设置里没有定义 id 列，在 beforeEditSubmit 返回到 record 中就不存在 id 属性，此时就缺失 id 用于提交表单了。此时可以根据 rowKey，补充至返回到 record 中。
5、使用 render 的时候，例如希望用彩色的 tag 显示记录的状态，此时出现类似上面”2“的情况，如果此记录经过 EditableCell 修改过，返回到 record 的是旧值，无法通过 render 显示最新的状态。

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
