### PR TITLE
fix: showIndexColumn/showRowSelection cache by route name

### DIFF
--- a/src/components/Table/src/components/settings/ColumnSetting.vue
+++ b/src/components/Table/src/components/settings/ColumnSetting.vue
@@ -210,7 +210,9 @@
     // 更新 showIndexColumn
     showIndexColumnUpdate(e.target.checked);
     // 更新 showIndexColumn 缓存
-    props.cache && tableSettingStore.setShowIndexColumn(e.target.checked);
+    props.cache &&
+      typeof route.name === 'string' &&
+      tableSettingStore.setShowIndexColumn(route.name, e.target.checked);
   };
 
   // 是否显示选择列
@@ -220,7 +222,9 @@
     // 更新 showRowSelection
     showRowSelectionUpdate(e.target.checked);
     // 更新 showRowSelection 缓存
-    props.cache && tableSettingStore.setShowRowSelection(e.target.checked);
+    props.cache &&
+      typeof route.name === 'string' &&
+      tableSettingStore.setShowRowSelection(route.name, e.target.checked);
   };
 
   // 更新列缓存
@@ -435,12 +439,18 @@
 
   // 从缓存恢复
   const restore = () => {
-    // 设置过才恢复
-    if (typeof tableSettingStore.getShowIndexColumn === 'boolean') {
-      isIndexColumnShow.value = defaultIsIndexColumnShow && tableSettingStore.getShowIndexColumn;
-    }
-    if (typeof tableSettingStore.getShowRowSelection === 'boolean') {
-      isRowSelectionShow.value = defaultIsRowSelectionShow && tableSettingStore.getShowRowSelection;
+    if (typeof route.name === 'string') {
+      const isIndexColumnShowCache = tableSettingStore.getShowIndexColumn(route.name);
+      // 设置过才恢复
+      if (typeof isIndexColumnShowCache === 'boolean') {
+        isIndexColumnShow.value = defaultIsIndexColumnShow && isIndexColumnShowCache;
+      }
+
+      const isRowSelectionShowCache = tableSettingStore.getShowRowSelection(route.name);
+      // 设置过才恢复
+      if (typeof isRowSelectionShowCache === 'boolean') {
+        isRowSelectionShow.value = defaultIsRowSelectionShow && isRowSelectionShowCache;
+      }
     }
     // 序号列更新
     onIndexColumnShowChange({

--- a/src/store/modules/tableSetting.ts
+++ b/src/store/modules/tableSetting.ts
@@ -26,11 +26,15 @@ export const useTableSettingStore = defineStore({
     },
     //
     getShowIndexColumn(state) {
-      return state.setting?.showIndexColumn;
+      return (routerName: string) => {
+        return state.setting?.showIndexColumn?.[routerName];
+      };
     },
     //
     getShowRowSelection(state) {
-      return state.setting?.showRowSelection;
+      return (routerName: string) => {
+        return state.setting?.showRowSelection?.[routerName];
+      };
     },
     //
     getColumns(state) {
@@ -59,18 +63,24 @@ export const useTableSettingStore = defineStore({
       );
     },
     //
-    setShowIndexColumn(show: boolean) {
+    setShowIndexColumn(routerName: string, show: boolean) {
       this.setTableSetting(
         Object.assign({}, this.setting, {
-          showIndexColumn: show,
+          showIndexColumn: {
+            ...this.setting?.showIndexColumn,
+            [routerName]: show,
+          },
         }),
       );
     },
     //
-    setShowRowSelection(show: boolean) {
+    setShowRowSelection(routerName: string, show: boolean) {
       this.setTableSetting(
         Object.assign({}, this.setting, {
-          showRowSelection: show,
+          showRowSelection: {
+            ...this.setting?.showRowSelection,
+            [routerName]: show,
+          },
         }),
       );
     },

--- a/types/store.d.ts
+++ b/types/store.d.ts
@@ -54,7 +54,7 @@ export interface BeforeMiniState {
 
 export interface TableSetting {
   size: Nullable<SizeType>;
-  showIndexColumn: Nullable<boolean>;
+  showIndexColumn: Recordable<Nullable<boolean>>;
   columns: Recordable<Nullable<Array<ColumnOptionsType>>>;
-  showRowSelection: Nullable<boolean>;
+  showRowSelection: Recordable<Nullable<boolean>>;
 }


### PR DESCRIPTION
### `General`

> 列设置的序号列、选择列在不同页面之间存在干涉，逻辑错误，缓存记录也应该根据路由隔离，现修复之。
> 错误场景具体描述：在打开列设置的缓存功能的情况下，假设页面 A、B 均显示选择列，此时任意隐藏其中一个页面的选择列，另外一个页面的选择列也消失了。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
