### PR TITLE
perf: improve destroyOnClose for VbenModal

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
@@ -186,7 +186,7 @@ const getAppendTo = computed(() => {
 });
 
 const getForceMount = computed(() => {
-  return !unref(destroyOnClose);
+  return !unref(destroyOnClose) && unref(firstOpened);
 });
 
 function handleClosed() {


### PR DESCRIPTION
destroyOnClose=false，即使modal未打开也会渲染
优化后，只有modal第一次open才会渲染

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved modal behavior to ensure content is only force-mounted after the modal has been opened at least once, providing a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->