### PR TITLE
fix: preserve tree default value when treeData starts empty

### DIFF
--- a/.changeset/tree-default-value.md
+++ b/.changeset/tree-default-value.md
@@ -1,0 +1,5 @@
+---
+"@vben-core/shadcn-ui": patch
+---
+
+fix: preserve tree default value when treeData starts empty

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
@@ -70,7 +70,9 @@ let lastTreeData: any = null;
 onMounted(() => {
   watchEffect(() => {
     flattenData.value = flatten(props.treeData, props.childrenField);
-    updateTreeValue();
+    if (flattenData.value.length > 0) {
+      updateTreeValue();
+    }
 
     // 只在 treeData 变化时执行展开
     const currentTreeData = JSON.stringify(props.treeData);


### PR DESCRIPTION
## Description

When `treeData` is initially empty while async data is loading, `updateTreeValue()` can clear `modelValue` before the real tree nodes are available. This preserves the default value until flattened tree data exists.

Fixes #6522

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the tree component's default value was not being preserved when the tree data initially starts empty.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vbenjs/vue-vben-admin/pull/7908)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->