### PR TITLE
fix: breadcrumb is displayed despite the menu being hidden

### DIFF
--- a/src/components/Form/src/hooks/useFormEvents.ts
+++ b/src/components/Form/src/hooks/useFormEvents.ts
@@ -135,6 +135,9 @@ export function useFormEvents({
       }
 
       const constructValue = tryConstructArray(key, values) || tryConstructObject(key, values);
+      const setDateFieldValue = (v) => {
+        return v ? (_props?.valueFormat ? v : dateUtil(v)) : null;
+      };
 
       // 0| '' is allow
       if (hasKey || !!constructValue) {
@@ -144,15 +147,11 @@ export function useFormEvents({
           if (Array.isArray(fieldValue)) {
             const arr: any[] = [];
             for (const ele of fieldValue) {
-              arr.push(ele ? dateUtil(ele) : null);
+              arr.push(setDateFieldValue(ele));
             }
             unref(formModel)[key] = arr;
           } else {
-            unref(formModel)[key] = fieldValue
-              ? _props?.valueFormat
-                ? fieldValue
-                : dateUtil(fieldValue)
-              : null;
+            unref(formModel)[key] = setDateFieldValue(fieldValue);
           }
         } else {
           unref(formModel)[key] = fieldValue;

--- a/src/layouts/default/header/components/Breadcrumb.vue
+++ b/src/layouts/default/header/components/Breadcrumb.vue
@@ -66,7 +66,10 @@
         const filterMenus = menus.filter((item) => item.path === parent[0]);
         const matched = getMatched(filterMenus, parent) as any;
 
-        if (!matched || matched.length === 0) return;
+        if (!matched || matched.length === 0){
+          routes.value = [];
+          return;
+        }
 
         const breadcrumbList = filterItem(matched);
 


### PR DESCRIPTION
The breadcrumb is initially hidden when accessing either the hidden menu or the "not found" page. However, upon returning to either the hidden menu or the "not found" page after navigating to other pages, the breadcrumb remains visible.

![image](https://github.com/vbenjs/vue-vben-admin/assets/88119911/2c9c3d5d-75cf-4439-9e8f-b5997667a604)

![image](https://github.com/vbenjs/vue-vben-admin/assets/88119911/c2d42347-462c-4268-aef4-9d3b3ca208a7)

![image](https://github.com/vbenjs/vue-vben-admin/assets/88119911/aa5bc5b8-86a1-4d19-bd1b-526590b0010b)



### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
