### PR TITLE
fix: missing route data in guard of web-ele and web-naive, fixed: #41…

### DIFF
--- a/apps/web-ele/src/router/guard.ts
+++ b/apps/web-ele/src/router/guard.ts
@@ -115,10 +115,10 @@ function setupAccessGuard(router: Router) {
     // 保存菜单信息和路由信息
     accessStore.setAccessMenus(accessibleMenus);
     accessStore.setAccessRoutes(accessibleRoutes);
-    const redirectPath = (from.query.redirect ?? to.path) as string;
+    const redirectPath = (from.query.redirect ?? to.fullPath) as string;
 
     return {
-      path: decodeURIComponent(redirectPath),
+      ...router.resolve(decodeURIComponent(redirectPath)),
       replace: true,
     };
   });

--- a/apps/web-naive/src/router/guard.ts
+++ b/apps/web-naive/src/router/guard.ts
@@ -115,10 +115,10 @@ function setupAccessGuard(router: Router) {
     // 保存菜单信息和路由信息
     accessStore.setAccessMenus(accessibleMenus);
     accessStore.setAccessRoutes(accessibleRoutes);
-    const redirectPath = (from.query.redirect ?? to.path) as string;
+    const redirectPath = (from.query.redirect ?? to.fullPath) as string;
 
     return {
-      path: decodeURIComponent(redirectPath),
+      ...router.resolve(decodeURIComponent(redirectPath)),
       replace: true,
     };
   });


### PR DESCRIPTION
…08 (#4115)

## Description

此PR解决以下web-ele和web-naive的BUG：

直接在浏览器地址栏输入带query的链接来访问，打开页面时query参数会丢失。如：https://www.vben.pro/#/demos/nested/menu1?id=123
未登录状态访问此链接会转到登录页面，登录成功后重定向时会丢失id=123
已登录状态下访问此链接会被直接重定向到不带query参数的地址

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved navigation experience by ensuring that redirections now include full paths with query parameters.
- **Bug Fixes**
  - Enhanced routing logic to better preserve user context during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->