### PR TITLE
fix: form-api解析fieldMappingTime结果时支持多级路径转换

### DIFF
--- a/playground/src/views/examples/form/basic.vue
+++ b/playground/src/views/examples/form/basic.vue
@@ -43,7 +43,7 @@ const [BaseForm, baseFormApi] = useVbenForm({
       class: 'w-full',
     },
   },
-  fieldMappingTime: [['rangePicker', ['startTime', 'endTime'], 'YYYY-MM-DD']],
+  fieldMappingTime: [['rangePicker', ['startTime', 'endTime'], 'YYYY-MM-DD'], ['rangePicker2', ['createTimeQuery.startTime', 'createTimeQuery.endTime'], 'YYYY-MM-DD HH:mm:ss']],
   // 提交函数
   handleSubmit: onSubmit,
   handleValuesChange(_values, fieldsChanged) {
@@ -280,6 +280,17 @@ const [BaseForm, baseFormApi] = useVbenForm({
       component: 'RangePicker',
       fieldName: 'rangePicker',
       label: '范围选择器',
+    },
+    {
+      component: 'RangePicker',
+      fieldName: 'rangePicker2',
+      componentProps: {
+        showTime: true,
+        format: 'YYYY-MM-DD HH:mm:ss',
+        valueFormat: 'YYYY-MM-DD HH:mm:ss',
+        placeholder: ['开始日期', '结束日期'],
+      },
+      label: '时间范围选择器',
     },
     {
       component: 'TimePicker',


### PR DESCRIPTION
1、form-api解析fieldMappingTime结果时支持多级路径转换
2、增加demo示例
3、数据转换示例：
fieldMappingTime: [
    [
      'createTimeRange',
      ['createTimeQuery.beginTime', 'createTimeQuery.endTime'],
      'YYYY-MM-DD HH:mm:ss',
    ]
  ]  转换示例 createTimeQuery: {
            beginTime: '2025-09-24 13:41:30',
            endTime: '2025-09-28 13:41:31',
          }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Form time-range mapping now supports nested keys (dot paths), allowing start/end times to be written to or removed from nested objects.
  * More robust handling of empty values and multiple formatting options (raw, function-based, and string/array formats), preserving undefined where appropriate.

* Documentation
  * Example form updated with a second time-range picker demonstrating nested key mapping and explicit date-time formatting (YYYY-MM-DD HH:mm:ss).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->