### PR TITLE
fix: activePath not working in menu, fixed: #4112

### DIFF
--- a/packages/effects/layouts/src/basic/menu/extra-menu.vue
+++ b/packages/effects/layouts/src/basic/menu/extra-menu.vue
@@ -30,7 +30,7 @@ async function handleSelect(key: string) {
   <Menu
     :accordion="accordion"
     :collapse="collapse"
-    :default-active="route.path"
+    :default-active="route.meta?.activePath || route.path"
     :menus="menus"
     :rounded="rounded"
     :theme="theme"

--- a/packages/effects/layouts/src/basic/menu/use-extra-menu.ts
+++ b/packages/effects/layouts/src/basic/menu/use-extra-menu.ts
@@ -81,7 +81,7 @@ function useExtraMenu() {
   watch(
     () => route.path,
     (path) => {
-      const currentPath = path;
+      const currentPath = route.meta?.activePath || path;
       // if (preferences.sidebar.expandOnHover) {
       //   return;
       // }

--- a/packages/effects/layouts/src/basic/menu/use-mixed-menu.ts
+++ b/packages/effects/layouts/src/basic/menu/use-mixed-menu.ts
@@ -113,7 +113,7 @@ function useMixedMenu() {
 
   // 初始化计算侧边菜单
   onBeforeMount(() => {
-    calcSideMenus();
+    calcSideMenus(route.meta?.activePath || route.path);
   });
 
   return {


### PR DESCRIPTION
## Description

修复路由元数据中的activePath不起作用的问题。

该问题导致切换到使用了hideInMenu的路由时，混合菜单和和双列菜单会出现空白的现象。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the logic for determining the active menu item, making navigation more intuitive based on the current route context.
	- Enhanced the responsiveness of the menu to reflect the active path accurately upon route changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->