### PR TITLE
perf: perf the control logic of `VbenModal` full screen and header

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
@@ -97,9 +97,7 @@ const {
   zIndex,
 } = usePriorityValues(props, state);
 
-const shouldFullscreen = computed(
-  () => (fullscreen.value && header.value) || isMobile.value,
-);
+const shouldFullscreen = computed(() => fullscreen.value || isMobile.value);
 
 const shouldDraggable = computed(
   () => draggable.value && !shouldFullscreen.value && header.value,


### PR DESCRIPTION
resolve the issue of header=false and full screen button display but not operable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the logic determining when the modal displays in fullscreen mode, now allowing fullscreen if either fullscreen mode is enabled or the device is mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->