### PR TITLE
fix: update fetch URL to use BASE_URL for version tag retrieval

### DIFF
--- a/packages/effects/layouts/src/widgets/check-updates/check-updates.vue
+++ b/packages/effects/layouts/src/widgets/check-updates/check-updates.vue
@@ -7,12 +7,15 @@ import { ToastAction, useToast } from '@vben-core/shadcn-ui';
 interface Props {
   // 轮训时间，分钟
   checkUpdatesInterval?: number;
+  // 检查更新的地址
+  checkUpdateUrl?: string;
 }
 
 defineOptions({ name: 'CheckUpdates' });
 
 const props = withDefaults(defineProps<Props>(), {
   checkUpdatesInterval: 1,
+  checkUpdateUrl: import.meta.env.BASE_URL || '/',
 });
 
 const lastVersionTag = ref('');
@@ -28,7 +31,7 @@ async function getVersionTag() {
     ) {
       return null;
     }
-    const response = await fetch(import.meta.env.BASE_URL, {
+    const response = await fetch(props.checkUpdateUrl, {
       cache: 'no-cache',
       method: 'HEAD',
     });

--- a/packages/effects/layouts/src/widgets/check-updates/check-updates.vue
+++ b/packages/effects/layouts/src/widgets/check-updates/check-updates.vue
@@ -28,7 +28,7 @@ async function getVersionTag() {
     ) {
       return null;
     }
-    const response = await fetch('/', {
+    const response = await fetch(import.meta.env.BASE_URL, {
       cache: 'no-cache',
       method: 'HEAD',
     });


### PR DESCRIPTION
## Description

修复检测更新在二级路径下下无效问题，比如我发布在 http://abc.com/test 下面，现在检测是根路径，导致无法正常提示更新

## Type of change

- [-] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [-] Run the tests with `pnpm test`.
- [-] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [-] My code follows the style guidelines of this project
- [-] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the update check functionality by introducing an optional `checkUpdateUrl` property, allowing for a configurable URL for checking updates, improving deployment flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->