### PR TITLE
feat(common-ui): add labelFn support to ApiComponent

### DIFF
--- a/packages/effects/common-ui/src/components/api-component/api-component.vue
+++ b/packages/effects/common-ui/src/components/api-component/api-component.vue
@@ -17,6 +17,7 @@ defineOptions({ name: 'ApiComponent', inheritAttrs: false });
 const props = withDefaults(defineProps<ApiComponentProps>(), {
   labelField: 'label',
   valueField: 'value',
+  labelFn: undefined,
   disabledField: 'disabled',
   childrenField: '',
   optionsPropName: 'options',
@@ -54,33 +55,37 @@ const hasPendingRequest = ref(false);
 const getOptions = computed(() => {
   const {
     labelField,
+    labelFn,
     valueField,
     disabledField,
     childrenField,
     numberToString,
   } = props;
 
-  const refOptionsData = unref(refOptions);
-
-  function transformData(data: OptionsItem[]): OptionsItem[] {
+  function transformData(data: OptionsItem[] = []): OptionsItem[] {
     return data.map((item) => {
       const value = get(item, valueField);
-      const disabled = get(item, disabledField);
+      const children = childrenField ? item[childrenField] : item.children;
       return {
-        ...objectOmit(item, [labelField, valueField, disabled, childrenField]),
-        label: get(item, labelField),
+        ...objectOmit(item, [
+          labelField,
+          valueField,
+          disabledField,
+          ...(childrenField ? [childrenField] : []),
+        ]),
+        label: labelFn ? labelFn(item) : get(item, labelField),
         value: numberToString ? `${value}` : value,
         disabled: get(item, disabledField),
-        ...(childrenField && item[childrenField]
-          ? { children: transformData(item[childrenField]) }
+        ...(Array.isArray(children) && children.length > 0
+          ? { children: transformData(children) }
           : {}),
       };
     });
   }
 
-  const data: OptionsItem[] = transformData(refOptionsData);
+  const data = transformData(unref(refOptions));
 
-  return data.length > 0 ? data : props.options;
+  return data.length > 0 ? data : transformData(props.options);
 });
 
 const bindProps = computed(() => {

--- a/packages/effects/common-ui/src/components/api-component/api-component.vue
+++ b/packages/effects/common-ui/src/components/api-component/api-component.vue
@@ -65,7 +65,7 @@ const getOptions = computed(() => {
   function transformData(data: OptionsItem[] = []): OptionsItem[] {
     return data.map((item) => {
       const value = get(item, valueField);
-      const children = childrenField ? item[childrenField] : item.children;
+      const children = childrenField ? get(item, childrenField) : item.children;
       return {
         ...objectOmit(item, [
           labelField,

--- a/packages/effects/common-ui/src/components/api-component/index.ts
+++ b/packages/effects/common-ui/src/components/api-component/index.ts
@@ -1,5 +1,6 @@
 export { default as ApiComponent } from './api-component.vue';
 export type {
+  ApiComponentLabelFn,
   ApiComponentOptionsItem,
   ApiComponentProps,
   ApiComponentSharedProps,

--- a/packages/effects/common-ui/src/components/api-component/types.ts
+++ b/packages/effects/common-ui/src/components/api-component/types.ts
@@ -10,6 +10,8 @@ export type ApiComponentOptionsItem = {
   value?: number | string;
 };
 
+export type ApiComponentLabelFn = (item: ApiComponentOptionsItem) => string;
+
 export interface ApiComponentProps {
   /** 组件 */
   component: Component;
@@ -23,6 +25,8 @@ export interface ApiComponentProps {
   resultField?: string;
   /** label字段名 */
   labelField?: string;
+  /** 通过选项数据自定义label */
+  labelFn?: ApiComponentLabelFn;
   /** children字段名，需要层级数据的组件可用 */
   childrenField?: string;
   /** value字段名 */


### PR DESCRIPTION
 ## Summary

  Add `labelFn` support to `ApiComponent` so consumers can derive option labels from
  the full option record instead of being limited to a single `labelField`.

  ## Changes

  - add `labelFn` to `ApiComponentProps`
  - update `ApiComponent` option normalization to:
    - prefer `labelFn(item)` when provided
    - fall back to `labelField` when `labelFn` is not provided
  - normalize direct `options` with the same transform path as API-loaded options
  - export `ApiComponentLabelFn` type

  ## Why

  Some option sources need labels composed from multiple fields, for example:

  - `code + name`
  - `id + title`
  - nested option display text assembled from custom business fields

  Using `labelFn` keeps this logic at the component boundary and avoids requiring
  callers to pre-transform every option list.

  ## Example

  ```ts
  componentProps: {
    labelFn: (item) => `${item.code} - ${item.name}`,
    valueField: 'id',
  }
  ```
  ## Verification

  - pnpm exec eslint packages/effects/common-ui/src/components/api-component/api-component.vue packages/effects/common-ui/src/
    components/api-component/index.ts packages/effects/common-ui/src/components/api-component/types.ts
  - pnpm exec vue-tsc --noEmit -p packages/effects/common-ui/tsconfig.json

  ## Notes

  - existing labelField behavior is preserved as the fallback path
  - no new wrapper component was introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `labelFn` prop to the API component to allow custom label generation from option items.

* **Bug Fixes & Improvements**
  * More robust handling of empty/missing option data and children to avoid broken or inconsistent option trees.
  * Ensures fetched and fallback options are consistently transformed for predictable output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->