### PR TITLE
fix: modal closing animation

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
@@ -103,7 +103,7 @@ const { dragging, transform } = useModalDraggable(
 );
 
 const firstOpened = ref(false);
-const isClosed = ref(false);
+const isClosed = ref(true);
 
 watch(
   () => state?.value?.isOpen,


### PR DESCRIPTION
解决destroyOnClose=false条件下，打开页面动画会一闪而过的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated modal behavior so that it is now closed by default when first rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->