### PR TITLE
fix(imgUpload): disabled not effect in the form

### DIFF
--- a/src/components/Upload/src/components/ImageUpload.vue
+++ b/src/components/Upload/src/components/ImageUpload.vue
@@ -9,6 +9,7 @@
       :maxCount="maxNumber"
       :before-upload="beforeUpload"
       :custom-request="customRequest"
+      :disabled="disabled"
       @preview="handlePreview"
       @remove="handleRemove"
     >


### PR DESCRIPTION
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

发现imageUpload 的 disabled 不生效。下面是复现该问题的最小示例。设置了了disabled后这个表单项仍然可以进行点击

```vue
<template>
  <Alert message="嵌入表单,加入resultFiled自定义返回值" />
  <BasicForm @register="registerCustom" class="my-5" />
</template>

<script setup lang="ts">
  import { Alert } from 'ant-design-vue';
  import { BasicForm, FormSchema, useForm } from '@/components/Form';
  const schemasCustom: FormSchema[] = [
    {
      field: 'field4',
      component: 'ImageUpload',
      label: '字段4(ImageUpload)',
      colProps: {
        span: 8,
      },
      componentProps: {
        disabled:true,
        api: (file, progress) => {
          return new Promise((resolve) => {
            resolve({  
            });
          });
        },
      },
    },
  ];
  const [registerCustom] = useForm({
    labelWidth: 160,
    schemas: schemasCustom,
   
  });
</script>


```

