### PR TITLE
fix: handleFormValues 不再将所有空字符串转换为undefined

### DIFF
--- a/src/components/Form/src/hooks/useFormEvents.ts
+++ b/src/components/Form/src/hooks/useFormEvents.ts
@@ -432,7 +432,7 @@ function getDefaultValue(
   let defaultValue = cloneDeep(defaultValueRef.value[key]);
   const isInput = checkIsInput(schema);
   if (isInput) {
-    return defaultValue || '';
+    return defaultValue || undefined;
   }
   if (!defaultValue && schema && checkIsRangeSlider(schema)) {
     defaultValue = [0, 0];

--- a/src/components/Form/src/hooks/useFormValues.ts
+++ b/src/components/Form/src/hooks/useFormValues.ts
@@ -76,12 +76,7 @@ export function useFormValues({
       }
       // Remove spaces
       if (isString(value)) {
-        // remove params from URL
-        if (value === '') {
-          value = undefined;
-        } else {
-          value = value.trim();
-        }
+        value = value.trim();
       }
       if (!tryDeconstructArray(key, value, res) && !tryDeconstructObject(key, value, res)) {
         // 没有解构成功的，按原样赋值


### PR DESCRIPTION
handleFormValues 在获取 fields 时调用，判断字段为空字符串时会转换为 undefined，但这样就无法将有内容的字符串修改为空字符串值，因为 json 序列化会忽略 undefined 字段
之前这里的修改是 [为了重置表单时移除URL中的参数 #2559](https://github.com/vbenjs/vue-vben-admin/pull/2559/)
在 resetFields 里调用的 getDefaultValue 里把 input 默认值设置为 undefined 一样可以实现