### PR TITLE
fix: meta.link invalid issue

### DIFF
--- a/packages/effects/layouts/src/basic/menu/use-navigation.ts
+++ b/packages/effects/layouts/src/basic/menu/use-navigation.ts
@@ -29,7 +29,8 @@ function useNavigation() {
       return true;
     }
     const route = routeMetaMap.get(path);
-    return route?.meta?.openInNewWindow ?? false;
+    // 如果有外链或者设置了在新窗口打开，返回 true
+    return !!(route?.meta?.link || route?.meta?.openInNewWindow);
   };
 
   const resolveHref = (path: string): string => {
@@ -39,7 +40,13 @@ function useNavigation() {
   const navigation = async (path: string) => {
     try {
       const route = routeMetaMap.get(path);
-      const { openInNewWindow = false, query = {} } = route?.meta ?? {};
+      const { openInNewWindow = false, query = {}, link } = route?.meta ?? {};
+
+      // 检查是否有外链
+      if (link && typeof link === 'string') {
+        openWindow(link, { target: '_blank' });
+        return;
+      }
 
       if (isHttpUrl(path)) {
         openWindow(path, { target: '_blank' });


### PR DESCRIPTION
## Description

修复 link 属性无法跳转新窗口问题

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Menu navigation now supports external links defined in route metadata. When a link is provided or the path is an HTTP URL, it opens in a new tab/window and bypasses internal navigation.
  - Enhanced “open in new window” behavior: navigation opens a new window if a link string is present, the open-in-new-window flag is set, or the path is an HTTP URL, improving consistency for external destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->