### PR TITLE
fix: fix bug where `renderEcharts` gets stuck in a dead loop

### DIFF
--- a/playground/src/router/routes/modules/dashboard.ts
+++ b/playground/src/router/routes/modules/dashboard.ts
@@ -20,6 +20,7 @@ const routes: RouteRecordRaw[] = [
           affixTab: true,
           icon: 'lucide:area-chart',
           title: $t('page.dashboard.analytics'),
+          keepAlive: true,
         },
       },
       {


### PR DESCRIPTION
 * 触发条件：echart所在页面开启keepalive 在其他页面切换颜色模式


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * ECharts instances now feature active state tracking for more efficient rendering and improved resource management.
  * Enhanced lifecycle-driven control ensures charts properly initialize and dispose based on component visibility and activity status.
  * Optimized Analytics dashboard route with keep-alive caching to improve page transition and navigation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->