### PR TITLE
fix(@vben/common-ui): pagination current page error

### DIFF
--- a/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
+++ b/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
@@ -41,6 +41,7 @@ const emit = defineEmits<{
 const refTrigger = useTemplateRef<HTMLElement>('refTrigger');
 const currentSelect = ref('');
 const currentList = ref(props.icons);
+const currentPage = ref(1);
 
 watch(
   () => props.icons,
@@ -72,6 +73,7 @@ const handleClick = (icon: string) => {
 };
 
 const handlePageChange = (page: number) => {
+  currentPage.value = page;
   setCurrentPage(page);
 };
 
@@ -114,7 +116,6 @@ defineExpose({ changeOpenState });
         class="flex-center flex justify-end overflow-hidden border-t py-2 pr-3"
       >
         <Pagination
-          v-slot="{ page }"
           :items-per-page="36"
           :sibling-count="1"
           :total="total"
@@ -136,7 +137,7 @@ defineExpose({ changeOpenState });
                 as-child
               >
                 <Button
-                  :variant="item.value === page ? 'default' : 'outline'"
+                  :variant="item.value === currentPage ? 'default' : 'outline'"
                   class="size-5 p-0 text-sm"
                 >
                   {{ item.value }}


### PR DESCRIPTION
icon-picker组件操作过翻页之后，并且选择了一个icon，再次打开选择时，当前页显示是1 ，但实际页面是之前选择过的icon页。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced pagination functionality in the icon picker component, allowing users to navigate through icons more efficiently.
	- The current page state is now clearly indicated, enhancing user experience.

- **Bug Fixes**
	- Improved clarity in the representation of the current page in the pagination controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->