### PR TITLE
fix: 混合双列 onMounted 关闭二级侧边栏

### DIFF
--- a/packages/effects/layouts/src/basic/layout.vue
+++ b/packages/effects/layouts/src/basic/layout.vue
@@ -158,7 +158,9 @@ function clickLogo() {
 function autoCollapseMenuByRouteMeta(route: RouteLocationNormalizedLoaded) {
   // 只在双列模式下生效
   if (
-    preferences.app.layout === 'sidebar-mixed-nav' &&
+    ['header-mixed-nav', 'sidebar-mixed-nav'].includes(
+      preferences.app.layout,
+    ) &&
     route.meta &&
     route.meta.hideInMenu
   ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected auto-collapse behavior in mixed-navigation layouts. The sidebar now automatically collapses when using either header-mixed-nav or sidebar-mixed-nav, aligning behavior across layout variants and improving responsiveness on smaller viewports.
  * No changes to configuration or other layout interactions; existing behavior remains the same elsewhere.
  * Ensures a more predictable navigation experience when switching between mixed-nav layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->