### PR TITLE
fix: alert confirm state in beforeClose callback

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -47,6 +47,10 @@ function onAlertClosed() {
   isConfirm.value = false;
 }
 
+function onEscapeKeyDown() {
+  isConfirm.value = false;
+}
+
 const getIconRender = computed(() => {
   let iconRender: Component | null = null;
   if (props.icon) {
@@ -116,13 +120,11 @@ function handleCancel() {
 
 const loading = ref(false);
 async function handleOpenChange(val: boolean) {
-  const confirmState = isConfirm.value;
-  isConfirm.value = false;
-  await nextTick();
+  await nextTick(); // 等待标记isConfirm状态
   if (!val && props.beforeClose) {
     loading.value = true;
     try {
-      const res = await props.beforeClose({ isConfirm: confirmState });
+      const res = await props.beforeClose({ isConfirm: isConfirm.value });
       if (res !== false) {
         open.value = false;
       }
@@ -142,6 +144,7 @@ async function handleOpenChange(val: boolean) {
       :overlay-blur="overlayBlur"
       @opened="emits('opened')"
       @closed="onAlertClosed"
+      @escape-key-down="onEscapeKeyDown"
       :class="
         cn(
           containerClass,


### PR DESCRIPTION
修复alert的beforeClose回调函数中获得的isConfirm状态可能不正确的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved alert dialog behavior when pressing the Escape key, ensuring dialogs close more reliably and as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->