### PR TITLE
fix: 修复 web-naive 表单页 Input 输入 _ 不显示的问题 (#7962)

### DIFF
--- a/packages/styles/src/naive/index.css
+++ b/packages/styles/src/naive/index.css
@@ -18,3 +18,9 @@
     --n-border: 1px solid rgb(255 56 96);
   }
 }
+
+.n-input .n-input__input-el,
+.n-input .n-input__textarea-el,
+.n-input-number .n-input__input-el {
+  font-family: Arial, Roboto, 'Helvetica Neue', sans-serif;
+}

--- a/packages/styles/src/naive/index.css
+++ b/packages/styles/src/naive/index.css
@@ -17,10 +17,11 @@
   .n-checkbox-box__border {
     --n-border: 1px solid rgb(255 56 96);
   }
+
+  .n-input .n-input__input-el,
+  .n-input .n-input__textarea-el,
+  .n-input-number .n-input__input-el {
+    font-family: Arial, Roboto, 'Helvetica Neue', sans-serif;
+  }
 }
 
-.n-input .n-input__input-el,
-.n-input .n-input__textarea-el,
-.n-input-number .n-input__input-el {
-  font-family: Arial, Roboto, 'Helvetica Neue', sans-serif;
-}


### PR DESCRIPTION
## Description

close #7962

在 `web-naive` 的 `/demos/form` 页面中，`Input` 相关输入框输入 `_` 时，界面不显示下划线，但实际值中存在该字符。

排查结论：
- 表单值链路正常（`value` 中可确认有 `_`，charCode 为 `95`）。
- 适配层未对 `_` 做替换或过滤。
- 临时将输入字体改为 `monospace` 后 `_` 可以显示，问题定位到字体渲染链路。

本 PR 对 Naive Input 文本渲染层进行最小范围修复，不改动业务逻辑与表单数据处理流程。

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added an explicit font-family stack (Arial, Roboto, Helvetica Neue, sans-serif) for input elements (text inputs, textareas, and number inputs) within form validation error states to ensure consistent typography across these controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vbenjs/vue-vben-admin/pull/7965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->