### PR TITLE
docs: 对scripts中的包添加使用文档

### DIFF
--- a/packages/effects/plugins/src/echarts/use-echarts.ts
+++ b/packages/effects/plugins/src/echarts/use-echarts.ts
@@ -109,7 +109,7 @@ function useEcharts(chartRef: Ref<EchartsUIType>) {
   return {
     renderEcharts,
     resize,
-    chartInstance
+    chartInstance,
   };
 }
 

--- a/scripts/turbo-run/README.md
+++ b/scripts/turbo-run/README.md
@@ -1,3 +1,7 @@
 # @vben/turbo-run
 
 turbo-run is a command line tool that allows you to run multiple commands in parallel.
+
+提供 `turbo-run` 命令：`turbo-run [目标命令]` `turbo-run dev`
+
+- 获取大仓项目所有的包，并过滤出包含`目标命令`的包，并将所有包放入`@clack/prompts`提供的`select`组件提供给用户选择，选择后运行其对应的命令

--- a/scripts/turbo-run/src/run.ts
+++ b/scripts/turbo-run/src/run.ts
@@ -25,7 +25,7 @@ export async function run(options: RunOptions) {
 
   let selectPkg: string | symbol;
   if (selectPkgs.length > 1) {
-    selectPkg = await select<any, string>({
+    selectPkg = await select<string>({
       message: `Select the app you need to run [${command}]:`,
       options: selectPkgs.map((item) => ({
         label: item?.packageJson.name,

--- a/scripts/vsh/README.md
+++ b/scripts/vsh/README.md
@@ -1,3 +1,21 @@
 # @vben/vsh
 
 shell 脚本工具集合
+
+主要提供了以下命令
+
+- lint
+  - 用于检查代码的格式是否正确，相当于同时执行了：`stylelint` `eslint` `prettier`的代码风格检测
+  - `--format` 参数：会自动修复代码
+- publint
+  - 用于检查项目中的包是否符合 `publint` 规则
+  - `--check` 参数：仅检查错误，不退出程序
+- code-workspace
+  - 用于生成和更新 Visual Studio Code 的 .code-workspace 文件的工具
+  - `--spaces` 参数：生成 `.code-workspace` 文件时指定缩进空格数 `默认: 2`
+  - `--auto-commit`参数： 生成 `.code-workspace` 文件时自动将其添加到Git仓库
+- check-circular
+  - 检测项目中的所有循环依赖，并详细输出结果
+  - `--staged`参数：仅检测暂存区中的文件是否存在循环依赖，并详细输出结果
+- check-dep
+  - 用于检测项目中的未使用依赖和未声明依赖


### PR DESCRIPTION
## Description
包含两个commit，`await select<any, string>` 此处`<any, string>`在编辑器中报错，于是删除了`any`

对scripts中的包添加使用文档

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated `turbo-run` README with detailed command usage and functionality description.
  - Enhanced `vsh` README with new command documentation:
    - Added `lint` command for code formatting.
    - Added `publint` for package rule compliance.
    - Added `code-workspace` for VS Code workspace generation.
    - Added `check-circular` for dependency cycle detection.
    - Added `check-dep` for dependency analysis.

- **Code Improvements**
  - Simplified type signature in `turbo-run` selection function.
  - Enhanced `useEcharts` function to expose `chartInstance` for external access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->