### PR TITLE
docs(@vben/docs): add public static resources path documentation (#4788)

### DIFF
--- a/docs/src/en/guide/essentials/development.md
+++ b/docs/src/en/guide/essentials/development.md
@@ -150,6 +150,12 @@ To run the `docs` application:
 pnpm dev:docs
 ```
 
+## Public Static Resources
+
+If you need to use public static resources in the project, such as images, static HTML, etc., and you want to directly import them in the development process through `src="/xxx.png"`.
+
+You need to put the resource in the corresponding project's `public/static` directory. The import path for the resource should be `src="/static/xxx.png"`.
+
 ## DevTools
 
 The project has a built-in [Vue DevTools](https://github.com/vuejs/devtools-next) plugin, which can be used during development. It is disabled by default, but can be enabled in the `.env.development` file. After enabling it, restart the project:

--- a/docs/src/guide/essentials/development.md
+++ b/docs/src/guide/essentials/development.md
@@ -150,6 +150,12 @@ pnpm dev:ele
 pnpm dev:docs
 ```
 
+## 公共静态资源
+
+项目中需要使用到的公共静态资源，如：图片、静态HTML等，需要在开发中通过 `src="/xxx.png"` 直接引入的。
+
+需要将资源放在对应项目的 `public/static` 目录下。引入的路径为：`src="/static/xxx.png"`。
+
 ## DevTools
 
 项目内置了 [Vue DevTools](https://github.com/vuejs/devtools-next) 插件，可以在开发过程中使用。默认关闭，可在`.env.development` 内开启，并重新运行项目即可：


### PR DESCRIPTION
## Description

I need to use public static resources in my project, like `pdf.js`. I couldn't find any documentation specifying which directory I should place them in.  So I just placed them under `public/`, but that was the wrong path.

After reading the issue, I discovered why: due to`vite-plugin-html`, you should place your public static resources under `public/static/ `, and then reference them using `src="/static/xxx.png"`.

I believe this should be documented.

## Type of change

Please delete options that are not relevant.

- [ ] This change requires a documentation update

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section on "Public Static Resources" to guide users on using images and static HTML files in the project.
	- Reorganized existing content for improved clarity without altering the overall structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->