### PR TITLE
feat: add global event bus based on Mitt

### DIFF
--- a/packages/@core/base/shared/package.json
+++ b/packages/@core/base/shared/package.json
@@ -89,6 +89,7 @@
     "lodash.get": "catalog:",
     "lodash.isequal": "catalog:",
     "lodash.set": "catalog:",
+    "mitt": "catalog:",
     "nprogress": "catalog:",
     "tailwind-merge": "catalog:",
     "theme-colors": "catalog:"

--- a/packages/@core/base/shared/src/utils/__tests__/event-bus.test.ts
+++ b/packages/@core/base/shared/src/utils/__tests__/event-bus.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { emitEvent, offEvent, onEvent } from '../event-bus';
+
+describe('event Bus', () => {
+  beforeEach(() => {
+    // 清除所有模拟函数调用记录
+    vi.clearAllMocks();
+  });
+
+  it('should trigger event handler when event is emitted', () => {
+    const testHandler = vi.fn();
+    const testData = { message: 'test' };
+
+    onEvent('test-event', testHandler);
+    emitEvent('test-event', testData);
+
+    expect(testHandler).toHaveBeenCalledTimes(1);
+    expect(testHandler).toHaveBeenCalledWith(testData);
+  });
+
+  it('should not trigger handler after it is removed', () => {
+    const testHandler = vi.fn();
+
+    onEvent('test-event', testHandler);
+    offEvent('test-event', testHandler);
+    emitEvent('test-event');
+
+    expect(testHandler).not.toHaveBeenCalled();
+  });
+
+  it('should support multiple handlers for the same event', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const testData = 'multiple handlers';
+
+    onEvent('multi-event', handler1);
+    onEvent('multi-event', handler2);
+    emitEvent('multi-event', testData);
+
+    expect(handler1).toHaveBeenCalledWith(testData);
+    expect(handler2).toHaveBeenCalledWith(testData);
+  });
+
+  it('should only remove specific handler when multiple exist', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    onEvent('remove-specific', handler1);
+    onEvent('remove-specific', handler2);
+    offEvent('remove-specific', handler1);
+    emitEvent('remove-specific');
+
+    expect(handler1).not.toHaveBeenCalled();
+    expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle events with different data types', () => {
+    const dataHandler = vi.fn();
+
+    onEvent('data-types', dataHandler);
+
+    emitEvent('data-types', 'string');
+    emitEvent('data-types', 123);
+    emitEvent('data-types', true);
+    emitEvent('data-types', { key: 'value' });
+    emitEvent('data-types', [1, 2, 3]);
+
+    expect(dataHandler).toHaveBeenCalledTimes(5);
+    expect(dataHandler).toHaveBeenNthCalledWith(1, 'string');
+    expect(dataHandler).toHaveBeenNthCalledWith(2, 123);
+    expect(dataHandler).toHaveBeenNthCalledWith(3, true);
+    expect(dataHandler).toHaveBeenNthCalledWith(4, { key: 'value' });
+    expect(dataHandler).toHaveBeenNthCalledWith(5, [1, 2, 3]);
+  });
+});

--- a/packages/@core/base/shared/src/utils/event-bus.ts
+++ b/packages/@core/base/shared/src/utils/event-bus.ts
@@ -1,0 +1,21 @@
+import type { EventType } from 'mitt';
+
+import mitt from 'mitt';
+
+export type EventKey = EventType;
+
+const eventBus = mitt();
+
+const emitEvent = (key: EventKey, data?: any) => {
+  eventBus.emit(key, data);
+};
+
+const onEvent = (key: EventKey, handler: (data?: any) => void) => {
+  eventBus.on(key, handler);
+};
+
+const offEvent = (key: EventKey, handler: (data?: any) => void) => {
+  eventBus.off(key, handler);
+};
+
+export { emitEvent, offEvent, onEvent };

--- a/packages/@core/base/shared/src/utils/index.ts
+++ b/packages/@core/base/shared/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './date';
 export * from './diff';
 export * from './dom';
 export * from './download';
+export * from './event-bus';
 export * from './inference';
 export * from './letter';
 export * from './merge';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ catalogs:
     medium-zoom:
       specifier: ^1.1.0
       version: 1.1.0
+    mitt:
+      specifier: ^3.0.1
+      version: 3.0.1
     naive-ui:
       specifier: ^2.42.0
       version: 2.42.0
@@ -1258,6 +1261,9 @@ importers:
       lodash.set:
         specifier: 'catalog:'
         version: 4.3.2
+      mitt:
+        specifier: 'catalog:'
+        version: 3.0.1
       nprogress:
         specifier: 'catalog:'
         version: 0.2.0
@@ -10374,6 +10380,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,6 +124,7 @@ catalog:
   lodash.set: ^4.3.2
   lucide-vue-next: ^0.507.0
   medium-zoom: ^1.1.0
+  mitt: ^3.0.1
   naive-ui: ^2.42.0
   nitropack: ^2.11.13
   nprogress: ^0.2.0


### PR DESCRIPTION
feat: add global event bus based on Mitt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a lightweight event bus utility for app-wide event publishing and subscription, enabling emit, listen, and unsubscribe flows. Available via the shared utils package.

- Tests
  - Added comprehensive unit tests covering event emission, multiple listeners, handler removal, and diverse payload types.

- Chores
  - Added a new lightweight event emitter dependency to the shared base package.
  - Updated workspace catalog to include the new dependency.
  - Exposed the event bus through the utils barrel for easier consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->