### PR TITLE
fix: 个人中心在后端权限模式打不开

### DIFF
--- a/playground/src/router/routes/core.ts
+++ b/playground/src/router/routes/core.ts
@@ -36,7 +36,18 @@ const coreRoutes: RouteRecordRaw[] = [
     name: 'Root',
     path: '/',
     redirect: preferences.app.defaultHomePath,
-    children: [],
+    children: [
+      {
+        name: 'Profile',
+        path: '/profile',
+        component: () => import('#/views/_core/profile/index.vue'),
+        meta: {
+          title: '个人中心',
+          icon: 'lucide:user',
+          hideInMenu: true, // 隐藏在菜单栏，但路由依然存在
+        },
+      },
+    ],
   },
   {
     component: AuthPageLayout,

--- a/playground/src/router/routes/modules/vben.ts
+++ b/playground/src/router/routes/modules/vben.ts
@@ -101,16 +101,6 @@ const routes: RouteRecordRaw[] = [
     name: 'VbenAbout',
     path: '/vben-admin/about',
   },
-  {
-    name: 'Profile',
-    path: '/profile',
-    component: () => import('#/views/_core/profile/index.vue'),
-    meta: {
-      icon: 'lucide:user',
-      hideInMenu: true,
-      title: $t('page.auth.profile'),
-    },
-  },
 ];
 
 export default routes;


### PR DESCRIPTION
issue: https://github.com/vbenjs/vue-vben-admin/issues/7133

问题: 个人中心, 切换到 后端访问模式 打不开, 切换到 前端访问模式 就可以打开.
分析: 所有登陆的人应该都能打开 个人中心, 那是他自己的信息维护.
解决方案: 将 /profile 路由的定义, 从 `router/routes/modules/vben.ts` 移入 `router/routes/modules/core.ts`, 然后就可以打开了.

讨论: 我觉得没必要 在 /menu/all 这个 api 给每个用户额外加个 profile 的 menu, 因为所有人都有. 所以直接改前端定义就好了.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal routing structure with no changes to user-facing functionality or accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->