### PR TITLE
fix: the mobile terminal can wrap lines and expand slot attributes

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/components/button/button.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/components/button/button.ts
@@ -36,7 +36,7 @@ export interface VbenButtonGroupProps
   btnClass?: any;
   gap?: number;
   multiple?: boolean;
-  options?: { label: CustomRenderType; value: ValueType }[];
+  options?: { [key: string]: any; label: CustomRenderType; value: ValueType }[];
   showIcon?: boolean;
   size?: 'large' | 'middle' | 'small';
 }

--- a/packages/@core/ui-kit/shadcn-ui/src/components/button/check-button-group.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/components/button/check-button-group.vue
@@ -119,7 +119,7 @@ async function onBtnClick(value: ValueType) {
         <CircleCheckBig v-else-if="innerValue.includes(btn.value)" />
         <Circle v-else />
       </div>
-      <slot name="option" :label="btn.label" :value="btn.value">
+      <slot name="option" :label="btn.label" :value="btn.value" :data="btn">
         <VbenRenderContent :content="btn.label" />
       </slot>
     </Button>
@@ -127,6 +127,9 @@ async function onBtnClick(value: ValueType) {
 </template>
 <style lang="scss" scoped>
 .vben-check-button-group {
+  display: flex;
+  flex-wrap: wrap;
+
   &:deep(.size-large) button {
     .icon-wrapper {
       margin-right: 0.3rem;
@@ -157,6 +160,17 @@ async function onBtnClick(value: ValueType) {
         width: 0.65rem;
         height: 0.65rem;
       }
+    }
+  }
+
+  &.no-gap > :deep(button):nth-of-type(1) {
+    border-right-width: 0;
+  }
+
+  &.no-gap {
+    :deep(button + button) {
+      margin-right: -1px;
+      border-left-width: 1px;
     }
   }
 }

--- a/playground/src/views/examples/button-group/index.vue
+++ b/playground/src/views/examples/button-group/index.vue
@@ -19,7 +19,7 @@ const checkValue = ref(['a', 'b']);
 
 const options = [
   { label: '选项1', value: 'a' },
-  { label: '选项2', value: 'b' },
+  { label: '选项2', value: 'b', num: 999 },
   { label: '选项3', value: 'c' },
   { label: '选项4', value: 'd' },
   { label: '选项5', value: 'e' },
@@ -168,10 +168,11 @@ function onBtnClick(value: any) {
           :options="options"
           v-bind="compProps"
         >
-          <template #option="{ label, value }">
+          <template #option="{ label, value, data }">
             <div class="flex items-center">
               <span>{{ label }}</span>
               <span class="ml-2 text-gray-400">{{ value }}</span>
+              <span v-if="data.num" class="white ml-2">{{ data.num }}</span>
             </div>
           </template>
         </VbenCheckButtonGroup>


### PR DESCRIPTION
## Description

问题一：如果按钮太多移动端显示有问题，在移动端换行显示体验会好一点 image 
![image](https://github.com/user-attachments/assets/db517b87-28b8-4c2a-a716-0f5bc1441f2d)
这段css的作用是修复换行时候首个按钮左边没有 border 的问题

 问题二：遇到个需求需要在接口显示当前 tab 下有多少条数据，而且一进来之后选中哪项是由用户行为决定的，需要固定 value，加个配置项可以满足更多用户需求。

改完之后是这样的
![image](https://github.com/user-attachments/assets/20a37a64-0c9f-402f-8f7f-640423ba6e7f)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Button group options can now include extra custom properties, allowing for more flexible button configurations.
  - Button group slots now provide access to the full option data, enabling richer and more dynamic button displays.
  - Example usage updated to show additional custom data (such as a numeric label) alongside button labels.

- **Style**
  - Improved button group layout with flexible wrapping and enhanced styling for groups with no gaps between buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->