### PR TITLE
fix: 修复 IconPicker 对 v-model 的同步支持

### DIFF
--- a/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
+++ b/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
@@ -147,6 +147,9 @@ const searchInputProps = computed(() => {
 
 function updateCurrentSelect(v: string) {
   currentSelect.value = v;
+  if (props.modelValueProp === 'modelValue') {
+    modelValue.value = v;
+  }
   const eventKey = `onUpdate:${props.modelValueProp}`;
   if (attrs[eventKey] && isFunction(attrs[eventKey])) {
     attrs[eventKey](v);


### PR DESCRIPTION
## Description

`IconPicker` 组件在设计时通过 `$attrs` 动态代理内部输入组件的更新事件。但在 Vue 3 中，由于 `IconPicker` 已经通过 `defineModel` 声明了 `modelValue`，导致 `onUpdate:modelValue` 事件会从 `$attrs` 中被移除。
这导致了以下现象：
- 当内部使用 `v-model:value`（如 Ant Design）时，更新依然通过 `$attrs` 生效。
- 当内部使用标准的 `v-model`（如 Element Plus 的 `Input` 组件）时，由于属性名是 `modelValue`，更新逻辑因在 `$attrs` 中找不到对应的事件处理函数而失效，导致手动输入无法同步到表单。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon picker component to properly synchronize internal values when using model binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->