### PR TITLE
fix: fix the issue of excessive line spacing in vbenForm

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-render/form.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form.vue
@@ -43,12 +43,10 @@ const emits = defineEmits<{
 
 const wrapperClass = computed(() => {
   const cls = ['flex'];
-  if (props.layout === 'vertical') {
-    cls.push(props.compact ? 'gap-x-2' : 'gap-x-4', 'flex-col grid');
-  } else if (props.layout === 'inline') {
-    cls.push('flex-wrap gap-2');
+  if (props.layout === 'inline') {
+    cls.push('flex-wrap gap-x-2');
   } else {
-    cls.push('gap-2 flex-col grid');
+    cls.push(props.compact ? 'gap-x-2' : 'gap-x-4', 'flex-col grid');
   }
   return cn(...cls, props.wrapperClass);
 });


### PR DESCRIPTION
 * gap-2和 pb-4/2 重叠导致间距过宽，使用gap-x只保留列间距


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved form layout spacing and consistency.
  * Inline forms now use consistent horizontal spacing for better alignment.
  * Non-inline forms adopt adaptive spacing based on the compact setting, enhancing readability.
  * Unified handling of vertical layouts under the non-inline behavior for a more consistent appearance across variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->