### PR TITLE
fix: update selector for active menu item in useMenuScroll hook

### DIFF
--- a/packages/@core/ui-kit/menu-ui/src/hooks/use-menu-scroll.ts
+++ b/packages/@core/ui-kit/menu-ui/src/hooks/use-menu-scroll.ts
@@ -20,7 +20,7 @@ export function useMenuScroll(
     if (!isEnabled) return;
 
     const activeElement = document.querySelector(
-      `aside li[role=menuitem].is-active`,
+      `aside a[role=menuitem].is-active`,
     );
     if (activeElement) {
       activeElement.scrollIntoView({


### PR DESCRIPTION
## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

The menu item's root element changed from `<li>` to `<a>`, but `useMenuScroll.ts` still uses the selector `aside li[role=menuitem].is-active` to find the active menu item. Since the element is now an `<a>` tag, this `querySelector` call will never match, and the `scrollToActive` feature silently stops working.

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
