### PR TITLE
fix:修复showAdvancedButton为true时，FormSchema中ifshow是与model有关的函数时候，查询按钮位置…

### DIFF
--- a/src/components/Form/src/BasicForm.vue
+++ b/src/components/Form/src/BasicForm.vue
@@ -124,7 +124,9 @@
   const getBindValue = computed(() => ({ ...attrs, ...props, ...unref(getProps) }) as AntFormProps);
 
   const getSchema = computed((): FormSchema[] => {
-    const schemas: FormSchema[] = cloneDeep(unref(schemaRef) || (unref(getProps).schemas as any));
+    const schemas: (FormSchema & { ifshow2?: boolean })[] = cloneDeep(
+      unref(schemaRef) || (unref(getProps).schemas as any),
+    );
     for (const schema of schemas) {
       const {
         defaultValue,
@@ -134,7 +136,16 @@
         field,
         isHandleDefaultValue = true,
         valueFormat,
+        ifShow,
       } = schema;
+
+      //fix:修复showAdvancedButton为true时，FormSchema中ifshow是与model有关的函数时候，查询按钮位置不重新计算的问题。
+      if (unref(getProps).showAdvancedButton) {
+        schema.ifshow2 = isFunction(ifShow)
+          ? ifShow({ schema, values: formModel, model: formModel, field })
+          : ifShow;
+      }
+
       // handle date type
       if (
         isHandleDateDefaultValue &&

--- a/src/components/Form/src/hooks/useAdvanced.ts
+++ b/src/components/Form/src/hooks/useAdvanced.ts
@@ -1,6 +1,15 @@
 import type { ColEx } from '../types';
 import type { AdvanceState } from '../types/hooks';
-import { ComputedRef, getCurrentInstance, Ref, shallowReactive, computed, unref, watch } from 'vue';
+import {
+  ComputedRef,
+  getCurrentInstance,
+  Ref,
+  shallowReactive,
+  computed,
+  unref,
+  watch,
+  nextTick,
+} from 'vue';
 import type { FormProps, FormSchemaInner as FormSchema } from '../types/form';
 import { isBoolean, isFunction, isNumber, isObject } from '@/utils/is';
 import { useBreakpoint } from '@/hooks/event/useBreakpoint';
@@ -49,14 +58,17 @@ export default function ({
     return 0;
   });
 
-  const debounceUpdateAdvanced = useDebounceFn(updateAdvanced, 30);
+  // const debounceUpdateAdvanced = useDebounceFn(updateAdvanced, 30);
 
   watch(
     [() => unref(getSchema), () => advanceState.isAdvanced, () => unref(realWidthRef)],
     () => {
       const { showAdvancedButton } = unref(getProps);
       if (showAdvancedButton) {
-        debounceUpdateAdvanced();
+        // debounceUpdateAdvanced();
+        nextTick(() => {
+          updateAdvanced();
+        });
       }
     },
     { immediate: true },


### PR DESCRIPTION
修复showAdvancedButton为true时，FormSchema中ifshow是与model有关的函数时候，查询按钮位置

## Description

![image](https://github.com/user-attachments/assets/0d2aebdf-93d4-4773-813d-5df2024c320b)

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.