### PR TITLE
fix: when keepAlive is enabled, returning directly through browser bu…

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -9,6 +9,7 @@ import {
   h,
   inject,
   nextTick,
+  onDeactivated,
   provide,
   reactive,
   ref,
@@ -70,6 +71,14 @@ export function useVbenDrawer<
         inheritAttrs: false,
       },
     );
+
+    /**
+     * 在开启keepAlive情况下 直接通过浏览器按钮/手势等返回 不会关闭弹窗
+     */
+    onDeactivated(() => {
+      (extendedApi as ExtendedDrawerApi)?.close?.();
+    });
+
     return [Drawer, extendedApi as ExtendedDrawerApi] as const;
   }
 

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -5,6 +5,7 @@ import {
   h,
   inject,
   nextTick,
+  onDeactivated,
   provide,
   reactive,
   ref,
@@ -69,6 +70,14 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
         inheritAttrs: false,
       },
     );
+
+    /**
+     * 在开启keepAlive情况下 直接通过浏览器按钮/手势等返回 不会关闭弹窗
+     */
+    onDeactivated(() => {
+      (extendedApi as ExtendedModalApi)?.close?.();
+    });
+
     return [Modal, extendedApi as ExtendedModalApi] as const;
   }
 


### PR DESCRIPTION
…ttons/gestures will not close pop ups

## Description

在开启`keepAlive`时 通过浏览器返回按钮/手势等 modal/drawer不会关闭

## 复现流程: 

- 开启keepAlive

<img width="451" alt="image" src="https://github.com/user-attachments/assets/07130be7-7165-4a71-a4f0-42d2eddb3ebd" />

<img width="579" alt="image" src="https://github.com/user-attachments/assets/831a5d09-8b1c-4fae-b43e-a582d04cb11f" />

- 从首页进入到部门管理 点击弹窗 再点击浏览器返回 此时弹窗依旧存在

![image](https://github.com/user-attachments/assets/333c6405-780a-456d-9935-067ea532cb8e)

## fix

使用keepAlive的hook  onDeactivated  在未激活页面情况进行手动关闭

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that drawers and modals are automatically closed when navigating away from a component (such as when using browser navigation or gestures), improving the user experience with components kept alive in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->