### PR TITLE
fix: vbenTree disabled supported

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
@@ -192,9 +192,9 @@ defineExpose({
     :model-value="treeValue"
     v-model:expanded="expanded as string[]"
     :default-expanded="defaultExpandedKeys as string[]"
-    :propagate-select="!checkStrictly"
-    :multiple="multiple"
-    :disabled="disabled"
+    :propagate-select="!props.checkStrictly"
+    :multiple="props.multiple"
+    :disabled="props.disabled"
     :selection-behavior="allowClear || multiple ? 'toggle' : 'replace'"
     @update:model-value="updateModelValue"
     v-slot="{ flattenItems }"
@@ -229,7 +229,11 @@ defineExpose({
         v-bind="item.bind"
         @select="
           (event) => {
-            if (event.detail.originalEvent.type === 'click') {
+            if (
+              event.detail.originalEvent.type === 'click' ||
+              props.disabled ||
+              get(item.value, 'disabled')
+            ) {
               event.preventDefault();
             }
             onSelect(item, event.detail.isSelected);
@@ -263,6 +267,7 @@ defineExpose({
           v-if="multiple"
           :checked="isSelected"
           :indeterminate="isIndeterminate"
+          :disabled="disabled || get(item.value, 'disabled')"
           @click="
             () => {
               handleSelect();
@@ -274,10 +279,10 @@ defineExpose({
           class="flex items-center gap-1 pl-2"
           @click="
             (_event) => {
-              // $event.stopPropagation();
-              // $event.preventDefault();
+              if (props.disabled || get(item.value, 'disabled')) {
+                return;
+              }
               handleSelect();
-              // onSelect(item, !isSelected);
             }
           "
         >

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -106,7 +106,6 @@ function getNodeClass(node: Recordable<any>) {
             :default-expanded-level="2"
             :get-node-class="getNodeClass"
             v-bind="slotProps"
-            :disabled="true"
             value-field="id"
             label-field="meta.title"
             icon-field="meta.icon"

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -106,6 +106,7 @@ function getNodeClass(node: Recordable<any>) {
             :default-expanded-level="2"
             :get-node-class="getNodeClass"
             v-bind="slotProps"
+            :disabled="true"
             value-field="id"
             label-field="meta.title"
             icon-field="meta.icon"


### PR DESCRIPTION
完善 vbenTree 对disabled属性的支持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of disabled states in the tree view, ensuring that tree nodes and checkboxes cannot be interacted with when disabled.
  - Enhanced consistency in how component properties are accessed, leading to more reliable behavior when using multiple or disabled options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->