### PR TITLE
ElementPlus date range系列都会报错

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
@@ -247,7 +247,16 @@ function createComponentProps(slotProps: Record<string, any>) {
       ? { onInput: computedProps.value.onInput }
       : {}),
   };
-
+  /**
+   * FormController会透传id binds会传name到组件
+   * id name传到element-plus 的 daterange datetimerange timerange等等
+   * 会报错 Invalid prop: type check failed for prop "name". Expected Array, got String with value
+   * 临时解决 如果作者有更好的修复方案 麻烦告知我下 sd-hxf@qq.com
+   */
+  if (binds.type?.indexOf('range') > -1) {
+    binds.name = [];
+    binds.id = [];
+  }
   return binds;
 }
 


### PR DESCRIPTION
ElementPlus date range系列都会报错    比如 <el-date-picker  id="v-11-item" name="sex" /> 会报错的 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Implemented a temporary fix for handling `name` and `id` properties in range-type components to prevent type check errors.
	- Addressed an issue with Element Plus date range components related to prop type expectations. 

- **Documentation**
	- Added comments to clarify the context of the temporary solution and invite suggestions for improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->