### PR TITLE
fix: the bug in the lock method of the vbenModal component

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/modal/modal-api.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal-api.ts
@@ -107,7 +107,6 @@ export class ModalApi {
       this.store.setState((prev) => ({
         ...prev,
         isOpen: false,
-        submitting: false,
       }));
     }
   }
@@ -162,7 +161,11 @@ export class ModalApi {
   }
 
   open() {
-    this.store.setState((prev) => ({ ...prev, isOpen: true }));
+    this.store.setState((prev) => ({
+      ...prev,
+      isOpen: true,
+      submitting: false,
+    }));
   }
 
   setData<T>(payload: T) {


### PR DESCRIPTION
## Description

vbenModal 组件，设置 lock 方法，然后 close 方法关闭弹窗，快速点击有时候执行了两次确定按钮。

<img width="782" height="400" alt="image" src="https://github.com/user-attachments/assets/b717ddc6-677f-4070-88d1-b37ab56cc67c" />


简单的 modal close 方法加个定时器快速点击偶尔也能复现
项目里 modal 实际 dom 会多一些，快速点击很容易复现，modal 消失之前及时是有 lock 方法，页面关闭之前也能再点击一次。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted modal behavior for more predictable submission handling. Closing a modal no longer clears the submission state, preventing unintended resets mid-flow. When the modal is opened, the submission state is now reset to provide a clean start. This ensures consistent user experience across open/close cycles, reduces confusion around in-progress actions, and aligns modal behavior with expected form interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->