### PR TITLE
fix: add missing translation for preferences drawer

### DIFF
--- a/packages/effects/layouts/src/widgets/preferences/blocks/layout/sidebar.vue
+++ b/packages/effects/layouts/src/widgets/preferences/blocks/layout/sidebar.vue
@@ -79,14 +79,14 @@ const handleCheckboxChange = () => {
   </SwitchItem>
   <CheckboxItem
     :items="[
-      { label: '收缩按钮', value: 'collapsed' },
-      { label: '固定按钮', value: 'fixed' },
+      { label: $t('preferences.sidebar.buttonCollapsed'), value: 'collapsed' },
+      { label: $t('preferences.sidebar.buttonFixed'), value: 'fixed' },
     ]"
     multiple
     v-model="sidebarButtons"
     :on-btn-click="handleCheckboxChange"
   >
-    按钮配置
+    {{ $t('preferences.sidebar.buttons') }}
   </CheckboxItem>
   <NumberFieldItem
     v-model="sidebarWidth"

--- a/packages/locales/src/langs/en-US/preferences.json
+++ b/packages/locales/src/langs/en-US/preferences.json
@@ -45,6 +45,9 @@
     "fixed": "Fixed"
   },
   "sidebar": {
+    "buttons": "Show Buttons",
+    "buttonFixed": "Fixed",
+    "buttonCollapsed": "Collapsed",
     "title": "Sidebar",
     "width": "Width",
     "visible": "Show Sidebar",

--- a/packages/locales/src/langs/zh-CN/preferences.json
+++ b/packages/locales/src/langs/zh-CN/preferences.json
@@ -45,6 +45,9 @@
     "fixed": "固定"
   },
   "sidebar": {
+    "buttons": "显示按钮",
+    "buttonFixed": "固定按钮",
+    "buttonCollapsed": "折叠按钮",
     "title": "侧边栏",
     "width": "宽度",
     "visible": "显示侧边栏",


### PR DESCRIPTION
补全偏好设置抽屉的部分翻译内容。
fixed: #6084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sidebar preference labels now support multiple languages with dynamic translations.
- **Documentation**
  - Added new English and Chinese translations for sidebar button preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->