### PR TITLE
fix: remove the overlap caused by border-b

### DIFF
--- a/packages/effects/common-ui/src/ui/dashboard/workbench/workbench-project.vue
+++ b/packages/effects/common-ui/src/ui/dashboard/workbench/workbench-project.vue
@@ -38,7 +38,7 @@ defineEmits(['click']);
             'border-b-0': index < 3,
             'pb-4': index > 2,
           }"
-          class="border-border group w-full cursor-pointer border-b border-r border-t p-4 transition-all hover:shadow-xl md:w-1/2 lg:w-1/3"
+          class="border-border group w-full cursor-pointer border-r border-t p-4 transition-all hover:shadow-xl md:w-1/2 lg:w-1/3"
         >
           <div class="flex items-center">
             <VbenIcon

--- a/packages/effects/common-ui/src/ui/dashboard/workbench/workbench-quick-nav.vue
+++ b/packages/effects/common-ui/src/ui/dashboard/workbench/workbench-quick-nav.vue
@@ -38,7 +38,7 @@ defineEmits(['click']);
             'pb-4': index > 2,
             'border-b-0': index < 3,
           }"
-          class="flex-col-center border-border group w-1/3 cursor-pointer border-b border-r border-t py-8 hover:shadow-xl"
+          class="flex-col-center border-border group w-1/3 cursor-pointer border-r border-t py-8 hover:shadow-xl"
           @click="$emit('click', item)"
         >
           <VbenIcon


### PR DESCRIPTION
## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

工作台中的项目以及快捷导航 card 存在双重 border
links: https://www.vben.pro/#/workspace

## Type of change

Please delete options that are not relevant.

- [ ✔️] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated visual styling of project list items by removing unnecessary bottom border.
	- Adjusted quick navigation item styling to enhance visual clarity by removing bottom border for specific items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->