### PR TITLE
fix: 修复角色修改时VbenTree组件没有回显选中

### DIFF
--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -47,23 +47,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
         drawerApi.unlock();
       });
   },
-  onOpenChange(isOpen) {
-    if (isOpen) {
-      const data = drawerApi.getData<SystemRoleApi.SystemRole>();
-      formApi.resetForm();
-      if (data) {
-        formData.value = data;
-        id.value = data.id;
-// playground/src/views/system/role/modules/form.vue
 
-<script setup lang="ts">
-import { computed, ref, nextTick } from 'vue';
-// … other imports …
-
-export default {
-  // … other component options …
-  methods: {
-    // Refactored to ensure form fields are mounted before setting values
    async onOpenChange(isOpen) {
        if (isOpen) {
          const data = drawerApi.getData<SystemRoleApi.SystemRole>();
@@ -79,27 +63,13 @@ export default {
          if (permissions.value.length === 0) {
            await loadPermissions();
          }
-
         // Wait for Vue to flush DOM updates (form fields mounted)
          await nextTick();
-
          if (data) {
            formApi.setValues(data);
          }
        }
      },
-  },
-};
-</script>
-      } else {
-        id.value = undefined;
-      }
-
-      if (permissions.value.length === 0) {
-        loadPermissions();
-      }
-    }
-  },
 });
 
 async function loadPermissions() {

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -54,9 +54,43 @@ const [Drawer, drawerApi] = useVbenDrawer({
       if (data) {
         formData.value = data;
         id.value = data.id;
-        setTimeout(() => {
-          formApi.setValues(data);
-        }, 300);
+// playground/src/views/system/role/modules/form.vue
+
+<script setup lang="ts">
+import { computed, ref, nextTick } from 'vue';
+// … other imports …
+
+export default {
+  // … other component options …
+  methods: {
+    // Refactored to ensure form fields are mounted before setting values
+   async onOpenChange(isOpen) {
+       if (isOpen) {
+         const data = drawerApi.getData<SystemRoleApi.SystemRole>();
+         formApi.resetForm();
+
+         if (data) {
+           formData.value = data;
+           id.value = data.id;
+         } else {
+           id.value = undefined;
+         }
+
+         if (permissions.value.length === 0) {
+           await loadPermissions();
+         }
+
+        // Wait for Vue to flush DOM updates (form fields mounted)
+         await nextTick();
+
+         if (data) {
+           formApi.setValues(data);
+         }
+       }
+     },
+  },
+};
+</script>
       } else {
         id.value = undefined;
       }

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -5,7 +5,7 @@ import type { Recordable } from '@vben/types';
 
 import type { SystemRoleApi } from '#/api/system/role';
 
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 
 import { useVbenDrawer, VbenTree } from '@vben/common-ui';
 import { IconifyIcon } from '@vben/icons';
@@ -48,28 +48,28 @@ const [Drawer, drawerApi] = useVbenDrawer({
       });
   },
 
-   async onOpenChange(isOpen) {
-       if (isOpen) {
-         const data = drawerApi.getData<SystemRoleApi.SystemRole>();
-         formApi.resetForm();
+  async onOpenChange(isOpen) {
+    if (isOpen) {
+      const data = drawerApi.getData<SystemRoleApi.SystemRole>();
+      formApi.resetForm();
 
-         if (data) {
-           formData.value = data;
-           id.value = data.id;
-         } else {
-           id.value = undefined;
-         }
+      if (data) {
+        formData.value = data;
+        id.value = data.id;
+      } else {
+        id.value = undefined;
+      }
 
-         if (permissions.value.length === 0) {
-           await loadPermissions();
-         }
-        // Wait for Vue to flush DOM updates (form fields mounted)
-         await nextTick();
-         if (data) {
-           formApi.setValues(data);
-         }
-       }
-     },
+      if (permissions.value.length === 0) {
+        await loadPermissions();
+      }
+      // Wait for Vue to flush DOM updates (form fields mounted)
+      await nextTick();
+      if (data) {
+        formApi.setValues(data);
+      }
+    }
+  },
 });
 
 async function loadPermissions() {

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -54,7 +54,9 @@ const [Drawer, drawerApi] = useVbenDrawer({
       if (data) {
         formData.value = data;
         id.value = data.id;
-        formApi.setValues(data);
+        setTimeout(() => {
+          formApi.setValues(data);
+        }, 300);
       } else {
         id.value = undefined;
       }


### PR DESCRIPTION
## Description

角色修改时VbenTree组件没有回显选中项。
<img width="584" height="749" alt="image" src="https://github.com/user-attachments/assets/7a0b73c7-8a4e-44e4-8e95-ba65bb32cd48" />

针对form.vue `formApi.setValues(data);` 修改如下
```javascript
setTimeout(() => {
          formApi.setValues(data);
        }, 300);
```

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [√ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [√ ] Run the tests with `pnpm test`.
- [√] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [√] My code follows the style guidelines of this project
- [√] I have performed a self-review of my own code
- [√] I have commented my code, particularly in hard-to-understand areas
- [√] I have made corresponding changes to the documentation
- [√] My changes generate no new warnings
- [√] I have added tests that prove my fix is effective or that my feature works
- [√] New and existing unit tests pass locally with my changes
- [√] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role form drawer now waits until permissions and form fields are ready before populating, preventing flicker and timing issues.
  * Opening with existing data reliably resets the form and sets the record ID consistently.
  * Value population timing improved for more stable, predictable form behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->