### PR TITLE
fix: requestClient.upload会将vbenform中value为undefined的值转为字符串undefined’提…

### DIFF
--- a/packages/effects/request/src/request-client/modules/uploader.ts
+++ b/packages/effects/request/src/request-client/modules/uploader.ts
@@ -20,7 +20,7 @@ class FileUploader {
     Object.entries(data).forEach(([key, value]) => {
       if (Array.isArray(value)) {
         value.forEach((item, index) => {
-          formData.append(`${key}[${index}]`, item);
+          !isUndefined(item) && formData.append(`${key}[${index}]`, item);
         });
       } else {
         !isUndefined(value) && formData.append(key, value);

--- a/packages/effects/request/src/request-client/modules/uploader.ts
+++ b/packages/effects/request/src/request-client/modules/uploader.ts
@@ -1,6 +1,8 @@
 import type { RequestClient } from '../request-client';
 import type { RequestClientConfig } from '../types';
 
+import { isUndefined } from '@vben/utils';
+
 class FileUploader {
   private client: RequestClient;
 
@@ -21,7 +23,7 @@ class FileUploader {
           formData.append(`${key}[${index}]`, item);
         });
       } else {
-        formData.append(key, value);
+        !isUndefined(value) && formData.append(key, value);
       }
     });
 


### PR DESCRIPTION
表单格式提交，vbenform中未赋值的话，默认是undefined，这会导致 form.append会将undefined 转为字符串‘undefined’ 提交给后台保存到数据库


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file upload handling to prevent undefined values from being included in form data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->