### PR TITLE
fix: The projectSettings default dark mode is not taking effect in version 2

### DIFF
--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -16,6 +16,7 @@ import { Persistent } from '@/utils/cache/persistent';
 import { darkMode } from '@/settings/designSetting';
 import { resetRouter } from '@/router';
 import { deepMerge } from '@/utils';
+import setting from '@/settings/projectSetting';
 
 interface AppState {
   darkMode?: ThemeEnum;
@@ -40,7 +41,12 @@ export const useAppStore = defineStore({
       return state.pageLoading;
     },
     getDarkMode(state): 'light' | 'dark' | string {
-      return state.darkMode || localStorage.getItem(APP_DARK_MODE_KEY) || darkMode;
+      return (
+        state.darkMode ||
+        localStorage.getItem(APP_DARK_MODE_KEY) ||
+        setting.menuSetting.theme ||
+        darkMode
+      );
     },
 
     getBeforeMiniInfo(state): BeforeMiniState {


### PR DESCRIPTION
## Description

The projectSettings default dark mode is not taking effect. In the getDarkMode function, setting.menuSetting.theme should be present and must be higher priority than darkMode.

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
