### PR TITLE
fix: ant tag icon default style

### DIFF
--- a/packages/styles/src/antd/index.css
+++ b/packages/styles/src/antd/index.css
@@ -13,12 +13,22 @@
   }
 
   /* * 修复按钮添加图标时的位置问题 */
-  svg {
+  > svg {
     display: inline-block;
   }
 
-  svg + span {
+  > svg + span {
     margin-inline-start: 6px;
+  }
+}
+
+.ant-tag {
+  > svg {
+    display: inline-block;
+  }
+
+  > svg + span {
+    margin-inline-start: 4px;
   }
 }
 

--- a/playground/src/views/examples/tippy/index.vue
+++ b/playground/src/views/examples/tippy/index.vue
@@ -4,8 +4,9 @@ import type { TippyProps } from '@vben/common-ui';
 import { reactive } from 'vue';
 
 import { Page, Tippy } from '@vben/common-ui';
+import { ChevronDown } from '@vben/icons';
 
-import { Button, Card, Flex } from 'ant-design-vue';
+import { Button, Card, Flex, Tag } from 'ant-design-vue';
 
 import { useVbenForm } from '#/adapter/form';
 
@@ -254,7 +255,7 @@ function goDoc() {
       <p class="mb-4">
         指令形式使用比较简洁，直接在需要展示tooltip的组件上用v-tippy传递配置，适用于固定内容的工具提示。
       </p>
-      <Flex warp="warp" gap="20">
+      <Flex warp="warp" gap="20" align="center">
         <Button v-tippy="'这是一个提示，使用了默认的配置'">默认配置</Button>
 
         <Button
@@ -277,8 +278,18 @@ function goDoc() {
             animation: 'scale',
           }"
         >
+          <template #icon>
+            <ChevronDown class="size-4" />
+          </template>
           指定动画
         </Button>
+        <Tag color="#f50">
+          <template #icon>
+            <ChevronDown class="size-4" />
+          </template>
+
+          默认配置
+        </Tag>
       </Flex>
     </Card>
     <Card title="组件形式使用" class="mt-4">


### PR DESCRIPTION
## Description

修复 Antd 的 Tag 组件图标插槽样式不正确的问题

fix: #5472

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined button and tag styling for more precise visual presentation.
  - Introduced a new tag style with improved spacing for icons and text.

- **New Features**
  - Integrated the ChevronDown icon into button and tag elements.
  - Enhanced layout alignment in tooltip examples, offering a cleaner, more balanced interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->