### PR TITLE
perf(util): remove handleInputNumberValue

### DIFF
--- a/src/components/Form/src/helper.ts
+++ b/src/components/Form/src/helper.ts
@@ -2,7 +2,7 @@ import type { Rule as ValidationRule } from 'ant-design-vue/lib/form/interface';
 import type { ComponentType } from './types';
 import { useI18n } from '@/hooks/web/useI18n';
 import { dateUtil } from '@/utils/dateUtil';
-import { isNumber, isObject } from '@/utils/is';
+import { isObject } from '@/utils/is';
 
 const { t } = useI18n();
 

--- a/src/components/Form/src/helper.ts
+++ b/src/components/Form/src/helper.ts
@@ -69,14 +69,6 @@ export const defaultValueComponents = [
   'InputTextArea',
 ];
 
-export function handleInputNumberValue(component?: ComponentType, val?: any) {
-  if (!component) return val;
-  if (defaultValueComponents.includes(component)) {
-    return val && isNumber(val) ? val : `${val}`;
-  }
-  return val;
-}
-
 /**
  * 时间字段
  */

--- a/src/components/Form/src/hooks/useFormEvents.ts
+++ b/src/components/Form/src/hooks/useFormEvents.ts
@@ -6,7 +6,6 @@ import { isArray, isFunction, isObject, isString, isDef, isNil } from '@/utils/i
 import { deepMerge } from '@/utils';
 import {
   dateItemType,
-  handleInputNumberValue,
   defaultValueComponents,
   isIncludeSimpleComponents,
 } from '../helper';
@@ -79,8 +78,6 @@ export function useFormEvents({
       const schema = unref(getSchema).find((item) => item.field === key);
       let value = get(values, key);
       const hasKey = has(values, key);
-
-      value = handleInputNumberValue(schema?.component, value);
       const { componentProps } = schema || {};
       let _props = componentProps as any;
       if (typeof componentProps === 'function') {


### PR DESCRIPTION
fix:https://github.com/vbenjs/vue-vben-admin/issues/3805
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

 Pull request template structure not broken

历史遗留问题

当初这个函数的提出是为了解决这个默认值的bug( https://github.com/vbenjs/vue-vben-admin/issues/3274 )，但是默认值的问题没有彻底解决

直到 https://github.com/vbenjs/vue-vben-admin/pull/3287 之后才把这个问题大体解决了(定位问题是在isEmpty的使用上面，而跟这个函数没有什么关系)。这时handleInputNumberValue这个函数不仅没发挥到应有的作用，并且导致了input系列组件输入输出类型不一致的问题 。例如输入number，string，其他的数据都会变成string

最近 https://github.com/vbenjs/vue-vben-admin/pull/3802 pr提过之后，目前的行为是 number变成number，然后其他的都变成string，但是仍然导致了 null 和 undefined等其他类型 会被设置成 string类型。