### PR TITLE
fix: alert send wrong confirm state to beforeClose

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -91,14 +91,13 @@ const getIconRender = computed(() => {
 });
 
 function doCancel() {
-  isConfirm.value = false;
+  handleCancel();
   handleOpenChange(false);
 }
 
 function doConfirm() {
-  isConfirm.value = true;
+  handleConfirm();
   handleOpenChange(false);
-  emits('confirm');
 }
 
 provideAlertContext({
@@ -117,11 +116,13 @@ function handleCancel() {
 
 const loading = ref(false);
 async function handleOpenChange(val: boolean) {
+  const confirmState = isConfirm.value;
+  isConfirm.value = false;
   await nextTick();
   if (!val && props.beforeClose) {
     loading.value = true;
     try {
-      const res = await props.beforeClose({ isConfirm: isConfirm.value });
+      const res = await props.beforeClose({ isConfirm: confirmState });
       if (res !== false) {
         open.value = false;
       }


### PR DESCRIPTION
* 修复alert在按下Esc或者点击遮罩关闭时，可能发送错误的isConfirm状态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of confirm and cancel actions in the alert dialog for more accurate state management and event handling.
  - Enhanced the reliability of the confirmation state provided to custom callbacks when the alert closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->