### PR TITLE
feat: 优化头像上传组件,方便对接后端

### DIFF
--- a/src/api/sys/model/uploadModel.ts
+++ b/src/api/sys/model/uploadModel.ts
@@ -1,5 +1,6 @@
 export interface UploadApiResult {
   message: string;
+  type: string;
   code: number;
-  url: string;
+  result: string;
 }

--- a/src/components/Cropper/src/CropperAvatar.vue
+++ b/src/components/Cropper/src/CropperAvatar.vue
@@ -23,9 +23,12 @@
     <CropperModal
       @register="register"
       @upload-success="handleUploadSuccess"
+      @upload-error="handleUploadError"
       :uploadApi="uploadApi"
       :src="sourceValue"
-      :size="size"
+      :checkMaxSize="checkMaxSize"
+      :type="type"
+      :path="path"
     />
   </div>
 </template>
@@ -38,6 +41,7 @@
   import { useI18n } from '@/hooks/web/useI18n';
   import type { ButtonProps } from '@/components/Button';
   import Icon from '@/components/Icon/Icon.vue';
+  import { UploadFileParams } from '#/axios';
 
   defineOptions({ name: 'CropperAvatar' });
 
@@ -48,10 +52,11 @@
     btnProps: { type: Object as PropType<ButtonProps> },
     btnText: { type: String, default: '' },
     uploadApi: {
-      type: Function as PropType<({ file, name }: { file: Blob; name: string }) => Promise<void>>,
+      type: Function as PropType<({ file, type }: UploadFileParams) => Promise<void>>,
     },
-
-    size: { type: Number, default: 5 },
+    checkMaxSize: { type: Number, default: 2 },
+    type: { type: String, default: 'image' },
+    path: { type: String, default: 'image/avatar' },
   });
 
   const emit = defineEmits(['update:value', 'change']);
@@ -89,6 +94,10 @@
     sourceValue.value = source;
     emit('change', { source, data });
     createMessage.success(t('component.cropper.uploadSuccess'));
+  }
+
+  function handleUploadError({ msg }) {
+    createMessage.error(msg);
   }
 
   defineExpose({ openModal: openModal.bind(null, true), closeModal });

--- a/src/enums/appEnum.ts
+++ b/src/enums/appEnum.ts
@@ -1,5 +1,6 @@
 export const SIDE_BAR_MINI_WIDTH = 48;
 export const SIDE_BAR_SHOW_TIT_MINI_WIDTH = 80;
+export const STATIC_FILE_DIR_BACKEND = 'static';
 
 export enum ContentEnum {
   // auto width

--- a/src/locales/lang/en/component.json
+++ b/src/locales/lang/en/component.json
@@ -11,7 +11,8 @@
   "cropper": {
     "selectImage": "Select Image",
     "uploadSuccess": "Uploaded success!",
-    "imageTooBig": "Image too big",
+    "uploadError": "Uploaded error!",
+    "imageMaxSize": "Only upload image up to {0}MB!",
     "modalTitle": "Avatar upload",
     "okText": "Confirm and upload",
     "btn_reset": "Reset",

--- a/src/locales/lang/zh-CN/component.json
+++ b/src/locales/lang/zh-CN/component.json
@@ -11,7 +11,8 @@
   "cropper": {
     "selectImage": "选择图片",
     "uploadSuccess": "上传成功",
-    "imageTooBig": "图片超限",
+    "uploadError": "上传失败",
+    "imageMaxSize": "只能上传不超过{0}MB的图片",
     "modalTitle": "头像上传",
     "okText": "确认并上传",
     "btn_reset": "重置",

--- a/src/settings/projectSetting.ts
+++ b/src/settings/projectSetting.ts
@@ -8,6 +8,7 @@ import {
   RouterTransitionEnum,
   SettingButtonPositionEnum,
   SessionTimeoutProcessingEnum,
+  STATIC_FILE_DIR_BACKEND,
 } from '@/enums/appEnum';
 import {
   SIDE_BAR_BG_COLOR_LIST,
@@ -183,6 +184,9 @@ const setting: ProjectConfig = {
   // Whether to cancel the http request that has been sent but not responded when switching the interface.
   // If it is enabled, I want to overwrite a single interface. Can be set in a separate interface
   removeAllHttpPending: false,
+
+  // Backend server save static file to relative classpath dirctory
+  staticFileDirBackend: STATIC_FILE_DIR_BACKEND,
 };
 
 export default setting;

--- a/src/utils/http/axios/helper.ts
+++ b/src/utils/http/axios/helper.ts
@@ -1,4 +1,8 @@
 import { isObject, isString } from '@/utils/is';
+import { useGlobSetting } from '@/hooks/setting';
+import projectSetting from '@/settings/projectSetting';
+
+const globSetting = useGlobSetting();
 
 const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
@@ -46,3 +50,10 @@ export function formatRequestDate(params: Recordable) {
     }
   }
 }
+
+// Convert avatar image realtive path to url
+export const getAvatarUrl = (relaPath: string | undefined) => {
+  return relaPath
+    ? globSetting.apiUrl + '/' + projectSetting.staticFileDirBackend + '/' + relaPath
+    : '';
+};

--- a/types/axios.d.ts
+++ b/types/axios.d.ts
@@ -46,11 +46,13 @@ export interface Result<T = any> {
 export interface UploadFileParams {
   // Other parameters
   data?: Recordable;
-  // File parameter interface field name
-  name?: string;
   // file name
   file: File | Blob;
   // file name
   filename?: string;
+  // file type
+  type?: string | undefined;
+  // file realtive path
+  path?: string | undefined;
   [key: string]: any;
 }

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -136,6 +136,8 @@ export interface ProjectConfig {
   closeMessageOnSwitch: boolean;
   // Whether to cancel the http request that has been sent but not responded when switching the interface.
   removeAllHttpPending: boolean;
+  // static file saved in relative classpath dirctory for backend server
+  staticFileDirBackend: string;
 }
 
 export interface GlobConfig {


### PR DESCRIPTION
1. 调整UploadFileParams类型, 在头像图片上传中统一引用
2. 调整文件上传返回类型, 方便对接后端
3. 优化头像图片大小限制参数和提示语
4. 添加后端上传静态文件夹配置
5. 添加头像图片上传相对路径配置
6. 添加将图片相对路径转换为url的方法, 方便对接后端