### PR TITLE
fix(@vben-core/form-ui): 支持object类型值的合并

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-api.ts
+++ b/packages/@core/ui-kit/form-ui/src/form-api.ts
@@ -343,10 +343,11 @@ export class FormApi {
             isObject(value)) { // 添加对 value 也是对象的检查
           // 递归合并对象
           fieldMergeFn(obj[key], value);
+          return false;
         } else {
           obj[key] = value; // 直接赋值
+          return true;
         }
-        return false; // 返回 false 表示已经处理，不需要默认合并
       }
       return true;
     });


### PR DESCRIPTION
修复 FormApi.setValues 函数 values 多层嵌套 object 时无法合并导致依然是默认值的问题

## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More predictable form value updates: deep-merge now only happens when the incoming value is an object, preventing unintended merges so primitives and non-object values fully replace existing entries; array and date handling unchanged.

* **Refactor**
  * Streamlined internal merge logic for form updates without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->