### PR TITLE
fix(deploy): use IMAGE_NAME variable in remove_image instead of hardcoded name

### DIFF
--- a/scripts/deploy/build-local-docker-image.sh
+++ b/scripts/deploy/build-local-docker-image.sh
@@ -13,7 +13,7 @@ function stop_and_remove_container() {
 
 function remove_image() {
     # Remove the existing image
-    docker rmi vben-admin-pro >/dev/null 2>&1
+    docker rmi ${IMAGE_NAME} >/dev/null 2>&1
 }
 
 function install_dependencies() {


### PR DESCRIPTION
## Summary

- `remove_image` was calling `docker rmi vben-admin-pro` (hardcoded), but the script defines `IMAGE_NAME="vben-admin-local"` and `build_image` builds with that variable
- This means the old local image was never cleaned up before each rebuild
- Fix: replace the hardcoded string with `${IMAGE_NAME}`

## Change

```diff
-    docker rmi vben-admin-pro >/dev/null 2>&1
+    docker rmi ${IMAGE_NAME} >/dev/null 2>&1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker build script consistency for more reliable deployment workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vbenjs/vue-vben-admin/pull/7907)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->