### PR TITLE
fix: reset slider-captcha after login failed

### DIFF
--- a/playground/src/views/_core/authentication/login.vue
+++ b/playground/src/views/_core/authentication/login.vue
@@ -111,10 +111,11 @@ const loginRef =
 async function onSubmit(params: Recordable<any>) {
   authStore.authLogin(params).catch(() => {
     // 登陆失败，刷新验证码的演示
-
+    const formApi = loginRef.value?.getFormApi();
+    // 重置验证码组件的值
+    formApi?.setFieldValue('captcha', false, false);
     // 使用表单API获取验证码组件实例，并调用其resume方法来重置验证码
-    loginRef.value
-      ?.getFormApi()
+    formApi
       ?.getFieldComponentRef<InstanceType<typeof SliderCaptcha>>('captcha')
       ?.resume();
   });


### PR DESCRIPTION
修复登陆时如果接口i返回登陆失败后，划动验证没有重置的问题。

fixed: #6202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the login form's error handling for a smoother user experience. No visible changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->