### PR TITLE
fix: update existing route index to prevent 404 on user switch

### DIFF
--- a/packages/effects/access/src/accessible.ts
+++ b/packages/effects/access/src/accessible.ts
@@ -44,6 +44,14 @@ async function generateAccessible(
       // 根据router name判断，如果路由已经存在，则不再添加
       if (!names?.includes(route.name)) {
         root.children?.push(route);
+      } else {
+        // 找到已存在的路由索引并更新，不更新会造成切换用户时，一级目录未更新，homePath 在二级目录导致的404问题
+        const index = root.children?.findIndex(
+          (item) => item.name === route.name,
+        );
+        if (index !== undefined && index !== -1 && root.children) {
+          root.children[index] = route;
+        }
       }
     } else {
       router.addRoute(route);


### PR DESCRIPTION
## Description

后端访问控制路由时，切换登录账户有可能出现404错误。具体复现情况如下：
路由为两级菜单，假设 

zhangsan 的菜单是
/user
/user/manage
homePath 是 /user/manage

lisi 的菜单是
/user
/user/password
homePath 是 /user/password

因为一级目录都是 /user，导致路由未更新，但是作为 homePath 的二级目录有变化，会导致登录之后出现404页面。

代码修改了 route 更新逻辑，未找到的路由仍然保持添加逻辑，找到的路由根据 index 做更新可以解决这个问题。

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where outdated route data could cause navigation errors when switching users, ensuring more reliable access to the correct routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->