### PR TITLE
fix: change `drawer` and `modal` zIndex to 2000 compatible with element-plus

### DIFF
--- a/docs/src/components/common-ui/vben-drawer.md
+++ b/docs/src/components/common-ui/vben-drawer.md
@@ -100,7 +100,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
 | contentClass | modal内容区域的class | `string` | - |
 | footerClass | modal底部区域的class | `string` | - |
 | headerClass | modal顶部区域的class | `string` | - |
-| zIndex | 抽屉的ZIndex层级 | `number` | `1000` |
+| zIndex | 抽屉的ZIndex层级 | `number` | `2000` |
 
 ::: info appendToMain
 

--- a/docs/src/components/common-ui/vben-modal.md
+++ b/docs/src/components/common-ui/vben-modal.md
@@ -110,7 +110,7 @@ const [Modal, modalApi] = useVbenModal({
 | footerClass | modal底部区域的class | `string` | - |
 | headerClass | modal顶部区域的class | `string` | - |
 | bordered | 是否显示border | `boolean` | `false` |
-| zIndex | 弹窗的ZIndex层级 | `number` | `1000` |
+| zIndex | 弹窗的ZIndex层级 | `number` | `2000` |
 
 ::: info appendToMain
 

--- a/packages/@core/ui-kit/popup-ui/src/drawer/drawer.vue
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/drawer.vue
@@ -36,7 +36,7 @@ const props = withDefaults(defineProps<Props>(), {
   appendToMain: false,
   closeIconPlacement: 'right',
   drawerApi: undefined,
-  zIndex: 1000,
+  zIndex: 2000,
 });
 
 const components = globalShareState.getComponents();

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogContent.vue
@@ -29,7 +29,7 @@ const props = withDefaults(
       zIndex?: number;
     }
   >(),
-  { appendTo: 'body', showClose: true, zIndex: 1000 },
+  { appendTo: 'body', showClose: true, zIndex: 2000 },
 );
 const emits = defineEmits<
   DialogContentEmits & { close: []; closed: []; opened: [] }

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogScrollContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogScrollContent.vue
@@ -16,7 +16,7 @@ import {
 
 const props = withDefaults(
   defineProps<DialogContentProps & { class?: any; zIndex?: number }>(),
-  { zIndex: 1000 },
+  { zIndex: 2000 },
 );
 const emits = defineEmits<DialogContentEmits>();
 

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/sheet/SheetContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/sheet/SheetContent.vue
@@ -27,7 +27,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<SheetContentProps>(), {
   appendTo: 'body',
-  zIndex: 1000,
+  zIndex: 2000,
 });
 
 const emits = defineEmits<


### PR DESCRIPTION
## Description

### Why?

element-plus some pop-up controls have a z-index of 2000, causing some display issues.

https://github.com/search?q=repo%3Aelement-plus%2Felement-plus%20z-index%3A%202000&type=code

### Before

![screenshots](https://github.com/user-attachments/assets/2b0d8060-9032-4b15-ab17-1283e1216f49)

### After

![screenshots](https://github.com/user-attachments/assets/11000857-1dc2-4132-a848-afb0a99124e9)




<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for Vben Drawer and Modal components
	- Updated documentation for Dialog and Sheet components

- **Chores**
	- Modified default `zIndex` from `1000` to `2000` across multiple UI components
	- Ensures consistent layering of UI elements with higher default z-index values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->