### PR TITLE
fix: ColumnSetting about selectedRowKeys override

### DIFF
--- a/src/components/Table/src/components/settings/ColumnSetting.vue
+++ b/src/components/Table/src/components/settings/ColumnSetting.vue
@@ -111,7 +111,7 @@
   import { useDesign } from '@/hooks/web/useDesign';
   import { isFunction, isNil } from '@/utils/is';
   import { getPopupContainer as getParentContainer } from '@/utils';
-  import { cloneDeep } from 'lodash-es';
+  import { cloneDeep, omit } from 'lodash-es';
   import Sortablejs from 'sortablejs';
 
   // 列表设置缓存
@@ -492,7 +492,7 @@
     table.setProps({
       rowSelection: showRowSelection
         ? {
-            ...defaultRowSelection,
+            ...omit(defaultRowSelection, ['selectedRowKeys']),
             fixed: true,
           }
         : undefined,

--- a/src/components/Table/src/components/settings/index.vue
+++ b/src/components/Table/src/components/settings/index.vue
@@ -6,7 +6,7 @@
       v-if="getSetting.setting"
       @columns-change="handleColumnChange"
       :getPopupContainer="getTableContainer"
-      :cache="false"
+      :cache="getSetting.settingCache"
     />
     <FullScreenSetting v-if="getSetting.fullScreen" :getPopupContainer="getTableContainer" />
   </div>
@@ -39,6 +39,7 @@
       redo: true,
       size: true,
       setting: true,
+      settingCache: false,
       fullScreen: false,
       ...props.setting,
     };

--- a/src/components/Table/src/types/table.ts
+++ b/src/components/Table/src/types/table.ts
@@ -140,6 +140,7 @@ export interface TableSetting {
   redo?: boolean;
   size?: boolean;
   setting?: boolean;
+  settingCache?: boolean;
   fullScreen?: boolean;
 }
 


### PR DESCRIPTION
### `General`

> 经过反馈，启用 ColumnSetting 之后，默认情况下，无法使用 rowSelections；经过分析测试，是赋值 selectedRowKeys 导致的。此 pr 就是修复这个问题。顺便把 cache 开关增加 TableSettings 可以单独设置。

> 反馈来源与分析，https://github.com/vbenjs/vue-vben-admin/issues/3445

> 也意味着，目前 selectedRowKeys 受 useRowSelection 管理，不能自行设置 selectedRowKeys，需要通过 useRowSelection 的方法控制 selectedRowKeys。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
