### PR TITLE
fix(upload): 显式绑定删除功能的key

### DIFF
--- a/src/components/Upload/src/components/data.tsx
+++ b/src/components/Upload/src/components/data.tsx
@@ -81,7 +81,7 @@ export function createActionColumn(handleRemove: Function): FileBasicColumn {
         {
           label: t('component.upload.del'),
           color: 'error',
-          onClick: handleRemove.bind(null, record),
+          onClick: handleRemove.bind(null, record, "url"),
         },
       ];
       return <TableAction actions={actions} outside={true} />;
@@ -125,7 +125,7 @@ export function createPreviewActionColumn({
         {
           label: t('component.upload.del'),
           color: 'error',
-          onClick: handleRemove.bind(null, record),
+          onClick: handleRemove.bind(null, record, "url"),
         },
         {
           label: t('component.upload.download'),


### PR DESCRIPTION
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

https://github.com/vbenjs/vue-vben-admin/blob/e69dd1e223a2e817805739f11823092992d14ae1/src/components/Upload/src/components/UploadPreviewModal.vue#L82-L84

handleRemove的第二个参数在某些情况会变成 `mouseEvent` ,导致默认情况中不能正确进行删除

fix https://github.com/vbenjs/vue-vben-admin/issues/3867
