### PR TITLE
fix(FormItem): model should update before event call

### DIFF
--- a/src/components/Form/src/components/FormItem.vue
+++ b/src/components/Form/src/components/FormItem.vue
@@ -280,12 +280,14 @@
         const on = {
           [eventKey]: (...args: Nullable<Recordable<any>>[]) => {
             const [e] = args;
-            if (propsData[eventKey]) {
-              propsData[eventKey](...args);
-            }
+
             const target = e ? e.target : null;
             const value = target ? (isCheck ? target.checked : target.value) : e;
             props.setFormModel(field, value, props.schema);
+
+            if (propsData[eventKey]) {
+              propsData[eventKey](...args);
+            }
           },
         };
         const Comp = componentMap.get(component) as ReturnType<typeof defineComponent>;
@@ -385,8 +387,8 @@
             return slot
               ? getSlot(slots, slot, unref(getValues), opts)
               : render
-              ? render(unref(getValues), opts)
-              : renderComponent();
+                ? render(unref(getValues), opts)
+                : renderComponent();
           };
 
           const showSuffix = !!suffix;
@@ -437,8 +439,8 @@
           return colSlot
             ? getSlot(slots, colSlot, values, opts)
             : renderColContent
-            ? renderColContent(values, opts)
-            : renderItem();
+              ? renderColContent(values, opts)
+              : renderItem();
         };
 
         return (


### PR DESCRIPTION
### `General`

> 根据 https://github.com/vbenjs/vue-vben-admin/issues/3570 排查得知，FormItem 内部是先触发表单组件的 event，后更新 model，导致 getFormValues 及其依赖了它的例如 reload 方法没有获得最新的 model 值。现调整为优先更新 model。

- [x] Pull request template structure not broken

### `Type`

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
