### PR TITLE
fix(@vben/oxfmt-config): rename oxfmtConfig export to defaultOxfmtConfig

### DIFF
--- a/internal/lint-configs/oxfmt-config/src/index.ts
+++ b/internal/lint-configs/oxfmt-config/src/index.ts
@@ -2,7 +2,7 @@ import { defineConfig as defineOxfmtConfig } from 'oxfmt';
 
 type OxfmtConfig = Parameters<typeof defineOxfmtConfig>[0];
 
-const oxfmtConfig: OxfmtConfig = defineOxfmtConfig({
+const defaultOxfmtConfig: OxfmtConfig = defineOxfmtConfig({
   printWidth: 80,
   proseWrap: 'never',
   semi: true,
@@ -30,10 +30,10 @@ const oxfmtConfig: OxfmtConfig = defineOxfmtConfig({
 
 function defineConfig(config: OxfmtConfig = {}): OxfmtConfig {
   return defineOxfmtConfig({
-    ...oxfmtConfig,
+    ...defaultOxfmtConfig,
     ...config,
   });
 }
 
-export { defineConfig, oxfmtConfig };
+export { defaultOxfmtConfig, defineConfig };
 export type { OxfmtConfig };


### PR DESCRIPTION
## Description

This change renames the exported preset config in `@vben/oxfmt-config` from `oxfmtConfig` to `defaultOxfmtConfig`.

Previously, the package exported the `OxfmtConfig` type and the `oxfmtConfig` value, which differ only by case. That can cause compiler or auto-import issues in some tooling and makes the public API less clear.

Renaming the value export avoids the case-only collision and aligns the naming with the repository's existing `default*` config style.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed configuration export to reflect default configuration naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->