### PR TITLE
feat: 保存表单字段的blur状态

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-api.ts
+++ b/packages/@core/ui-kit/form-ui/src/form-api.ts
@@ -56,6 +56,9 @@ export class FormApi {
 
   public store: Store<VbenFormProps>;
 
+  // 保存字段的blur状态，字段触发校验时可以通过blur状态判断是否要校验
+  private fieldBlurState: Record<string, boolean> = {};
+
   // 最后一次点击提交时的表单值
   private latestSubmissionValues: null | Recordable<any> = null;
 
@@ -84,6 +87,10 @@ export class FormApi {
     this.stateHandler = new StateHandler();
     bindMethods(this);
   }
+
+  getFieldBlurState = (fieldName: string): boolean | undefined => {
+    return this.fieldBlurState[fieldName];
+  };
 
   getLatestSubmissionValues() {
     return this.latestSubmissionValues || {};
@@ -188,6 +195,10 @@ export class FormApi {
     });
   }
 
+  setFieldBlurState = (fieldName: string, state: boolean) => {
+    this.fieldBlurState[fieldName] = state;
+  };
+
   async setFieldValue(field: string, value: any, shouldValidate?: boolean) {
     const form = await this.getForm();
     form.setFieldValue(field, value, shouldValidate);
@@ -267,6 +278,7 @@ export class FormApi {
     this.latestSubmissionValues = null;
     this.isMounted = false;
     this.stateHandler.reset();
+    this.fieldBlurState = {};
   }
 
   updateSchema(schema: Partial<FormSchema>[]) {

--- a/packages/@core/ui-kit/form-ui/src/use-form-context.ts
+++ b/packages/@core/ui-kit/form-ui/src/use-form-context.ts
@@ -16,9 +16,13 @@ import { getDefaultsForSchema } from 'zod-defaults';
 type ExtendFormProps = VbenFormProps & { formApi: ExtendedFormApi };
 
 export const [injectFormProps, provideFormProps] =
-  createContext<[ComputedRef<ExtendFormProps> | ExtendFormProps, FormActions]>(
-    'VbenFormProps',
-  );
+  createContext<
+    [
+      ComputedRef<ExtendFormProps> | ExtendFormProps,
+      FormActions,
+      ExtendedFormApi,
+    ]
+  >('VbenFormProps');
 
 export function useFormInitial(
   props: ComputedRef<VbenFormProps> | VbenFormProps,

--- a/packages/@core/ui-kit/form-ui/src/vben-use-form.vue
+++ b/packages/@core/ui-kit/form-ui/src/vben-use-form.vue
@@ -31,7 +31,7 @@ const forward = useForwardPriorityValues(props, state);
 
 const { delegatedSlots, form } = useFormInitial(forward);
 
-provideFormProps([forward, form]);
+provideFormProps([forward, form, props.formApi]);
 
 props.formApi?.mount?.(form);
 


### PR DESCRIPTION
## Description

目前表单验证有一个问题，在自定义验证的时候校验方法会被多次调用( #5437)，vee-validate的作者表示这是正常的(logaretm/vee-validate#4737)，修改值的时候虽然不会显示错误信息，但是会调用校验方法。如果需要异步校验，这样会多次发送请求很浪费资源。

我通过组件的blur事件保存当前字段的blur状态到`formApi`中，这样自定义校验的时候通过`formApi.getFieldBlurState`可以拿到当前字段的blur状态，根据这个状态判断要不要发送请求校验数据，避免了多次请求的麻烦。

### 示例

```ts
const [Form, formApi] = useVbenForm({
  schema: [
    {
      fieldName: 'field1',
      formFieldProps: {
        // 必须要设置这两个状态，不设置表示不需要保存字段的blur状态
        validateOnModelUpdate: false,        
        validateOnBlur: true,
      },
      rules: z.string().refine(
        async (v: string | undefined) => {
          const blurState = formApi.getFieldBlurState('field1');
          // 判断当前字段的blur状态，避免修改值时多次触发校验
          if (blurState) {
            await new Promise((resolve) => {
              setTimeout(resolve, 1000);
            });
            return v === '123';
          }
          return true;
        },
        { message: '必须等于123' },
      ),
    },
  ],
});
```

### 使用

1. 在表单中需要设置`validateOnModelUpdate: false`和`validateOnBlur: true`才能保存字段的blur状态，只有input可以保存，其他类型的字段设置没用

```js
{
formFieldProps: {
        validateOnModelUpdate: false,
        validateOnBlur: true,
      }
}
```
2. 在自定义校验的方法中使用`const blurState = formApi.getFieldBlurState(fieldName);`获取字段的blur状态，如果字段已经blur会返回`true`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form interactions by tracking focus and blur events. This update improves field validations and user feedback during data entry.
  
- **Refactor**
	- Expanded the form’s contextual capabilities to support extended functionality, ensuring a more robust and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->