### PR TITLE
fix: watch open logic lost after build

### DIFF
--- a/src/components/Drawer/src/BasicDrawer.vue
+++ b/src/components/Drawer/src/BasicDrawer.vue
@@ -135,7 +135,10 @@
     (open) => {
       nextTick(() => {
         emit('open-change', open);
-        instance && drawerInstance.emitOpen?.(open, instance.uid);
+        //
+        instance !== null &&
+          isFunction(drawerInstance.emitOpen) &&
+          drawerInstance.emitOpen?.(open, instance.uid);
       });
     },
   );

--- a/src/components/Drawer/src/BasicDrawer.vue
+++ b/src/components/Drawer/src/BasicDrawer.vue
@@ -135,10 +135,9 @@
     (open) => {
       nextTick(() => {
         emit('open-change', open);
-        //
-        instance !== null &&
-          isFunction(drawerInstance.emitOpen) &&
-          drawerInstance.emitOpen?.(open, instance.uid);
+        if (instance && drawerInstance.emitOpen) {
+          drawerInstance.emitOpen(open, instance.uid);
+        }
       });
     },
   );


### PR DESCRIPTION
### `General`

> 使用 Drawer 的时候，在组件内部使用 getOpen 获取是否打开状态，发现 build 之后没有生效。对比build前后代码，关键逻辑丢失，如下：
![S0Ip7PTpt9](https://github.com/vbenjs/vue-vben-admin/assets/16830398/d33311d6-5a2e-4a57-93bf-38801ad6dfef)
> 不考虑 build 配置，微调判断可以避免这个问题。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
