### PR TITLE
feat(BasicForm): 监听表单收缩方法传值进行判断

### DIFF
--- a/src/components/Form/src/hooks/useAdvanced.ts
+++ b/src/components/Form/src/hooks/useAdvanced.ts
@@ -160,7 +160,7 @@ export default function ({
 
     getAdvanced(unref(getProps).actionColOptions || { span: BASIC_COL_LEN }, itemColSum, true);
 
-    emit('advanced-change');
+    emit('advanced-change', advanceState.isAdvanced);
   }
 
   function handleToggleAdvanced() {

--- a/src/views/demo/form/AdvancedForm.vue
+++ b/src/views/demo/form/AdvancedForm.vue
@@ -5,7 +5,7 @@
     </CollapseContainer>
 
     <CollapseContainer title="超过3行自动收起，折叠时保留2行" class="mt-4">
-      <BasicForm @register="register1" />
+      <BasicForm @register="register1" @advanced-change="onAdvancedChange" />
     </CollapseContainer>
   </PageWrapper>
 </template>
@@ -182,4 +182,13 @@
     showAdvancedButton: true,
     alwaysShowLines: 2,
   });
+
+  function onAdvancedChange(isAdvanced: boolean) {
+    console.log('isAdvanced: ' + isAdvanced);
+    if (isAdvanced) {
+      // do something
+    } else {
+      // do something
+    }
+  }
 </script>


### PR DESCRIPTION
需求：表单折叠除了动态计算表格高度之外，比如在一些非表格的页面也需要根据表单的高度动态计算列表（如：CardList）的高度，可以进行页面高度自适应