### PR TITLE
fix: fix renderEcharts refresh issue

### DIFF
--- a/packages/effects/plugins/src/echarts/use-echarts.ts
+++ b/packages/effects/plugins/src/echarts/use-echarts.ts
@@ -31,12 +31,11 @@ function useEcharts(chartRef: Ref<EchartsUIType>) {
 
   const getOptions = computed((): EChartsOption => {
     if (!isDark.value) {
-      return cacheOptions;
+      return {};
     }
 
     return {
       backgroundColor: 'transparent',
-      ...cacheOptions,
     };
   });
 
@@ -52,10 +51,14 @@ function useEcharts(chartRef: Ref<EchartsUIType>) {
 
   const renderEcharts = (options: EChartsOption, clear = true) => {
     cacheOptions = options;
+    const currentOptions = {
+      ...options,
+      ...getOptions.value,
+    };
     return new Promise((resolve) => {
       if (chartRef.value?.offsetHeight === 0) {
         useTimeoutFn(() => {
-          renderEcharts(getOptions.value);
+          renderEcharts(currentOptions);
           resolve(null);
         }, 30);
         return;
@@ -67,7 +70,7 @@ function useEcharts(chartRef: Ref<EchartsUIType>) {
             if (!instance) return;
           }
           clear && chartInstance?.clear();
-          chartInstance?.setOption(getOptions.value);
+          chartInstance?.setOption(currentOptions);
           resolve(null);
         }, 30);
       });


### PR DESCRIPTION
## Description

使用renderEcharts对同一图表在更新数据后重新渲染，实际图表并未发送变化。
原因: renderEcharts里getOptions.value值依旧是第一次渲染的值


<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved chart options management for better rendering performance.
	- Enhanced responsiveness to theme changes and window resizing.

- **Bug Fixes**
	- Resolved issues with chart state management and initialization.

- **Documentation**
	- Updated function signatures and export statements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->