### PR TITLE
fix: tabbar lose current tab without persistent

### DIFF
--- a/packages/stores/src/modules/tabbar.ts
+++ b/packages/stores/src/modules/tabbar.ts
@@ -208,7 +208,7 @@ export const useTabbarStore = defineStore('core-tabbar', {
       const keys: string[] = [];
 
       for (const key of closeKeys) {
-        if (key !== tab.key) {
+        if (key !== getTabKeyFromTab(tab)) {
           const closeTab = this.tabs.find(
             (item) => getTabKeyFromTab(item) === key,
           );


### PR DESCRIPTION
修复在关闭标签栏持久化的情况下，刷新页面后会丢失当前标签的问题。
fixed: #6242
