### PR TITLE
perf: vxe-table 活动颜色，松开颜色，按下颜色，没有随主题颜色修复

### DIFF
--- a/packages/effects/plugins/src/vxe-table/style.css
+++ b/packages/effects/plugins/src/vxe-table/style.css
@@ -45,6 +45,9 @@
   );
   --vxe-ui-table-row-current-background-color: hsl(var(--accent));
   --vxe-ui-table-row-hover-current-background-color: hsl(var(--accent-hover));
+  --vxe-ui-font-primary-tinge-color: hsl(var(--primary));
+  --vxe-ui-font-primary-lighten-color: hsl(var(--primary) / 60%);
+  --vxe-ui-font-primary-darken-color: hsl(var(--primary));
 
   height: auto !important;
 


### PR DESCRIPTION
![微信截图_20250421184535](https://github.com/user-attachments/assets/72d29356-6b29-4cd2-a16d-11237f355705)
