### PR TITLE
fix: fix password input icon visual bug in certain browser

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/ui/input/Input.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/input/Input.vue
@@ -33,5 +33,16 @@ const modelValue = useVModel(props, 'modelValue', emits, {
 <style lang="scss" scoped>
 input {
   --ring: var(--primary);
+  
+  &::-ms-reveal,
+  &::-ms-clear {
+    display: none;
+  }
+
+  &::-webkit-credentials-auto-fill-button,
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
## Description

1.Use Edge browser to open https://naive.vben.pro/#/auth/login
2.clear password then input one character
3.results to this 
<img width="1916" height="985" alt="企业微信截图_17703465142050" src="https://github.com/user-attachments/assets/ceec8847-faf3-4a97-a368-52d0dc28d9ab" />


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [✅️ ] Run the tests with `pnpm test`.
- [ ✅️] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [✅️ ] My code follows the style guidelines of this project
- [ ✅️] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined input field styling to provide a cleaner, more consistent visual experience by streamlining the display of browser interface elements across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->