### PR TITLE
fix: improve layout boundary issues

### DIFF
--- a/packages/effects/layouts/src/basic/layout.vue
+++ b/packages/effects/layouts/src/basic/layout.vue
@@ -143,6 +143,19 @@ watch(
   },
 );
 
+watch(
+  () => preferences.app.layout,
+  async (val) => {
+    if (val === 'sidebar-mixed-nav' && preferences.sidebar.hidden) {
+      updatePreferences({
+        sidebar: {
+          hidden: false,
+        },
+      });
+    }
+  },
+);
+
 const slots = useSlots();
 const headerSlots = computed(() => {
   return Object.keys(slots).filter((key) => key.startsWith('header-'));


### PR DESCRIPTION


## Description
主题sidebar-nav 布局 隐藏 菜单后   --> 切换为 sidebar-mixed-nav 布局 找不到主菜单 & Header 宽度计算 空白问题

## Type of change

Please delete options that are not relevant.

-  Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new watcher that automatically adjusts sidebar visibility based on layout preferences, ensuring the sidebar is displayed when using the 'sidebar-mixed-nav' layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->