### PR TITLE
fix: basemodal 无法透传 attributes 至 Modal.tsx

### DIFF
--- a/src/components/Modal/src/components/Modal.tsx
+++ b/src/components/Modal/src/components/Modal.tsx
@@ -2,7 +2,6 @@ import { Modal } from 'ant-design-vue';
 import { defineComponent, toRefs, unref } from 'vue';
 import { basicProps } from '../props';
 import { useModalDragMove } from '../hooks/useModalDrag';
-import { useAttrs } from '@vben/hooks';
 import { extendSlots } from '@/utils/helper/tsxHelper';
 
 export default defineComponent({
@@ -10,9 +9,8 @@ export default defineComponent({
   inheritAttrs: false,
   props: basicProps as any,
   emits: ['cancel'],
-  setup(props, { slots, emit }) {
+  setup(props, { slots, emit, attrs }) {
     const { open, draggable, destroyOnClose } = toRefs(props);
-    const attrs = useAttrs();
     useModalDragMove({
       open,
       destroyOnClose,


### PR DESCRIPTION
### `General`

fix: basemodal 无法透传 attributes 至 Modal.tsx.
close #3636 

可以在 <script setup> 中使用 useAttrs() API 来访问一个组件的所有透传 attribute 。 如果没有使用 <script setup>，attrs 会作为 setup() 上下文对象的一个属性暴露，这边修改了透传 attribute 的方式。

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
