### PR TITLE
fix: filter out the external onBlur of antdv-next TreeSelect

### DIFF
--- a/apps/web-antdv-next/src/adapter/component/index.ts
+++ b/apps/web-antdv-next/src/adapter/component/index.ts
@@ -86,8 +86,20 @@ const Textarea = defineAsyncComponent(
 const TimePicker = defineAsyncComponent(
   () => import('antdv-next/dist/time-picker/index'),
 );
-const TreeSelect = defineAsyncComponent(
-  () => import('antdv-next/dist/tree-select/index'),
+const TreeSelect = defineAsyncComponent(() =>
+  import('antdv-next/dist/tree-select/index').then((mod) => {
+    const Raw = mod.default;
+    return defineComponent({
+      name: 'TreeSelect',
+      inheritAttrs: false,
+      setup(_props: any, { attrs, slots }) {
+        return () => {
+          const { onBlur: _, ...restAttrs } = attrs;
+          return h(Raw, restAttrs, slots);
+        };
+      },
+    });
+  }),
 );
 const Cascader = defineAsyncComponent(
   () => import('antdv-next/dist/cascader/index'),


### PR DESCRIPTION
## Description

过滤掉外部的 onBlur，防止出现 Vue 道具类警告。antdv-next TreeSelect 内部使用 mergeProps，它会将外部和自身的 onBlur 合并成数组，从而触发警告

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TreeSelect component attribute handling and event forwarding to ensure proper inheritance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->