### PR TITLE
fix: modified fixed and unfixed logic, fixed #4640

### DIFF
--- a/packages/stores/src/modules/tabbar.ts
+++ b/packages/stores/src/modules/tabbar.ts
@@ -311,15 +311,15 @@ export const useTabbarStore = defineStore('core-tabbar', {
         tab.meta.title = oldTab?.meta?.title as string;
         // this.addTab(tab);
         this.tabs.splice(index, 1, tab);
-        // 过滤固定tabs，后面更改affixTabOrder的值的话可能会有问题，目前行464排序affixTabs没有设置值
-        const affixTabs = this.tabs.filter((tab) => isAffixTab(tab));
-        // 获得固定tabs的index
-        const newIndex = affixTabs.findIndex(
-          (item) => getTabPath(item) === getTabPath(tab),
-        );
-        // 交换位置重新排序
-        await this.sortTabs(index, newIndex);
       }
+      // 过滤固定tabs，后面更改affixTabOrder的值的话可能会有问题，目前行464排序affixTabs没有设置值
+      const affixTabs = this.tabs.filter((tab) => isAffixTab(tab));
+      // 获得固定tabs的index
+      const newIndex = affixTabs.findIndex(
+        (item) => getTabPath(item) === getTabPath(tab),
+      );
+      // 交换位置重新排序
+      await this.sortTabs(index, newIndex);
     },
 
     /**

--- a/packages/stores/src/modules/tabbar.ts
+++ b/packages/stores/src/modules/tabbar.ts
@@ -311,6 +311,14 @@ export const useTabbarStore = defineStore('core-tabbar', {
         tab.meta.title = oldTab?.meta?.title as string;
         // this.addTab(tab);
         this.tabs.splice(index, 1, tab);
+        // 过滤固定tabs，后面更改affixTabOrder的值的话可能会有问题，目前行464排序affixTabs没有设置值
+        const affixTabs = this.tabs.filter((tab) => isAffixTab(tab));
+        // 获得固定tabs的index
+        const newIndex = affixTabs.findIndex(
+          (item) => getTabPath(item) === getTabPath(tab),
+        );
+        // 交换位置重新排序
+        await this.sortTabs(index, newIndex);
       }
     },
 
@@ -419,6 +427,12 @@ export const useTabbarStore = defineStore('core-tabbar', {
         // this.addTab(tab);
         this.tabs.splice(index, 1, tab);
       }
+      // 过滤固定tabs，后面更改affixTabOrder的值的话可能会有问题，目前行464排序affixTabs没有设置值
+      const affixTabs = this.tabs.filter((tab) => isAffixTab(tab));
+      // 获得固定tabs的index,使用固定tabs的下一个位置也就是活动tabs的第一个位置
+      const newIndex = affixTabs.length;
+      // 交换位置重新排序
+      await this.sortTabs(index, newIndex);
     },
 
     /**


### PR DESCRIPTION
## Description
标签页关闭逻辑修复，固定了一个标签页后关闭左右页签会发生关闭不了应该关闭的左右标签，取消固定标签会跳回原来位置，现在逻辑修复为跳回活动标签第一个，逻辑仿照谷歌浏览器。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved tab management with enhanced sorting for pinned tabs when they are pinned or unpinned.
	- Added functionality to reorder tabs dynamically based on user actions.

These updates provide a more intuitive experience for users managing their tabs, ensuring a seamless organization of pinned content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->