### PR TITLE
fix: getFieldComponentRef will return actual ref within AsyncComponent

### DIFF
--- a/playground/src/views/examples/form/api.vue
+++ b/playground/src/views/examples/form/api.vue
@@ -134,7 +134,7 @@ function handleClick(
     }
     case 'componentRef': {
       // 获取下拉组件的实例，并调用它的focus方法
-      formApi.getFieldComponentRef<RefSelectProps>('fieldOptions')?.focus();
+      formApi.getFieldComponentRef<RefSelectProps>('fieldOptions')?.focus?.();
       break;
     }
     case 'disabled': {


### PR DESCRIPTION
修复异步加载组件时，表单的getFieldComponentRef方法没能获取到正确的组件实例。
fixed: #6239