### PR TITLE
fix: renderComponentContent lose slot props data

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
@@ -329,10 +329,14 @@ function autofocus() {
               v-bind="createComponentProps(slotProps)"
               :disabled="shouldDisabled"
             >
-              <template v-for="name in renderContentKey" :key="name" #[name]>
+              <template
+                v-for="name in renderContentKey"
+                :key="name"
+                #[name]="renderSlotProps"
+              >
                 <VbenRenderContent
                   :content="customContentRender[name]"
-                  v-bind="slotProps"
+                  v-bind="{ ...renderSlotProps, $formContext: slotProps }"
                 />
               </template>
               <!-- <slot></slot> -->


### PR DESCRIPTION
## Description

修复表单的renderComponentContent传递插槽时，会丢失插槽数据的问题。
formField渲染自定义组件的内部插槽时，没有正确传递原本的props。

fix #5464

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced form field rendering logic to improve dynamic content integration
	- Updated slot property handling for more flexible content rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->