### PR TITLE
feat: add fieldMapToTime prop to FormRenderProps

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/types.ts
+++ b/packages/@core/ui-kit/form-ui/src/types.ts
@@ -205,6 +205,12 @@ export type HandleResetFn = (
   values: Record<string, any>,
 ) => Promise<void> | void;
 
+export type FieldMapToTime = [
+  string,
+  [string, string],
+  ([string, string] | string)?,
+][];
+
 export interface FormSchema<
   T extends BaseFormComponentType = BaseFormComponentType,
 > extends FormCommonConfig {
@@ -265,6 +271,10 @@ export interface FormRenderProps<
    * 组件集合
    */
   componentMap: Record<BaseFormComponentType, Component>;
+  /**
+   * 表单字段映射成时间格式
+   */
+  fieldMapToTime?: FieldMapToTime;
   /**
    * 表单实例
    */

--- a/playground/src/views/examples/vxe-table/form.vue
+++ b/playground/src/views/examples/vxe-table/form.vue
@@ -21,6 +21,7 @@ interface RowType {
 const formOptions: VbenFormProps = {
   // 默认展开
   collapsed: false,
+  fieldMapToTime: [['dateRangePicker', ['startTime', 'endTime'], 'YYYY-MM']],
   schema: [
     {
       component: 'Input',
@@ -61,6 +62,11 @@ const formOptions: VbenFormProps = {
       component: 'DatePicker',
       fieldName: 'datePicker',
       label: 'Date',
+    },
+    {
+      component: 'RangePicker',
+      fieldName: 'dateRangePicker',
+      label: 'DateRange',
     },
   ],
   // 控制表单是否显示折叠按钮


### PR DESCRIPTION
## Description

feat: add fieldMapToTime prop to FormRenderProps

fix: #4642  Form表单添加fieldMapToTime格式化时间范围字段

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form submission and reset functionalities with improved handling of time-related fields.
	- Introduced a new `RangePicker` component for selecting date ranges in forms.
	- Added a mapping capability for form fields to time formats.

- **Type Definitions**
	- New type `FieldMapToTime` added to support mapping form fields to time formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->