### PR TITLE
fix: form-api.setValues can't resolve nested fields

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-api.ts
+++ b/packages/@core/ui-kit/form-ui/src/form-api.ts
@@ -13,12 +13,12 @@ import { toRaw } from 'vue';
 import { Store } from '@vben-core/shared/store';
 import {
   bindMethods,
+  createMerge,
   isFunction,
+  isObject,
   mergeWithArrayOverride,
   StateHandler,
 } from '@vben-core/shared/utils';
-
-import { objectPick } from '@vueuse/core';
 
 function getDefaultState(): VbenFormProps {
   return {
@@ -250,8 +250,17 @@ export class FormApi {
       form.setValues(fields, shouldValidate);
       return;
     }
-    const fieldNames = this.state?.schema?.map((item) => item.fieldName) ?? [];
-    const filteredFields = objectPick(fields, fieldNames);
+
+    const fieldMergeFn = createMerge((obj, key, value) => {
+      if (key in obj) {
+        obj[key] =
+          !Array.isArray(obj[key]) && isObject(obj[key])
+            ? fieldMergeFn(obj[key], value)
+            : value;
+      }
+      return true;
+    });
+    const filteredFields = fieldMergeFn(fields, form.values);
     form.setValues(filteredFields, shouldValidate);
   }
 


### PR DESCRIPTION
fix #4912

## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

### Bug Desc

1. In add page, create a form with this schemas for test object:
```json
[
  {
    "fieldName": "a",
    ...
  },
  {
    "fieldName": "b.c",
    ...
  },
  {
    "fieldName": "b.d",
    ...
  },
  {
    "fieldName": "e[0]",
    ...
  },
  {
    "fieldName": "f.g.h.i",
    ...
  },
  {
    "fieldName": "j[0][0]",
    ...
  }
]
```

2. submit and call create function to create a test object in backend
3. In edit page, get the test object by backend api and use form-api.setValues for the form with the same schemas
4. I can't get all nested fields' value now, like b, e, f, j

### Fix Code

use new merge func replace objectPick

```javascript
// package/@core/ui-kit/form-ui/src/form-api.ts
// add new import
import { createMerge, isObject } from '@vben-core/shared/utils';


// fix FormApi.setValues func
  async setValues(
    fields: Record<string, any>,
    filterFields: boolean = true,
    shouldValidate: boolean = false,
  ) {
    const form = await this.getForm();
    if (!filterFields) {
      form.setValues(fields, shouldValidate);
      return;
    }

    // use defu's createDefu create a merge function
    const fieldMergeFn = createMerge((obj, key, value) => {
      if (key in obj) {
        obj[key] =
          !Array.isArray(obj[key]) && isObject(obj[key])
            ? fieldMergeFn(obj[key], value)
            : value;
      }
      return true;
    });
    const filteredFields = fieldMergeFn(fields, form.values);
    form.setValues(filteredFields, shouldValidate);
  }
```

### Test Case

1. I create a form use `useForm` and write schema option like Bug Desc;
2. Input these fields and get value by call FormApis.getValues;
3. Use the value as `fields` params call FormApis.setValues;
4. All fields can be fill in now;

### Reference
1. [VeeValidate Doc: Nested Objects and Arrays](https://vee-validate.logaretm.com/v4/guide/composition-api/nested-objects-and-arrays#nested-objects)
5. [defu github page: Custom Merger](https://github.com/unjs/defu?tab=readme-ov-file#custom-merger)

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
 