### PR TITLE
feat(form): add valueFormat for schema

### DIFF
--- a/src/components/Form/src/BasicForm.vue
+++ b/src/components/Form/src/BasicForm.vue
@@ -64,6 +64,7 @@
   import { useDesign } from '@/hooks/web/useDesign';
   import { cloneDeep } from 'lodash-es';
   import { TableActionType } from '@/components/Table';
+  import { isFunction } from '@/utils/is';
 
   defineOptions({ name: 'BasicForm' });
 
@@ -130,6 +131,9 @@
         component,
         componentProps = {},
         isHandleDateDefaultValue = true,
+        field,
+        isHandleDefaultValue = true,
+        valueFormat,
       } = schema;
       // handle date type
       if (
@@ -160,6 +164,21 @@
           });
           schema.defaultValue = def;
         }
+      }
+
+      // handle schema.valueFormat
+      if (
+        isHandleDefaultValue &&
+        defaultValue &&
+        component &&
+        isFunction(valueFormat)
+      ) {
+        schema.defaultValue = valueFormat({
+          value: defaultValue,
+          schema,
+          model: formModel,
+          field,
+        });
       }
     }
     if (unref(getProps).showAdvancedButton) {

--- a/src/components/Form/src/components/FormItem.vue
+++ b/src/components/Form/src/components/FormItem.vue
@@ -277,6 +277,7 @@
           field,
           changeEvent = 'change',
           valueField,
+          valueFormat,
         } = props.schema;
 
         const isCheck = component && ['Switch', 'Checkbox'].includes(component);
@@ -286,9 +287,12 @@
         const on = {
           [eventKey]: (...args: Nullable<Recordable<any>>[]) => {
             const [e] = args;
-
+            
             const target = e ? e.target : null;
-            const value = target ? (isCheck ? target.checked : target.value) : e;
+            let value = target ? (isCheck ? target.checked : target.value) : e;
+            if(isFunction(valueFormat)){
+              value = valueFormat({...unref(getValues),value});
+            }
             props.setFormModel(field, value, props.schema);
 
             if (propsData[eventKey]) {

--- a/src/components/Form/src/types/form.ts
+++ b/src/components/Form/src/types/form.ts
@@ -197,6 +197,9 @@ interface BaseFormSchema<T extends ComponentType = any> {
   // 是否自动处理与时间相关组件的默认值
   isHandleDateDefaultValue?: boolean;
 
+  // 是否使用valueFormat自动处理默认值
+  isHandleDefaultValue?: boolean;
+
   isAdvanced?: boolean;
 
   // Matching details components
@@ -232,6 +235,8 @@ interface BaseFormSchema<T extends ComponentType = any> {
   dynamicReadonly?: boolean | ((renderCallbackParams: RenderCallbackParams) => boolean);
 
   dynamicRules?: (renderCallbackParams: RenderCallbackParams) => Rule[];
+
+  valueFormat?: (arg: Partial<RenderCallbackParams> & { value: any }) => any;
 }
 export interface ComponentFormSchema<T extends ComponentType = any> extends BaseFormSchema<T> {
   // render component


### PR DESCRIPTION
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

添加 valueFormat方法 和 isHandleDefaultValue 属性(用来判断valueFormat是否对默认值生效)

例如下面例子，在upload组件的 field1中绑定的值只能是 string[] 格式的值。假如数据格式要求是要string格式的值，那么需要做额外的处理。现在可以通过 valueFormat这个方法，直接把field1 变成string格式的 


```vue
<template>
  <Alert message="新功能测试" />
  <BasicForm @register="registerValiate" class="my-5" />
</template>

<script setup lang="ts">
  import { Alert } from 'ant-design-vue';
  import { BasicForm, FormSchema, useForm } from '@/components/Form';
  import { useMessage } from '@/hooks/web/useMessage';
  import { uploadApi } from '@/api/sys/upload';

  const { createMessage } = useMessage();

  const schemasValiate: FormSchema[] = [
    {
      field: 'field1',
      component: 'ImageUpload',
      label: '字段1',
      defaultValue:["https://avatars.githubusercontent.com/u/1"],
      componentProps: {
        api: uploadApi,
        maxNumber:1
      },
      valueFormat:({value})=>{
        return value[0]
      },
    }
  ];
  const [registerValiate, { getFieldsValue: getFieldsValueValiate}] = useForm({
    labelWidth: 160,
    schemas: schemasValiate,
    actionColOptions: {
      span: 18,
    },
    submitFunc: () => {
      return new Promise((resolve) => {
        resolve();
        console.log(getFieldsValueValiate());
        createMessage.success(`请到控制台查看结果`);
      });
    },
  });
</script>


```


