### PR TITLE
fix: vite:html warning

### DIFF
--- a/internal/vite-config/src/plugins/html.ts
+++ b/internal/vite-config/src/plugins/html.ts
@@ -8,6 +8,7 @@ import { createHtmlPlugin } from 'vite-plugin-html';
 export function configHtmlPlugin({ isBuild }: { isBuild: boolean }) {
   const htmlPlugin: PluginOption[] = createHtmlPlugin({
     minify: isBuild,
+    viteNext: true,
   });
   return htmlPlugin;
 }


### PR DESCRIPTION
### `General`

> 消除升级 vite5 出现以下的 vite:html warning:
> WARN  plugin 'vite:html' uses deprecated 'enforce' option. Use 'order' option instead.                                                           
> WARN  plugin 'vite:html' uses deprecated 'transform' option. Use 'handler' option instead.   

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
