### PR TITLE
fix: menu->about icon is missing

### DIFF
--- a/src/router/routes/modules/about.ts
+++ b/src/router/routes/modules/about.ts
@@ -10,7 +10,7 @@ const about: AppRouteModule = {
   redirect: '/about/index',
   meta: {
     hideChildrenInMenu: true,
-    icon: 'simple-icons:about-dot-me',
+    icon: 'simple-icons:aboutdotme',
     title: t('routes.dashboard.about'),
     orderNo: 100000,
   },
@@ -21,7 +21,7 @@ const about: AppRouteModule = {
       component: () => import('@/views/sys/about/index.vue'),
       meta: {
         title: t('routes.dashboard.about'),
-        icon: 'simple-icons:about-dot-me',
+        icon: 'simple-icons:aboutdotme',
         hideMenu: true,
       },
     },


### PR DESCRIPTION
![image](https://github.com/vbenjs/vue-vben-admin/assets/29778465/4ab30424-ce2e-4f64-95d6-c27a58ce3af3)
![image](https://github.com/vbenjs/vue-vben-admin/assets/29778465/dde795eb-46b1-42e8-9972-65eaf66e0b2b)
