### PR TITLE
fix: preferences-button click to show setting drawer

### DIFF
--- a/packages/effects/layouts/src/widgets/preferences/preferences-button.vue
+++ b/packages/effects/layouts/src/widgets/preferences/preferences-button.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { ref } from 'vue';
+
 import { Settings } from '@vben/icons';
 
 import { VbenIconButton } from '@vben-core/shadcn-ui';
@@ -10,10 +12,13 @@ const emit = defineEmits<{ clearPreferencesAndLogout: [] }>();
 function clearPreferencesAndLogout() {
   emit('clearPreferencesAndLogout');
 }
+
+const preferencesRef = ref<InstanceType<typeof Preferences> | null>(null);
+
 </script>
 <template>
-  <Preferences @clear-preferences-and-logout="clearPreferencesAndLogout">
-    <VbenIconButton class="hover:animate-[shrink_0.3s_ease-in-out]">
+  <Preferences ref="preferencesRef" @clear-preferences-and-logout="clearPreferencesAndLogout">
+    <VbenIconButton class="hover:animate-[shrink_0.3s_ease-in-out]" @click="preferencesRef?.open();">
       <Settings class="size-4 text-foreground" />
     </VbenIconButton>
   </Preferences>


### PR DESCRIPTION
## Description

fix the newest brand of vben can't open the seeting drawer by click preferemces-button

## Type of change

Please delete options that are not relevant.

- [ √ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [√ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ √] Run the tests with `pnpm test`.
- [ √] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [√ ] My code follows the style guidelines of this project
- [ √] I have performed a self-review of my own code
- [√ ] I have commented my code, particularly in hard-to-understand areas
- [√ ] I have made corresponding changes to the documentation
- [√ ] My changes generate no new warnings
- [√ ] I have added tests that prove my fix is effective or that my feature works
- [ √] New and existing unit tests pass locally with my changes
- [ √] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal implementation of the preferences button to better handle opening the preferences panel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vbenjs/vue-vben-admin/pull/7938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->