### PR TITLE
feat: 偏好设置的快捷键列表追加ESC快捷键的控制（关闭当前窗口）

### DIFF
--- a/packages/@core/preferences/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/@core/preferences/__tests__/__snapshots__/config.test.ts.snap
@@ -75,7 +75,7 @@ exports[`defaultPreferences immutability test > should not modify the config obj
   },
   "shortcutKeys": {
     "enable": true,
-    "globalEscape": true,
+    "globalEscape": false,
     "globalLockScreen": true,
     "globalLogout": true,
     "globalPreferences": true,

--- a/packages/@core/preferences/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/@core/preferences/__tests__/__snapshots__/config.test.ts.snap
@@ -75,6 +75,7 @@ exports[`defaultPreferences immutability test > should not modify the config obj
   },
   "shortcutKeys": {
     "enable": true,
+    "globalEscape": true,
     "globalLockScreen": true,
     "globalLogout": true,
     "globalPreferences": true,

--- a/packages/@core/preferences/src/config.ts
+++ b/packages/@core/preferences/src/config.ts
@@ -76,6 +76,7 @@ const defaultPreferences: Preferences = {
   },
   shortcutKeys: {
     enable: true,
+    globalEscape: true,
     globalLockScreen: true,
     globalLogout: true,
     globalPreferences: true,

--- a/packages/@core/preferences/src/config.ts
+++ b/packages/@core/preferences/src/config.ts
@@ -76,7 +76,7 @@ const defaultPreferences: Preferences = {
   },
   shortcutKeys: {
     enable: true,
-    globalEscape: true,
+    globalEscape: false,
     globalLockScreen: true,
     globalLogout: true,
     globalPreferences: true,

--- a/packages/@core/preferences/src/preferences.ts
+++ b/packages/@core/preferences/src/preferences.ts
@@ -135,7 +135,7 @@ class PreferenceManager {
     const cachedPreferences = (await this.loadFromCache()) || {};
     const mergedPreference = merge(
       {},
-      cachedPreferences,       // 用户缓存的设置优先
+      cachedPreferences, // 用户缓存的设置优先
       this.initialPreferences, // 初始设置仅补齐缺失字段
     );
 

--- a/packages/@core/preferences/src/types.ts
+++ b/packages/@core/preferences/src/types.ts
@@ -277,6 +277,8 @@ interface SidebarPreferences {
 interface ShortcutKeyPreferences {
   /** 是否启用快捷键-全局 */
   enable: boolean;
+  /** 是否启用全局关闭窗口快捷键 */
+  globalEscape: boolean;
   /** 是否启用全局锁屏快捷键 */
   globalLockScreen: boolean;
   /** 是否启用全局注销快捷键 */

--- a/packages/@core/preferences/src/use-preferences.ts
+++ b/packages/@core/preferences/src/use-preferences.ts
@@ -185,6 +185,14 @@ function usePreferences() {
     return enable && globalLogout;
   });
 
+  /**
+   * @zh_CN 是否启用全局注销快捷键
+   */
+  const globalEscapeShortcutKey = computed(() => {
+    const { enable, globalEscape } = shortcutKeysPreferences.value;
+    return enable && globalEscape;
+  });
+
   const globalLockScreenShortcutKey = computed(() => {
     const { enable, globalLockScreen } = shortcutKeysPreferences.value;
     return enable && globalLockScreen;
@@ -247,6 +255,7 @@ function usePreferences() {
     diffCustomPreference,
     globalLockScreenShortcutKey,
     globalLogoutShortcutKey,
+    globalEscapeShortcutKey,
     globalSearchShortcutKey,
     isDark,
     isFullContent,

--- a/packages/@core/preferences/src/use-preferences.ts
+++ b/packages/@core/preferences/src/use-preferences.ts
@@ -39,7 +39,7 @@ function usePreferences() {
   });
 
   const locale = computed(() => {
-    return preferences.app.locale;
+    return appPreferences.value.locale;
   });
 
   const isMobile = computed(() => {
@@ -274,6 +274,7 @@ function usePreferences() {
     preferencesButtonPosition,
     sidebarCollapsed,
     theme,
+    app: appPreferences.value,
   };
 }
 

--- a/packages/@core/ui-kit/popup-ui/package.json
+++ b/packages/@core/ui-kit/popup-ui/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@vben-core/composables": "workspace:*",
     "@vben-core/icons": "workspace:*",
+    "@vben-core/preferences": "workspace:*",
     "@vben-core/shadcn-ui": "workspace:*",
     "@vben-core/shared": "workspace:*",
     "@vben-core/typings": "workspace:*",

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.ts
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.ts
@@ -36,6 +36,8 @@ export type AlertProps = {
   contentClass?: string;
   /** 执行beforeClose回调期间，在内容区域显示一个loading遮罩*/
   contentMasking?: boolean;
+  /** 点击遮罩层或按下Esc时是否关闭弹窗 */
+  escapeKeyClose?: boolean;
   /** 弹窗底部内容（与按钮在同一个容器中） */
   footer?: Component | string;
   /** 弹窗的图标（在标题的前面） */

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.ts
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.ts
@@ -36,7 +36,7 @@ export type AlertProps = {
   contentClass?: string;
   /** 执行beforeClose回调期间，在内容区域显示一个loading遮罩*/
   contentMasking?: boolean;
-  /** 点击遮罩层或按下Esc时是否关闭弹窗 */
+  /** 按下Esc时是否关闭弹窗 */
   escapeKeyClose?: boolean;
   /** 弹窗底部内容（与按钮在同一个容器中） */
   footer?: Component | string;

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -54,7 +54,7 @@ function onEscapeKeyDown(e: KeyboardEvent) {
   isConfirm.value = false;
 
   // 当不允许 Esc 关闭时，阻止默认关闭行为
-  if (!props.escapeKeyClose && !globalEscapeShortcutKey.value) {
+  if (!props.escapeKeyClose || !globalEscapeShortcutKey.value) {
     e.preventDefault();
   }
 }

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -35,6 +35,7 @@ const props = withDefaults(defineProps<AlertProps>(), {
   bordered: true,
   buttonAlign: 'end',
   centered: true,
+  escapeKeyClose: true,
 });
 const emits = defineEmits(['closed', 'confirm', 'opened']);
 const { globalEscapeShortcutKey } = usePreferences();
@@ -52,8 +53,8 @@ function onEscapeKeyDown(e: KeyboardEvent) {
   // 先标记是按 Esc 触发的（用于后续 isConfirm 判断等）
   isConfirm.value = false;
 
-  // 当不允许 Esc 关闭时，阻止默认关闭行为
-  if (!globalEscapeShortcutKey.value) {
+  // 只有当组件参数和全局配置都为false时才阻止关闭，其任意一个为true都需要让esc生效
+  if (!props.escapeKeyClose && !globalEscapeShortcutKey.value) {
     e.preventDefault();
   }
 }

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -14,6 +14,7 @@ import {
   Info,
   X,
 } from '@vben-core/icons';
+import { usePreferences } from '@vben-core/preferences';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,8 +35,10 @@ const props = withDefaults(defineProps<AlertProps>(), {
   bordered: true,
   buttonAlign: 'end',
   centered: true,
+  escapeKeyClose: true,
 });
 const emits = defineEmits(['closed', 'confirm', 'opened']);
+const { globalEscapeShortcutKey } =  usePreferences();
 const open = defineModel<boolean>('open', { default: false });
 const { $t } = useSimpleLocale();
 const components = globalShareState.getComponents();
@@ -47,7 +50,9 @@ function onAlertClosed() {
 }
 
 function onEscapeKeyDown() {
-  isConfirm.value = false;
+  if (props.escapeKeyClose || globalEscapeShortcutKey.value) {
+    isConfirm.value = false;
+  }
 }
 
 const getIconRender = computed(() => {

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -38,7 +38,7 @@ const props = withDefaults(defineProps<AlertProps>(), {
   escapeKeyClose: true,
 });
 const emits = defineEmits(['closed', 'confirm', 'opened']);
-const { globalEscapeShortcutKey } =  usePreferences();
+const { globalEscapeShortcutKey } = usePreferences();
 const open = defineModel<boolean>('open', { default: false });
 const { $t } = useSimpleLocale();
 const components = globalShareState.getComponents();

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -35,7 +35,6 @@ const props = withDefaults(defineProps<AlertProps>(), {
   bordered: true,
   buttonAlign: 'end',
   centered: true,
-  escapeKeyClose: true,
 });
 const emits = defineEmits(['closed', 'confirm', 'opened']);
 const { globalEscapeShortcutKey } = usePreferences();
@@ -54,7 +53,7 @@ function onEscapeKeyDown(e: KeyboardEvent) {
   isConfirm.value = false;
 
   // 当不允许 Esc 关闭时，阻止默认关闭行为
-  if (!props.escapeKeyClose || !globalEscapeShortcutKey.value) {
+  if (!globalEscapeShortcutKey.value) {
     e.preventDefault();
   }
 }

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -49,10 +49,13 @@ function onAlertClosed() {
   isConfirm.value = false;
 }
 
-function onEscapeKeyDown() {
-  // alert组件支持特殊场景：未启用全局esc快捷键时，特殊场景的弹出窗需要支持esc按键关闭弹窗
-  if (props.escapeKeyClose || globalEscapeShortcutKey.value) {
-    isConfirm.value = false;
+function onEscapeKeyDown(e: KeyboardEvent) {
+  // 先标记是按 Esc 触发的（用于后续 isConfirm 判断等）
+  isConfirm.value = false;
+
+  // 当不允许 Esc 关闭时，阻止默认关闭行为
+  if (!props.escapeKeyClose && !globalEscapeShortcutKey.value) {
+    e.preventDefault();
   }
 }
 
@@ -149,7 +152,7 @@ async function handleOpenChange(val: boolean) {
       :overlay-blur="overlayBlur"
       @opened="emits('opened')"
       @closed="onAlertClosed"
-      @escape-key-down="onEscapeKeyDown"
+      @escape-key-down="onEscapeKeyDown($event)"
       :class="
         cn(
           containerClass,

--- a/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
+++ b/packages/@core/ui-kit/popup-ui/src/alert/alert.vue
@@ -50,6 +50,7 @@ function onAlertClosed() {
 }
 
 function onEscapeKeyDown() {
+  // alert组件支持特殊场景：未启用全局esc快捷键时，特殊场景的弹出窗需要支持esc按键关闭弹窗
   if (props.escapeKeyClose || globalEscapeShortcutKey.value) {
     isConfirm.value = false;
   }

--- a/packages/@core/ui-kit/popup-ui/src/drawer/drawer.vue
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/drawer.vue
@@ -54,7 +54,7 @@ const components = globalShareState.getComponents();
 const id = useId();
 provide('DISMISSABLE_DRAWER_ID', id);
 
-const wrapperRef = ref<HTMLElement>();
+// const wrapperRef = ref<HTMLElement>();
 const { $t } = useSimpleLocale();
 const { isMobile } = useIsMobile();
 
@@ -285,8 +285,8 @@ const getForceMount = computed(() => {
           <SheetDescription />
         </VisuallyHidden>
       </template>
+      <!-- 注释掉的部分 <div ref="wrapperRef" -->
       <div
-        ref="wrapperRef"
         :class="
           cn('relative flex-1 overflow-y-auto p-3', contentClass, {
             'pointer-events-none': showLoading || submitting,

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -16,6 +16,7 @@ import {
 
 import { usePreferences } from '@vben-core/preferences';
 import { useStore } from '@vben-core/shared/store';
+import { merge } from '@vben-core/shared/utils';
 
 import { DrawerApi } from './drawer-api';
 import VbenDrawer from './drawer.vue';
@@ -27,9 +28,7 @@ const { globalEscapeShortcutKey } = usePreferences();
 /**
  * 默认配置
  */
-const DEFAULT_DRAWER_PROPS: Partial<DrawerProps> = {
-  closeOnPressEscape: globalEscapeShortcutKey.value, // Esc按钮为关闭事件
-};
+const DEFAULT_DRAWER_PROPS: Partial<DrawerProps> = {};
 
 export function setDefaultDrawerProps(props: Partial<DrawerProps>) {
   Object.assign(DEFAULT_DRAWER_PROPS, props);
@@ -47,13 +46,21 @@ export function useVbenDrawer<
     const isDrawerReady = ref(true);
     const Drawer = defineComponent(
       (props: TParentDrawerProps, { attrs, slots }) => {
+        const mergedOptions = merge(
+          {},
+          options,
+          // 若是options没有配置，则使用全局配置Esc快捷键配置
+          {
+            closeOnPressEscape: globalEscapeShortcutKey.value,
+          },
+        );
         provide(USER_DRAWER_INJECT_KEY, {
           extendApi(api: ExtendedDrawerApi) {
             // 不能直接给 reactive 赋值，会丢失响应
             // 不能用 Object.assign,会丢失 api 的原型函数
             Object.setPrototypeOf(extendedApi, api);
           },
-          options,
+          mergedOptions,
           async reCreateDrawer() {
             isDrawerReady.value = false;
             await nextTick();
@@ -84,11 +91,17 @@ export function useVbenDrawer<
 
   const injectData = inject<any>(USER_DRAWER_INJECT_KEY, {});
 
-  const mergedOptions = {
-    ...DEFAULT_DRAWER_PROPS,
-    ...injectData.options,
-    ...options,
-  } as DrawerApiOptions;
+  const mergedOptions = merge(
+    {
+      ...DEFAULT_DRAWER_PROPS,
+      ...injectData.options,
+      ...options,
+    } as DrawerApiOptions,
+    // 若是options没有配置，则使用全局配置Esc快捷键配置
+    {
+      closeOnPressEscape: globalEscapeShortcutKey.value,
+    },
+  );
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {
     options.onOpenChange?.(isOpen);

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -14,6 +14,7 @@ import {
   ref,
 } from 'vue';
 
+import { usePreferences } from '@vben-core/preferences';
 import { useStore } from '@vben-core/shared/store';
 
 import { DrawerApi } from './drawer-api';
@@ -21,7 +22,14 @@ import VbenDrawer from './drawer.vue';
 
 const USER_DRAWER_INJECT_KEY = Symbol('VBEN_DRAWER_INJECT');
 
-const DEFAULT_DRAWER_PROPS: Partial<DrawerProps> = {};
+const { globalEscapeShortcutKey } =  usePreferences();
+
+/**
+ * 默认配置
+ */
+const DEFAULT_DRAWER_PROPS: Partial<DrawerProps> = {
+  closeOnPressEscape: globalEscapeShortcutKey.value, // Esc按钮为关闭事件
+};
 
 export function setDefaultDrawerProps(props: Partial<DrawerProps>) {
   Object.assign(DEFAULT_DRAWER_PROPS, props);

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -16,7 +16,6 @@ import {
 
 import { usePreferences } from '@vben-core/preferences';
 import { useStore } from '@vben-core/shared/store';
-import { merge } from '@vben-core/shared/utils';
 
 import { DrawerApi } from './drawer-api';
 import VbenDrawer from './drawer.vue';
@@ -40,9 +39,10 @@ export function useVbenDrawer<
   // Drawer一般会抽离出来，所以如果有传入 connectedComponent，则表示为外部调用，与内部组件进行连接
   // 外部的Drawer通过provide/inject传递api
 
-  const defaultOptions = merge({}, options, {
-    closeOnPressEscape: globalEscapeShortcutKey.value, // 若是options没有配置，则使用全局配置Esc快捷键配置
-  });
+  const defaultOptions = {
+    closeOnPressEscape: globalEscapeShortcutKey.value, // 全局Esc快捷键配置
+    ...options,
+  };
   const { connectedComponent } = options;
   if (connectedComponent) {
     const extendedApi = reactive({});
@@ -86,14 +86,11 @@ export function useVbenDrawer<
 
   const injectData = inject<any>(USER_DRAWER_INJECT_KEY, {});
 
-  const mergedOptions = merge(
-    {
-      ...DEFAULT_DRAWER_PROPS,
-      ...injectData.options,
-      ...options,
-    },
-    defaultOptions,
-  );
+  const mergedOptions = {
+    ...DEFAULT_DRAWER_PROPS,
+    ...injectData.options,
+    ...defaultOptions,
+  } as DrawerApiOptions;
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {
     options.onOpenChange?.(isOpen);

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -40,27 +40,22 @@ export function useVbenDrawer<
   // Drawer一般会抽离出来，所以如果有传入 connectedComponent，则表示为外部调用，与内部组件进行连接
   // 外部的Drawer通过provide/inject传递api
 
+  const defaultOptions = merge({}, options, {
+    closeOnPressEscape: globalEscapeShortcutKey.value, // 若是options没有配置，则使用全局配置Esc快捷键配置
+  });
   const { connectedComponent } = options;
   if (connectedComponent) {
     const extendedApi = reactive({});
     const isDrawerReady = ref(true);
     const Drawer = defineComponent(
       (props: TParentDrawerProps, { attrs, slots }) => {
-        const mergedOptions = merge(
-          {},
-          options,
-          // 若是options没有配置，则使用全局配置Esc快捷键配置
-          {
-            closeOnPressEscape: globalEscapeShortcutKey.value,
-          },
-        );
         provide(USER_DRAWER_INJECT_KEY, {
           extendApi(api: ExtendedDrawerApi) {
             // 不能直接给 reactive 赋值，会丢失响应
             // 不能用 Object.assign,会丢失 api 的原型函数
             Object.setPrototypeOf(extendedApi, api);
           },
-          mergedOptions,
+          defaultOptions,
           async reCreateDrawer() {
             isDrawerReady.value = false;
             await nextTick();
@@ -96,11 +91,8 @@ export function useVbenDrawer<
       ...DEFAULT_DRAWER_PROPS,
       ...injectData.options,
       ...options,
-    } as DrawerApiOptions,
-    // 若是options没有配置，则使用全局配置Esc快捷键配置
-    {
-      closeOnPressEscape: globalEscapeShortcutKey.value,
     },
+    defaultOptions,
   );
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -22,7 +22,7 @@ import VbenDrawer from './drawer.vue';
 
 const USER_DRAWER_INJECT_KEY = Symbol('VBEN_DRAWER_INJECT');
 
-const { globalEscapeShortcutKey } =  usePreferences();
+const { globalEscapeShortcutKey } = usePreferences();
 
 /**
  * 默认配置

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -12,7 +12,6 @@ import {
 
 import { usePreferences } from '@vben-core/preferences';
 import { useStore } from '@vben-core/shared/store';
-import { merge } from '@vben-core/shared/utils';
 
 import { ModalApi } from './modal-api';
 import VbenModal from './modal.vue';
@@ -35,9 +34,10 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   // Modal一般会抽离出来，所以如果有传入 connectedComponent，则表示为外部调用，与内部组件进行连接
   // 外部的Modal通过provide/inject传递api
 
-  const defaultOptions = merge({}, options, {
-    closeOnPressEscape: globalEscapeShortcutKey.value, // 若是options没有配置，则使用全局配置Esc快捷键配置
-  });
+  const defaultOptions = {
+    closeOnPressEscape: globalEscapeShortcutKey.value, // 全局Esc快捷键配置
+    ...options,
+  };
   const { connectedComponent } = options;
   if (connectedComponent) {
     const extendedApi = reactive({});
@@ -91,14 +91,11 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
     injectData.consumed = true;
   }
 
-  const mergedOptions = merge(
-    {
-      ...DEFAULT_MODAL_PROPS,
-      ...injectData.options,
-      ...options,
-    },
-    defaultOptions,
-  );
+  const mergedOptions = {
+    ...DEFAULT_MODAL_PROPS,
+    ...injectData.options,
+    ...defaultOptions,
+  } as ModalApiOptions;
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {
     options.onOpenChange?.(isOpen);

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -35,20 +35,15 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   // Modal一般会抽离出来，所以如果有传入 connectedComponent，则表示为外部调用，与内部组件进行连接
   // 外部的Modal通过provide/inject传递api
 
+  const defaultOptions = merge({}, options, {
+    closeOnPressEscape: globalEscapeShortcutKey.value, // 若是options没有配置，则使用全局配置Esc快捷键配置
+  });
   const { connectedComponent } = options;
   if (connectedComponent) {
     const extendedApi = reactive({});
     const isModalReady = ref(true);
     const Modal = defineComponent(
       (props: TParentModalProps, { attrs, slots }) => {
-        const mergedOptions = merge(
-          {},
-          options,
-          // 若是options没有配置，则使用全局配置Esc快捷键配置
-          {
-            closeOnPressEscape: globalEscapeShortcutKey.value,
-          },
-        );
         provide(USER_MODAL_INJECT_KEY, {
           extendApi(api: ExtendedModalApi) {
             // 不能直接给 reactive 赋值，会丢失响应
@@ -56,7 +51,7 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
             Object.setPrototypeOf(extendedApi, api);
           },
           consumed: false,
-          mergedOptions,
+          defaultOptions,
           async reCreateModal() {
             isModalReady.value = false;
             await nextTick();
@@ -101,11 +96,8 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
       ...DEFAULT_MODAL_PROPS,
       ...injectData.options,
       ...options,
-    } as ModalApiOptions,
-    // 若是options没有配置，则使用全局配置Esc快捷键配置
-    {
-      closeOnPressEscape: globalEscapeShortcutKey.value,
     },
+    defaultOptions,
   );
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -18,7 +18,7 @@ import VbenModal from './modal.vue';
 
 const USER_MODAL_INJECT_KEY = Symbol('VBEN_MODAL_INJECT');
 
-const { globalEscapeShortcutKey } =  usePreferences();
+const { globalEscapeShortcutKey } = usePreferences();
 /**
  * 默认配置
  */

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -10,6 +10,7 @@ import {
   ref,
 } from 'vue';
 
+import { usePreferences } from '@vben-core/preferences';
 import { useStore } from '@vben-core/shared/store';
 
 import { ModalApi } from './modal-api';
@@ -17,7 +18,13 @@ import VbenModal from './modal.vue';
 
 const USER_MODAL_INJECT_KEY = Symbol('VBEN_MODAL_INJECT');
 
-const DEFAULT_MODAL_PROPS: Partial<ModalProps> = {};
+const { globalEscapeShortcutKey } =  usePreferences();
+/**
+ * 默认配置
+ */
+const DEFAULT_MODAL_PROPS: Partial<ModalProps> = {
+  closeOnPressEscape: globalEscapeShortcutKey.value, // Esc按钮为关闭事件
+};
 
 export function setDefaultModalProps(props: Partial<ModalProps>) {
   Object.assign(DEFAULT_MODAL_PROPS, props);

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -12,6 +12,7 @@ import {
 
 import { usePreferences } from '@vben-core/preferences';
 import { useStore } from '@vben-core/shared/store';
+import { merge } from '@vben-core/shared/utils';
 
 import { ModalApi } from './modal-api';
 import VbenModal from './modal.vue';
@@ -22,9 +23,7 @@ const { globalEscapeShortcutKey } = usePreferences();
 /**
  * 默认配置
  */
-const DEFAULT_MODAL_PROPS: Partial<ModalProps> = {
-  closeOnPressEscape: globalEscapeShortcutKey.value, // Esc按钮为关闭事件
-};
+const DEFAULT_MODAL_PROPS: Partial<ModalProps> = {};
 
 export function setDefaultModalProps(props: Partial<ModalProps>) {
   Object.assign(DEFAULT_MODAL_PROPS, props);
@@ -42,6 +41,14 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
     const isModalReady = ref(true);
     const Modal = defineComponent(
       (props: TParentModalProps, { attrs, slots }) => {
+        const mergedOptions = merge(
+          {},
+          options,
+          // 若是options没有配置，则使用全局配置Esc快捷键配置
+          {
+            closeOnPressEscape: globalEscapeShortcutKey.value,
+          },
+        );
         provide(USER_MODAL_INJECT_KEY, {
           extendApi(api: ExtendedModalApi) {
             // 不能直接给 reactive 赋值，会丢失响应
@@ -49,7 +56,7 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
             Object.setPrototypeOf(extendedApi, api);
           },
           consumed: false,
-          options,
+          mergedOptions,
           async reCreateModal() {
             isModalReady.value = false;
             await nextTick();
@@ -89,11 +96,17 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
     injectData.consumed = true;
   }
 
-  const mergedOptions = {
-    ...DEFAULT_MODAL_PROPS,
-    ...injectData.options,
-    ...options,
-  } as ModalApiOptions;
+  const mergedOptions = merge(
+    {
+      ...DEFAULT_MODAL_PROPS,
+      ...injectData.options,
+      ...options,
+    } as ModalApiOptions,
+    // 若是options没有配置，则使用全局配置Esc快捷键配置
+    {
+      closeOnPressEscape: globalEscapeShortcutKey.value,
+    },
+  );
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {
     options.onOpenChange?.(isOpen);

--- a/packages/effects/layouts/src/widgets/preferences/blocks/general/animation.vue
+++ b/packages/effects/layouts/src/widgets/preferences/blocks/general/animation.vue
@@ -45,7 +45,10 @@ function handleClick(value: string) {
       class="outline-box p-2"
       @click="handleClick(item)"
     >
-      <div :class="`${item}-slow`" class="h-10 w-12 rounded-md bg-primary"></div>
+      <div
+        :class="`${item}-slow`"
+        class="h-10 w-12 rounded-md bg-primary"
+      ></div>
     </div>
   </div>
 </template>

--- a/packages/effects/layouts/src/widgets/preferences/blocks/general/animation.vue
+++ b/packages/effects/layouts/src/widgets/preferences/blocks/general/animation.vue
@@ -45,7 +45,7 @@ function handleClick(value: string) {
       class="outline-box p-2"
       @click="handleClick(item)"
     >
-      <div :class="`${item}-slow`" class="h-10 w-12 rounded-md bg-accent"></div>
+      <div :class="`${item}-slow`" class="h-10 w-12 rounded-md bg-primary"></div>
     </div>
   </div>
 </template>

--- a/packages/effects/layouts/src/widgets/preferences/blocks/shortcut-keys/global.vue
+++ b/packages/effects/layouts/src/widgets/preferences/blocks/shortcut-keys/global.vue
@@ -17,6 +17,7 @@ const shortcutKeysGlobalSearch = defineModel<boolean>(
 const shortcutKeysLogout = defineModel<boolean>('shortcutKeysLogout');
 // const shortcutKeysPreferences = defineModel<boolean>('shortcutKeysPreferences');
 const shortcutKeysLockScreen = defineModel<boolean>('shortcutKeysLockScreen');
+const shortcutKeysEscape = defineModel<boolean>('shortcutKeysEscape');
 
 const altView = computed(() => (isWindowsOs() ? 'Alt' : '⌥'));
 </script>
@@ -46,5 +47,9 @@ const altView = computed(() => (isWindowsOs() ? 'Alt' : '⌥'));
   <SwitchItem v-model="shortcutKeysLockScreen" :disabled="!shortcutKeysEnable">
     {{ $t('ui.widgets.lockScreen.title') }}
     <template #shortcut> {{ altView }} L </template>
+  </SwitchItem>
+  <SwitchItem v-model="shortcutKeysEscape" :disabled="!shortcutKeysEnable">
+    {{ $t('preferences.shortcutKeys.escape') }}
+    <template #shortcut> Esc </template>
   </SwitchItem>
 </template>

--- a/packages/effects/layouts/src/widgets/preferences/preferences-drawer.vue
+++ b/packages/effects/layouts/src/widgets/preferences/preferences-drawer.vue
@@ -166,7 +166,9 @@ const shortcutKeysGlobalSearch = defineModel<boolean>(
 const shortcutKeysGlobalLogout = defineModel<boolean>(
   'shortcutKeysGlobalLogout',
 );
-const shortcutKeysGlobalEscape = defineModel<boolean>('shortcutKeysGlobalEscape');
+const shortcutKeysGlobalEscape = defineModel<boolean>(
+  'shortcutKeysGlobalEscape',
+);
 
 const shortcutKeysGlobalLockScreen = defineModel<boolean>(
   'shortcutKeysGlobalLockScreen',

--- a/packages/effects/layouts/src/widgets/preferences/preferences-drawer.vue
+++ b/packages/effects/layouts/src/widgets/preferences/preferences-drawer.vue
@@ -166,6 +166,7 @@ const shortcutKeysGlobalSearch = defineModel<boolean>(
 const shortcutKeysGlobalLogout = defineModel<boolean>(
   'shortcutKeysGlobalLogout',
 );
+const shortcutKeysGlobalEscape = defineModel<boolean>('shortcutKeysGlobalEscape');
 
 const shortcutKeysGlobalLockScreen = defineModel<boolean>(
   'shortcutKeysGlobalLockScreen',
@@ -520,6 +521,7 @@ function handleCustomPreferencesUpdate(updates: CustomPreferencesRecord) {
                 v-model:shortcut-keys-global-search="shortcutKeysGlobalSearch"
                 v-model:shortcut-keys-lock-screen="shortcutKeysGlobalLockScreen"
                 v-model:shortcut-keys-logout="shortcutKeysGlobalLogout"
+                v-model:shortcut-keys-escape="shortcutKeysGlobalEscape"
               />
             </Block>
           </template>

--- a/packages/locales/src/langs/en-US/preferences.json
+++ b/packages/locales/src/langs/en-US/preferences.json
@@ -187,6 +187,7 @@
     "global": "Global",
     "search": "Global Search",
     "logout": "Logout",
+    "escape": "Close Current Window",
     "preferences": "Preferences"
   },
   "widget": {

--- a/packages/locales/src/langs/zh-CN/preferences.json
+++ b/packages/locales/src/langs/zh-CN/preferences.json
@@ -187,6 +187,7 @@
     "global": "全局",
     "search": "全局搜索",
     "logout": "退出登录",
+    "escape": "关闭当前窗口",
     "preferences": "偏好设置"
   },
   "widget": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1006,14 +1006,14 @@ importers:
         version: 2.9.7(vue@3.5.34(typescript@6.0.3))
       vitepress-plugin-group-icons:
         specifier: 'catalog:'
-        version: 1.7.5(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 1.7.5(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     devDependencies:
       '@nolebase/vitepress-plugin-git-changelog':
         specifier: 'catalog:'
         version: 2.18.2(vitepress@2.0.0-alpha.17(@types/node@25.9.1)(async-validator@4.2.5)(axios@1.16.1)(change-case@5.4.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(nprogress@0.2.0)(postcss@8.5.15)(qrcode@1.5.4)(sass-embedded@1.100.0)(sass@1.100.0)(sortablejs@1.15.7)(terser@5.48.0)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.3.0(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       '@vben/tailwind-config':
         specifier: workspace:*
         version: link:../internal/tailwind-config
@@ -1022,7 +1022,7 @@ importers:
         version: link:../internal/vite-config
       '@vite-pwa/vitepress':
         specifier: 'catalog:'
-        version: 1.1.0(vite-plugin-pwa@1.3.0(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
+        version: 1.1.0(vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
       vitepress:
         specifier: 'catalog:'
         version: 2.0.0-alpha.17(@types/node@25.9.1)(async-validator@4.2.5)(axios@1.16.1)(change-case@5.4.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(nprogress@0.2.0)(postcss@8.5.15)(qrcode@1.5.4)(sass-embedded@1.100.0)(sass@1.100.0)(sortablejs@1.15.7)(terser@5.48.0)(typescript@6.0.3)(yaml@2.9.0)
@@ -1522,6 +1522,9 @@ importers:
       '@vben-core/icons':
         specifier: workspace:*
         version: link:../../base/icons
+      '@vben-core/preferences':
+        specifier: workspace:*
+        version: link:../../preferences
       '@vben-core/shadcn-ui':
         specifier: workspace:*
         version: link:../shadcn-ui
@@ -14279,6 +14282,13 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
+  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+
   '@tanstack/match-sorter-utils@8.19.4':
     dependencies:
       remove-accents: 0.5.0
@@ -15015,9 +15025,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vite-pwa/vitepress@1.1.0(vite-plugin-pwa@1.3.0(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
+  '@vite-pwa/vitepress@1.1.0(vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
     dependencies:
-      vite-plugin-pwa: 1.3.0(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+      vite-plugin-pwa: 1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
 
   '@vitejs/plugin-vue-jsx@5.1.5(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -20397,6 +20407,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+    dependencies:
+      debug: 4.4.3
+      pretty-bytes: 6.1.1
+      tinyglobby: 0.2.16
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      workbox-build: 7.4.1
+      workbox-window: 7.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-devtools@8.1.2(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-core': 8.1.2(vue@3.5.34(typescript@6.0.3))
@@ -20481,13 +20502,13 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vitepress-plugin-group-icons@1.7.5(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitepress-plugin-group-icons@1.7.5(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@iconify-json/logos': 1.2.11
       '@iconify-json/vscode-icons': 1.2.50
       '@iconify/utils': 3.1.3
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
   vitepress@2.0.0-alpha.17(@types/node@25.9.1)(async-validator@4.2.5)(axios@1.16.1)(change-case@5.4.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(nprogress@0.2.0)(postcss@8.5.15)(qrcode@1.5.4)(sass-embedded@1.100.0)(sass@1.100.0)(sortablejs@1.15.7)(terser@5.48.0)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
1、新增功能：偏好设置 - 快捷键列表 - 增加ESC快捷键的控制（关闭当前窗口），此功能支持：三种类型的弹出框功能（alert、drawer、modal），其中alert组件默认支持ESC快捷键关闭窗口。
修改后效果：
<img width="674" height="713" alt="快捷键ESC" src="https://github.com/user-attachments/assets/c4e5bec8-461c-48bb-8e63-63bae3288ec6" />


2、优化偏好设置中local取值方式（其它方法的取值方式都使从ref中获取）
修改前：取config文件的静态配置
```
  const locale = computed(() => {
    return preferences.app.locale;
  });
```
修改后：取ref中响应内容
```
  const locale = computed(() => {
    return appPreferences.value.locale;
  });
```
3、优化偏好设置中页面切换动画的颜色看不清的问题（改为使用当前主题色）]
<img width="1333" height="509" alt="动画背景不清晰2" src="https://github.com/user-attachments/assets/359d53b2-e229-4145-9d1c-4004ad2d1fd9" />

