### PR TITLE
fix(ApiCascader): wrong api reload

### DIFF
--- a/src/components/Form/src/components/ApiCascader.vue
+++ b/src/components/Form/src/components/ApiCascader.vue
@@ -20,7 +20,7 @@
 </template>
 <script lang="ts" setup>
   import { type Recordable } from '@vben/types';
-  import { PropType, ref, unref, watch, watchEffect } from 'vue';
+  import { PropType, ref, unref, watch } from 'vue';
   import { Cascader } from 'ant-design-vue';
   import type { CascaderProps } from 'ant-design-vue';
   import { propTypes } from '@/utils/propTypes';
@@ -159,9 +159,15 @@
     }
   };
 
-  watchEffect(() => {
-    props.immediate && initialFetch();
-  });
+  watch(
+    () => props.immediate,
+    () => {
+      props.immediate && initialFetch();
+    },
+    {
+      immediate: true,
+    },
+  );
 
   watch(
     () => props.initFetchParams,


### PR DESCRIPTION
### `General`

> 避免使用 watchEffect，这里因为外部 updateSchema 触发了多余的 api reload了。（https://github.com/vbenjs/vue-vben-admin/issues/3534）

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
