### PR TITLE
fix: guard svg icon loading during docs SSR

### DIFF
--- a/.changeset/small-moons-hunt.md
+++ b/.changeset/small-moons-hunt.md
@@ -1,0 +1,5 @@
+---
+"@vben/icons": patch
+---
+
+fix: guard svg icon loading during docs SSR

--- a/packages/icons/src/svg/load.ts
+++ b/packages/icons/src/svg/load.ts
@@ -53,6 +53,14 @@ function parseSvg(svgData: string): IconifyIconStructure {
  * <Icon icon="svg:avatar"></Icon>
  */
 async function loadSvgIcons() {
+  if (
+    typeof DOMParser === 'undefined' ||
+    typeof Node === 'undefined' ||
+    typeof XMLSerializer === 'undefined'
+  ) {
+    return;
+  }
+
   const svgEagers = import.meta.glob('./icons/**', {
     eager: true,
     query: '?raw',


### PR DESCRIPTION
### Summary

While investigating the CI failures on related vue-vben-admin PRs, I found that the docs build was crashing during SSR because packages/icons/src/svg/load.ts eagerly uses DOMParser. In a Node.js SSR environment, DOMParser is not available, so VitePress failed while rendering pages.

### What changed

- Added an SSR guard in packages/icons/src/svg/load.ts so SVG icon loading is skipped when browser DOM APIs are unavailable
- Kept browser behavior unchanged
- Added a patch changeset for @vben/icons`n
### Validation

- Ran pnpm run build:docs successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SVG icon loading to properly handle server-side rendering environments where DOM APIs are unavailable, preventing errors during documentation builds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vbenjs/vue-vben-admin/pull/7912)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->