### PR TITLE
fix: long navigation menu can be scrolled

### DIFF
--- a/packages/@core/ui-kit/menu-ui/src/components/sub-menu.vue
+++ b/packages/@core/ui-kit/menu-ui/src/components/sub-menu.vue
@@ -208,6 +208,8 @@ onBeforeUnmount(() => {
           nsMenu.e('popup-container'),
           is(rootMenu.theme, true),
           opened ? '' : 'hidden',
+          'overflow-auto',
+          'max-h-[calc(var(--radix-hover-card-content-available-height)-20px)]',
         ]"
         :content-props="contentProps"
         :open="true"


### PR DESCRIPTION
* 修复超长的导航菜单无法纵向滚动的问题

fixed: #5938


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the hover card display in menus by enabling auto-scrolling for content that exceeds the available space. The new design maintains a calculated maximum height for a smoother and more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->