### PR TITLE
perf: improve destroyOnClose for VbenDrawer&VbenModal

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/drawer/drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/drawer.ts
@@ -53,6 +53,10 @@ export interface DrawerProps {
    */
   description?: string;
   /**
+   * 在关闭时销毁抽屉
+   */
+  destroyOnClose?: boolean;
+  /**
    * 是否显示底部
    * @default true
    */
@@ -143,10 +147,6 @@ export interface DrawerApiOptions extends DrawerState {
    * 独立的抽屉组件
    */
   connectedComponent?: Component;
-  /**
-   * 在关闭时销毁抽屉。仅在使用 connectedComponent 时有效
-   */
-  destroyOnClose?: boolean;
   /**
    * 关闭前的回调，返回 false 可以阻止关闭
    * @returns

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -21,7 +21,9 @@ import VbenDrawer from './drawer.vue';
 
 const USER_DRAWER_INJECT_KEY = Symbol('VBEN_DRAWER_INJECT');
 
-const DEFAULT_DRAWER_PROPS: Partial<DrawerProps> = {};
+const DEFAULT_DRAWER_PROPS: Partial<DrawerProps> = {
+  destroyOnClose: true,
+};
 
 export function setDefaultDrawerProps(props: Partial<DrawerProps>) {
   Object.assign(DEFAULT_DRAWER_PROPS, props);

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -17,7 +17,9 @@ import VbenModal from './modal.vue';
 
 const USER_MODAL_INJECT_KEY = Symbol('VBEN_MODAL_INJECT');
 
-const DEFAULT_MODAL_PROPS: Partial<ModalProps> = {};
+const DEFAULT_MODAL_PROPS: Partial<ModalProps> = {
+  destroyOnClose: true,
+};
 
 export function setDefaultModalProps(props: Partial<ModalProps>) {
   Object.assign(DEFAULT_MODAL_PROPS, props);
@@ -86,7 +88,7 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
 
   mergedOptions.onClosed = () => {
     options.onClosed?.();
-    if (options.destroyOnClose) {
+    if (mergedOptions.destroyOnClose) {
       injectData.reCreateModal?.();
     }
   };

--- a/playground/src/views/examples/drawer/in-content-demo.vue
+++ b/playground/src/views/examples/drawer/in-content-demo.vue
@@ -5,9 +5,27 @@ import { useVbenDrawer } from '@vben/common-ui';
 
 import { Input, message } from 'ant-design-vue';
 
+import { useVbenForm } from '#/adapter/form';
+
 const value = ref('');
 
+const [Form] = useVbenForm({
+  schema: [
+    {
+      component: 'Input',
+      componentProps: {
+        placeholder: 'KeepAlive测试：内部组件',
+      },
+      fieldName: 'field1',
+      hideLabel: true,
+      label: '字段1',
+    },
+  ],
+  showDefaultActions: false,
+});
+
 const [Drawer, drawerApi] = useVbenDrawer({
+  destroyOnClose: false,
   onCancel() {
     drawerApi.close();
   },
@@ -20,7 +38,11 @@ const [Drawer, drawerApi] = useVbenDrawer({
 <template>
   <Drawer append-to-main title="基础抽屉示例" title-tooltip="标题提示内容">
     <template #extra> extra </template>
-    本抽屉指定在内容区域打开
-    <Input v-model="value" placeholder="KeepAlive测试" />
+    此弹窗指定在内容区域打开，并且在关闭之后弹窗内容不会被销毁
+    <Input
+      v-model:value="value"
+      placeholder="KeepAlive测试:connectedComponent"
+    />
+    <Form />
   </Drawer>
 </template>


### PR DESCRIPTION
1、fix that the default value of modal destroyOnClose does not take effect
2、improve destroyOnClose for VbenDrawer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to control whether drawer and modal content is destroyed upon closing, using the new `destroyOnClose` property (default: true).
  - Users can now persist drawer content after closing by setting `destroyOnClose` to false.

- **Bug Fixes**
  - Improved consistency in handling the `destroyOnClose` property across drawers and modals.

- **Documentation**
  - Updated example to demonstrate persistent drawer content when `destroyOnClose` is set to false.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->