### PR TITLE
fix: 修复单列菜单和双列菜单侧边栏拖拽衍生问题

### DIFF
--- a/packages/@core/ui-kit/layout-ui/src/vben-layout.vue
+++ b/packages/@core/ui-kit/layout-ui/src/vben-layout.vue
@@ -247,9 +247,7 @@ const mainStyle = computed(() => {
       sidebarExtraVisible.value;
 
     if (isSideNavEffective) {
-      const sideCollapseWidth = sidebarCollapse.value
-        ? getSideCollapseWidth.value
-        : props.sidebarMixedWidth;
+      const sideCollapseWidth = props.sidebarMixedWidth;
       const sideWidth = sidebarExtraCollapse.value
         ? props.sidebarExtraCollapsedWidth
         : props.sidebarWidth;
@@ -258,10 +256,14 @@ const mainStyle = computed(() => {
       sidebarAndExtraWidth = `${sideCollapseWidth + sideWidth}px`;
       width = `calc(100% - ${sidebarAndExtraWidth})`;
     } else {
-      sidebarAndExtraWidth =
-        sidebarExpandOnHovering.value && !sidebarExpandOnHover.value
-          ? `${getSideCollapseWidth.value}px`
-          : `${getSidebarWidth.value}px`;
+      let sidebarWidth = getSidebarWidth.value;
+      if (sidebarExpandOnHovering.value && !sidebarExpandOnHover.value) {
+        sidebarWidth =
+          isSidebarMixedNav.value || isHeaderMixedNav.value
+            ? props.sidebarMixedWidth
+            : getSideCollapseWidth.value;
+      }
+      sidebarAndExtraWidth = `${sidebarWidth}px`;
       width = `calc(100% - ${sidebarAndExtraWidth})`;
     }
   }


### PR DESCRIPTION
**之前新增了侧边栏拖拽功能，后续使用时发现了几个小细节问题，一是原框架本身有的bug，如**
```
const getSideCollapseWidth = computed(() => {
  const { sidebarCollapseShowTitle, sidebarMixedWidth, sideCollapseWidth } =
    props;

  return sidebarCollapseShowTitle ||
    isSidebarMixedNav.value ||
    isHeaderMixedNav.value
    ? sidebarMixedWidth
    : sideCollapseWidth;
});
```
**这段代码，计算折叠宽度时，在双列布局时将折叠宽度设为sidebarMixedWidth：80px，这样在拖拽时就无法拖拽至设置的sidebarExtraCollapsedWidth：60px，所以上述代码已在之前修复，将 sidebarMixedWidth 改成了 sidebarExtraCollapsedWidth：**

```
const getSideCollapseWidth = computed(() => {
  const {
    sidebarCollapseShowTitle,
    sidebarExtraCollapsedWidth,
    sideCollapseWidth,
  } = props;

  return sidebarCollapseShowTitle ||
    isSidebarMixedNav.value ||
    isHeaderMixedNav.value
    ? sidebarExtraCollapsedWidth
    : sideCollapseWidth;
});
```

**但是上述代码再修改后就会衍生出几个问题，下面就是针对上述问题做出的修复调整，具体调整代码见提交的packages/@core/ui-kit/layout-ui/src/components/layout-sidebar.vue 和 packages/@core/ui-kit/layout-ui/src/vben-layout.vue 两个文件：**

**1、修复双列菜单布局时侧边栏拖拽线条位置显示bug**

- 修复前：拖拽线条可以拖拽到图示位置，少计算了双列布局的第一栏宽度

<img width="419" height="928" alt="image" src="https://github.com/user-attachments/assets/417d2731-8e55-4844-acf8-ad562d9c0ba0" />

- 修复后：拖拽线条只能拖拽到折叠宽度的位置，然后自动折叠

<img width="230" height="921" alt="image" src="https://github.com/user-attachments/assets/326c6bec-6ffe-4324-b1ee-7d63a6b1d816" />

**2、修复单列菜单和双列菜单切换时width计算导致侧边栏宽度显示异常问题**

- 修复前：单列菜单布局将宽度拖拽至折叠位置且自动折叠后，再在首选项中切换成双列菜单布局，此时双列菜单的第一列宽度会变成折叠宽度60px，而非mixedWidth: 80px，使得第一列视觉效果差

<img width="161" height="928" alt="image" src="https://github.com/user-attachments/assets/ef7a0d92-6d31-4b70-ae4d-b0c0c5ff6ce7" />

- 修复后：单列菜单布局将宽度拖拽至折叠位置且自动折叠后，再在首选项中切换成双列菜单布局，双列菜单第一列显示正常

<img width="193" height="921" alt="image" src="https://github.com/user-attachments/assets/202b9695-6e6d-45ec-9ff2-e33599406e51" />

**3、新增单列菜单和双列菜单侧边栏菜单折叠状态同步**

- 修复前：单列菜单布局将宽度拖拽至折叠位置且自动折叠后，再在首选项中切换成双列菜单布局，此时双列菜单的第二列宽度也是之前的单列菜单栏宽度（菜单栏宽度状态共享），但并非折叠状态，视觉效果较差，同理双列菜单拖拽至菜单栏折叠后，再切换布局到单列菜单布局，也是相同的情况

<img width="154" height="799" alt="image" src="https://github.com/user-attachments/assets/3e6b5349-a171-4449-97c7-4490f1a8815d" />


<img width="74" height="869" alt="image" src="https://github.com/user-attachments/assets/4259b9c7-009a-40dc-89ba-c21ff0b32774" />

- 修复后：菜单栏折叠时，不管单列菜单布局切换双列菜单布局，还是双列菜单布局切换到单列菜单布局，都达到状态共享，视觉效果同步

<img width="166" height="591" alt="image" src="https://github.com/user-attachments/assets/557549aa-30d7-4343-b4d6-5e179910b2f3" />


<img width="71" height="466" alt="image" src="https://github.com/user-attachments/assets/78153656-5dbf-4ab4-9262-337564c3ba3b" />

二是单列菜单和双列菜单不同布局情况时，拖拽线条位置计算位置修复，拖拽最小宽度、拖拽最大宽度、拖拽起始宽度，都需进行isSidebarMixed判断，且onDrag方法回调时也需判断(newWidth) => { if (isSidebarMixed) { ... } else { ... }}

```
const handleDragSidebar = (e: MouseEvent) => {
  const { isSidebarMixed, collapseWidth, extraWidth, width } = props;
  const minLimit = isSidebarMixed ? width + collapseWidth : collapseWidth;
  const maxLimit = isSidebarMixed ? width + 320 : 320;
  const startWidth = isSidebarMixed ? width + extraWidth : width;

  startDrag(
    e,
    {
      min: minLimit,
      max: maxLimit,
      startWidth,
    },
    {
      target: asideRef.value,
      dragBar: dragBarRef.value,
    },
    (newWidth) => {
      if (isSidebarMixed) {
        emit('update:width', newWidth - width);
        extraCollapse.value = collapse.value =
          newWidth - width <= collapseWidth;
      } else {
        emit('update:width', newWidth);
        collapse.value = extraCollapse.value = newWidth <= collapseWidth;
      }
    },
  );
};
```


## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sidebar drag behavior and width calculations in mixed layout mode.
  * Fixed content width computation for consistent layout spacing across different navigation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->