### PR TITLE
fix: fix `LoginExpiredModal` in some cases, `message` may be obscured

### DIFF
--- a/packages/effects/common-ui/src/ui/authentication/login-expired-modal.vue
+++ b/packages/effects/common-ui/src/ui/authentication/login-expired-modal.vue
@@ -36,6 +36,16 @@ const getZIndex = computed(() => {
 });
 
 /**
+ * 排除ant-message和loading:9999的z-index
+ */
+const zIndexExcludeClass = ['ant-message', 'loading'];
+function isZIndexExcludeClass(element: Element) {
+  return zIndexExcludeClass.some((className) =>
+    element.classList.contains(className),
+  );
+}
+
+/**
  * 获取最大的zIndex值
  */
 function calcZIndex() {
@@ -44,7 +54,11 @@ function calcZIndex() {
   [...elements].forEach((element) => {
     const style = window.getComputedStyle(element);
     const zIndex = style.getPropertyValue('z-index');
-    if (zIndex && !Number.isNaN(Number.parseInt(zIndex))) {
+    if (
+      zIndex &&
+      !Number.isNaN(Number.parseInt(zIndex)) &&
+      !isZIndexExcludeClass(element)
+    ) {
       maxZ = Math.max(maxZ, Number.parseInt(zIndex));
     }
   });


### PR DESCRIPTION
Trigger condition
1. Message rendering first
2. Refresh browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved z-index calculation for the login expiration modal to prevent interference from notification and loading elements, ensuring the modal displays correctly above other content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->