### PR TITLE
fix: repair login about redirect query

### DIFF
--- a/src/hooks/web/usePermission.ts
+++ b/src/hooks/web/usePermission.ts
@@ -46,10 +46,13 @@ export function usePermission() {
     const tabStore = useMultipleTabStore();
     tabStore.clearCacheTabs();
     resetRouter();
+
+    // 动态加载路由（再次）
     const routes = await permissionStore.buildRoutesAction();
     routes.forEach((route) => {
       router.addRoute(route as unknown as RouteRecordRaw);
     });
+
     permissionStore.setLastBuildMenuTime();
     closeAll();
   }

--- a/src/router/guard/permissionGuard.ts
+++ b/src/router/guard/permissionGuard.ts
@@ -71,16 +71,6 @@ export function createPermissionGuard(router: Router) {
       return;
     }
 
-    // Jump to the 404 page after processing the login
-    if (
-      from.path === LOGIN_PATH &&
-      to.name === PAGE_NOT_FOUND_ROUTE.name &&
-      to.fullPath !== (userStore.getUserInfo.homePath || PageEnum.BASE_HOME)
-    ) {
-      next(userStore.getUserInfo.homePath || PageEnum.BASE_HOME);
-      return;
-    }
-
     // get userinfo while last fetch time is empty
     if (userStore.getLastUpdateTime === 0) {
       try {
@@ -91,18 +81,35 @@ export function createPermissionGuard(router: Router) {
       }
     }
 
+    // 动态路由加载（首次）
     if (!permissionStore.getIsDynamicAddedRoute) {
       const routes = await permissionStore.buildRoutesAction();
-      routes.forEach((route) => {
+      [...routes, PAGE_NOT_FOUND_ROUTE].forEach((route) => {
         router.addRoute(route as unknown as RouteRecordRaw);
       });
-      router.addRoute(PAGE_NOT_FOUND_ROUTE as unknown as RouteRecordRaw);
+      // 记录动态路由加载完成
       permissionStore.setDynamicAddedRoute(true);
+
+      // 现在的to动态路由加载之前的，可能为PAGE_NOT_FOUND_ROUTE（例如，登陆后，刷新的时候）
+      // 此处应当重定向到fullPath，否则会加载404页面内容
+      next({ path: to.fullPath, replace: true, query: to.query });
+      return;
     }
 
     if (to.name === PAGE_NOT_FOUND_ROUTE.name) {
-      // 动态添加路由后，此处应当重定向到fullPath，否则会加载404页面内容
-      next({ path: to.fullPath, replace: true, query: to.query });
+      // 遇到不存在页面，后续逻辑不再处理redirect（阻止下面else逻辑）
+      from.query.redirect = '';
+
+      if (
+        from.path === LOGIN_PATH &&
+        to.fullPath !== (userStore.getUserInfo.homePath || PageEnum.BASE_HOME)
+      ) {
+        // 登陆重定向不存在路由，转去“首页”
+        next({ path: userStore.getUserInfo.homePath || PageEnum.BASE_HOME, replace: true });
+      } else {
+        // 正常前往“404”页面
+        next();
+      }
     } else if (from.query.redirect) {
       // 存在redirect
       const redirect = decodeURIComponent((from.query.redirect as string) || '');
@@ -114,6 +121,7 @@ export function createPermissionGuard(router: Router) {
         next({ path: redirect, replace: true });
       }
     } else {
+      // 正常访问
       next();
     }
   });

--- a/src/router/guard/permissionGuard.ts
+++ b/src/router/guard/permissionGuard.ts
@@ -91,29 +91,30 @@ export function createPermissionGuard(router: Router) {
       }
     }
 
-    if (permissionStore.getIsDynamicAddedRoute) {
-      next();
-      return;
+    if (!permissionStore.getIsDynamicAddedRoute) {
+      const routes = await permissionStore.buildRoutesAction();
+      routes.forEach((route) => {
+        router.addRoute(route as unknown as RouteRecordRaw);
+      });
+      router.addRoute(PAGE_NOT_FOUND_ROUTE as unknown as RouteRecordRaw);
+      permissionStore.setDynamicAddedRoute(true);
     }
-
-    const routes = await permissionStore.buildRoutesAction();
-
-    routes.forEach((route) => {
-      router.addRoute(route as unknown as RouteRecordRaw);
-    });
-
-    router.addRoute(PAGE_NOT_FOUND_ROUTE as unknown as RouteRecordRaw);
-
-    permissionStore.setDynamicAddedRoute(true);
 
     if (to.name === PAGE_NOT_FOUND_ROUTE.name) {
       // 动态添加路由后，此处应当重定向到fullPath，否则会加载404页面内容
       next({ path: to.fullPath, replace: true, query: to.query });
+    } else if (from.query.redirect) {
+      // 存在redirect
+      const redirect = decodeURIComponent((from.query.redirect as string) || '');
+      if (redirect === to.fullPath) {
+        // 已经被redirect
+        next();
+      } else {
+        // 指向redirect
+        next({ path: redirect, replace: true });
+      }
     } else {
-      const redirectPath = (from.query.redirect || to.path) as string;
-      const redirect = decodeURIComponent(redirectPath);
-      const nextData = to.path === redirect ? { ...to, replace: true } : { path: redirect };
-      next(nextData);
+      next();
     }
   });
 }

--- a/src/router/guard/permissionGuard.ts
+++ b/src/router/guard/permissionGuard.ts
@@ -38,7 +38,7 @@ export function createPermissionGuard(router: Router) {
         try {
           await userStore.afterLoginAction();
           if (!isSessionTimeout) {
-            next((to.query?.redirect as string) || '/');
+            next(decodeURIComponent((to.query?.redirect as string) || '/'));
             return;
           }
         } catch {

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -116,6 +116,7 @@ export const useUserStore = defineStore({
             router.addRoute(route as unknown as RouteRecordRaw);
           });
           router.addRoute(PAGE_NOT_FOUND_ROUTE as unknown as RouteRecordRaw);
+          permissionStore.setDynamicAddedRoute(true);
         }
         goHome && (await router.replace(userInfo?.homePath || PageEnum.BASE_HOME));
       }

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -116,7 +116,6 @@ export const useUserStore = defineStore({
             router.addRoute(route as unknown as RouteRecordRaw);
           });
           router.addRoute(PAGE_NOT_FOUND_ROUTE as unknown as RouteRecordRaw);
-          permissionStore.setDynamicAddedRoute(true);
         }
         goHome && (await router.replace(userInfo?.homePath || PageEnum.BASE_HOME));
       }
@@ -150,7 +149,18 @@ export const useUserStore = defineStore({
       this.setToken(undefined);
       this.setSessionTimeout(false);
       this.setUserInfo(null);
-      goLogin && router.push(PageEnum.BASE_LOGIN);
+      if (goLogin) {
+        // 直接回登陆页
+        router.replace(PageEnum.BASE_LOGIN);
+      } else {
+        // 回登陆页带上当前路由地址
+        router.replace({
+          path: PageEnum.BASE_LOGIN,
+          query: {
+            redirect: encodeURIComponent(router.currentRoute.value.fullPath),
+          },
+        });
+      }
     },
 
     /**
@@ -164,6 +174,7 @@ export const useUserStore = defineStore({
         title: () => h('span', t('sys.app.logoutTip')),
         content: () => h('span', t('sys.app.logoutMessage')),
         onOk: async () => {
+          // 主动登出，不带redirect地址
           await this.logout(true);
         },
       });

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -110,14 +110,17 @@ export const useUserStore = defineStore({
         this.setSessionTimeout(false);
       } else {
         const permissionStore = usePermissionStore();
+
+        // 动态路由加载（首次）
         if (!permissionStore.isDynamicAddedRoute) {
           const routes = await permissionStore.buildRoutesAction();
-          routes.forEach((route) => {
+          [...routes, PAGE_NOT_FOUND_ROUTE].forEach((route) => {
             router.addRoute(route as unknown as RouteRecordRaw);
           });
-          router.addRoute(PAGE_NOT_FOUND_ROUTE as unknown as RouteRecordRaw);
+          // 记录动态路由加载完成
           permissionStore.setDynamicAddedRoute(true);
         }
+
         goHome && (await router.replace(userInfo?.homePath || PageEnum.BASE_HOME));
       }
       return userInfo;

--- a/src/utils/http/axios/checkStatus.ts
+++ b/src/utils/http/axios/checkStatus.ts
@@ -33,7 +33,8 @@ export function checkStatus(
       if (stp === SessionTimeoutProcessingEnum.PAGE_COVERAGE) {
         userStore.setSessionTimeout(true);
       } else {
-        userStore.logout(true);
+        // 被动登出，带redirect地址
+        userStore.logout(false);
       }
       break;
     case 403:

--- a/src/utils/http/axios/index.ts
+++ b/src/utils/http/axios/index.ts
@@ -77,7 +77,8 @@ const transform: AxiosTransform = {
       case ResultEnum.TIMEOUT:
         timeoutMsg = t('sys.api.timeoutMessage');
         const userStore = useUserStoreWithOut();
-        userStore.logout(true);
+        // 被动登出，带redirect地址
+        userStore.logout(false);
         break;
       default:
         if (message) {

--- a/src/views/sys/lock/LockPage.vue
+++ b/src/views/sys/lock/LockPage.vue
@@ -124,6 +124,7 @@
   }
 
   function goLogin() {
+    // 主动登出，不带redirect地址
     userStore.logout(true);
     lockStore.resetLockInfo();
   }


### PR DESCRIPTION
### `General`

> 根据反馈 https://github.com/vbenjs/vue-vben-admin/issues/3588 重现问题，根源：
> src\store\modules\user.ts 重复并提前执行了 permissionStore.setDynamicAddedRoute(true)，导致 src\router\guard\permissionGuard.ts 无法通过到逻辑最后（不知道理解的对不对，测试通过部分场景）。
> 另外，目前登出均为 logout(true)，理应区分”主动“和”被动“两种场景，”主动“不带 redirect 回到登陆页，”被动“带。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
