### PR TITLE
fix: index still show when set showIndexColumn false

### DIFF
--- a/src/components/Table/src/components/settings/ColumnSetting.vue
+++ b/src/components/Table/src/components/settings/ColumnSetting.vue
@@ -445,12 +445,11 @@
   const restore = () => {
     // 设置过才恢复
     if (typeof tableSettingStore.getShowIndexColumn === 'boolean') {
-      isIndexColumnShow.value = tableSettingStore.getShowIndexColumn;
+      isIndexColumnShow.value = defaultIsIndexColumnShow && tableSettingStore.getShowIndexColumn;
     }
     if (typeof tableSettingStore.getShowRowSelection === 'boolean') {
       isRowSelectionShow.value = defaultIsRowSelectionShow && tableSettingStore.getShowRowSelection;
     }
-
     // 序号列更新
     onIndexColumnShowChange({
       target: { checked: isIndexColumnShow.value },


### PR DESCRIPTION
### `General`

> 当开启了ColumnSetting的缓存，将 showIndexColumn 从 true 改变成 false 的时候，序号列依旧显示，理应不显示。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
