### PR TITLE
fix: missing route data in guard, fixed: #4108

### DIFF
--- a/apps/web-antd/src/router/guard.ts
+++ b/apps/web-antd/src/router/guard.ts
@@ -115,10 +115,10 @@ function setupAccessGuard(router: Router) {
     // 保存菜单信息和路由信息
     accessStore.setAccessMenus(accessibleMenus);
     accessStore.setAccessRoutes(accessibleRoutes);
-    const redirectPath = (from.query.redirect ?? to.path) as string;
+    const redirectPath = (from.query.redirect ?? to.fullPath) as string;
 
     return {
-      path: decodeURIComponent(redirectPath),
+      ...router.resolve(decodeURIComponent(redirectPath)),
       replace: true,
     };
   });


### PR DESCRIPTION
## Description

此PR解决以下BUG：

直接在浏览器地址栏输入带query的链接来访问，打开页面时query参数会丢失。如：https://www.vben.pro/#/demos/nested/menu1?id=123
未登录状态访问此链接会转到登录页面，登录成功后重定向时会丢失id=123
已登录状态下访问此链接会被直接重定向到不带query参数的地址

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved navigation accuracy by updating the redirection logic in the access guard, ensuring full path context for route transitions.
  
- **Bug Fixes**
	- Enhanced routing behavior to correctly handle redirects with query parameters, resulting in a more seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->