### PR TITLE
fix: the route path did not synchronize with the page

### DIFF
--- a/playground/src/router/routes/modules/demos.ts
+++ b/playground/src/router/routes/modules/demos.ts
@@ -157,6 +157,18 @@ const routes: RouteRecordRaw[] = [
             },
             children: [
               {
+                name: 'HideChildrenInMenuDemo',
+                path: '',
+                component: () =>
+                  import(
+                    '#/views/demos/features/hide-menu-children/children.vue'
+                  ),
+                meta: {
+                  hideInMenu: true,
+                  title: $t('demos.features.hideChildrenInMenu'),
+                },
+              },
+              {
                 name: 'HideChildrenInMenuChildrenDemo',
                 path: '/demos/features/hide-menu-children/children',
                 component: () =>


### PR DESCRIPTION
## Description

fix: the route path did not synchronize with the page. 
close #4919 

修复多级路由隐藏子菜单， 但是路径与页面不匹配的问题。
修复方式：在子路由中提供一个隐藏的空的嵌套路径以匹配父路由的实际路径。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new nested route, `HideChildrenInMenuDemo`, under the `HideChildrenInMenuParentDemo`, which is hidden in the menu for a cleaner navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->