### PR TITLE
fix: NaiveUI的NRadioGroup组件支持options写法

### DIFF
--- a/apps/web-naive/src/adapter/component/index.ts
+++ b/apps/web-naive/src/adapter/component/index.ts
@@ -19,6 +19,7 @@ import {
   NDivider,
   NInput,
   NInputNumber,
+  NRadio,
   NRadioGroup,
   NSelect,
   NSpace,
@@ -29,6 +30,18 @@ import {
 } from 'naive-ui';
 
 import { message } from '#/adapter/naive';
+
+const customNRadioGroupRender = <T extends Component>(component: T) => {
+  return (props: any, { attrs }: Omit<SetupContext, 'expose'>) => {
+    const placeholder = '';
+    const options = props.options;
+    return h(component, { ...props, ...attrs, placeholder }, () => {
+      return options?.map((option: any) =>
+        h(NRadio, { label: option.label, value: option.value }),
+      );
+    });
+  };
+};
 
 const withDefaultPlaceholder = <T extends Component>(
   component: T,
@@ -77,7 +90,7 @@ async function initComponentAdapter() {
     Divider: NDivider,
     Input: withDefaultPlaceholder(NInput, 'input'),
     InputNumber: withDefaultPlaceholder(NInputNumber, 'input'),
-    RadioGroup: NRadioGroup,
+    RadioGroup: customNRadioGroupRender(NRadioGroup),
     Select: withDefaultPlaceholder(NSelect, 'select'),
     Space: NSpace,
     Switch: NSwitch,


### PR DESCRIPTION
# 问题
- 想通过类似ant的写法去写naive的功能，发现NaiveUI的NRadioGroup组件支持options写法
```ts
export const addRoleFormSchema: any = [
  {
    component: 'RadioGroup',
    componentProps: {
      options: [
        {
          label: $t('common.yes'),
          value: 1,
        },
        {
          label: $t('common.no'),
          value: 0,
        },
      ],
    },
    defaultValue: 0,
    fieldName: 'isDefault',
    label: $t('abp.role.isDefault'),
    rules: 'required',
  },
];
```

# 解决
在适配器适配该组件。customNRadioGroupRender

# 未修复之前效果
![QQ_1733279667149](https://github.com/user-attachments/assets/67295418-ed0e-4330-8b26-2ba9793314a5)

# 修复之后的效果
![image](https://github.com/user-attachments/assets/6e8498ea-33ee-4e43-92aa-35c2e8608c0f)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering of radio group components with a customizable function for improved user experience.
	- Updated radio group integration to utilize the new rendering logic for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->