### PR TITLE
fix: select Long option style problem

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
@@ -298,7 +298,11 @@ function autofocus() {
       >
         {{ label }}
       </FormLabel>
-      <div :class="cn('relative flex w-full items-center', wrapperClass)">
+      <div
+        :class="
+          cn('relative flex w-full items-center overflow-hidden', wrapperClass)
+        "
+      >
         <FormControl :class="cn(controlClass)">
           <slot
             v-bind="{


### PR DESCRIPTION
## Description

处理select 选择长选项导致样式超出的问题  close: #5029 

处理前：
![image](https://github.com/user-attachments/assets/1bac33fe-61ac-4e28-906f-71ef8d6fcc98)

处理后：
![image](https://github.com/user-attachments/assets/4366e346-06b8-43b6-989d-b2be571b8b3d)

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the visual presentation of form fields by updating the template structure and adding a new styling class. 

These changes improve the user experience without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->