### PR TITLE
fix(@vben/plugins): 修复 tiptap 重复注册扩展警告

### DIFF
--- a/packages/effects/plugins/src/tiptap/extensions.ts
+++ b/packages/effects/plugins/src/tiptap/extensions.ts
@@ -9,14 +9,12 @@ import { $t } from '@vben/locales';
 
 import { alert } from '@vben-core/popup-ui';
 
-import Document from '@tiptap/extension-document';
 import Highlight from '@tiptap/extension-highlight';
 import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import TextAlign from '@tiptap/extension-text-align';
 import { Color, TextStyle } from '@tiptap/extension-text-style';
-import Underline from '@tiptap/extension-underline';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import StarterKit from '@tiptap/starter-kit';
 
@@ -274,30 +272,30 @@ function createCustomImage(
         ...this.parent?.(),
         uploadImage:
           () =>
-          ({ editor: cmdEditor }: { editor: CoreEditor }) => {
-            const input = document.createElement('input');
-            input.type = 'file';
-            input.accept = imageUpload.accept ?? DEFAULT_ACCEPT;
-            input.style.display = 'none';
+            ({ editor: cmdEditor }: { editor: CoreEditor }) => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.accept = imageUpload.accept ?? DEFAULT_ACCEPT;
+              input.style.display = 'none';
 
-            input.addEventListener('change', () => {
-              const file = input.files?.[0];
-              if (!file) return;
+              input.addEventListener('change', () => {
+                const file = input.files?.[0];
+                if (!file) return;
 
-              const error = validateFile(file, imageUpload);
-              if (error) {
-                handleUploadError(new Error(error), imageUpload);
-                return;
-              }
+                const error = validateFile(file, imageUpload);
+                if (error) {
+                  handleUploadError(new Error(error), imageUpload);
+                  return;
+                }
 
-              createUploadProcess(cmdEditor, file, imageUpload, blobUrlTracker);
-              input.remove();
-            });
+                createUploadProcess(cmdEditor, file, imageUpload, blobUrlTracker);
+                input.remove();
+              });
 
-            document.body.append(input);
-            input.click();
-            return true;
-          },
+              document.body.append(input);
+              input.click();
+              return true;
+            },
       };
     },
 
@@ -405,13 +403,12 @@ export function createDefaultTiptapExtensions(
   options: VbenTiptapExtensionOptions = {},
 ): Extensions {
   return [
-    Document,
     StarterKit.configure({
       heading: {
         levels: [1, 2, 3, 4],
       },
+      link: false,
     }),
-    Underline,
     TextAlign.configure({
       types: ['heading', 'paragraph'],
     }),
@@ -431,20 +428,20 @@ export function createDefaultTiptapExtensions(
     }),
     options.imageUpload
       ? createCustomImage(
-          options.imageUpload,
-          options._blobUrlTracker,
-        ).configure({
-          allowBase64: true,
-          HTMLAttributes: {
-            class: 'vben-tiptap__image',
-          },
-        })
+        options.imageUpload,
+        options._blobUrlTracker,
+      ).configure({
+        allowBase64: true,
+        HTMLAttributes: {
+          class: 'vben-tiptap__image',
+        },
+      })
       : Image.configure({
-          allowBase64: true,
-          HTMLAttributes: {
-            class: 'vben-tiptap__image',
-          },
-        }),
+        allowBase64: true,
+        HTMLAttributes: {
+          class: 'vben-tiptap__image',
+        },
+      }),
     Placeholder.configure({
       placeholder: options.placeholder ?? $t('ui.tiptap.placeholder'),
     }),


### PR DESCRIPTION
StarterKit v3.22.0 已默认包含 Document、Link、Underline 扩展，与单独导入产生重复注册，导致控制台警告：
[tiptap warn]: Duplicate extension names found: ['link', 'doc', 'underline']

- 移除 Document 单独导入和使用，StarterKit 已内置
- 移除 Underline 单独导入和使用，StarterKit 已内置
- StarterKit 配置中添加 link: false，禁用内置 Link，保留自定义配置的 Link.configure({...})

## Description

tiptap StarterKit v3.22.0 默认包含 Document、Link、Underline 扩展，代码中又单独导入了这些扩展，导致重复注册，产生控制台警告：`[tiptap warn]: Duplicate extension names found: ['link', 'doc', 'underline']`。

修复方式：
- 移除 `@tiptap/extension-document` 的导入和 `Document` 的使用，StarterKit 已内置
- 移除 `@tiptap/extension-underline` 的导入和 `Underline` 的使用，StarterKit 已内置
- 在 `StarterKit.configure()` 中添加 `link: false` 禁用内置 Link 扩展，保留自定义配置的 `Link.configure({...})`，以支持 autolink、defaultProtocol 等自定义选项

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rich text editor extension configuration to adjust available formatting options.
  * Modified image upload and styling implementation for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vbenjs/vue-vben-admin/pull/7917)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->