### PR TITLE
fix(menu-ui): 修复菜单组件名称问题

### DIFF
--- a/.changeset/fancy-ears-walk.md
+++ b/.changeset/fancy-ears-walk.md
@@ -1,7 +1,7 @@
 ---
-"@vben/styles": patch
-"@vben-core/form-ui": patch
-"@vben/web-naive": patch
+'@vben/styles': patch
+'@vben-core/form-ui': patch
+'@vben/web-naive': patch
 ---
 
 feat(@core/form-ui): 新增 useVbenForm 数组编辑器 VbenFormFieldArray

--- a/packages/@core/ui-kit/menu-ui/src/components/menu.vue
+++ b/packages/@core/ui-kit/menu-ui/src/components/menu.vue
@@ -37,7 +37,7 @@ import SubMenu from './sub-menu.vue';
 
 interface Props extends MenuProps {}
 
-defineOptions({ name: 'MenuUI' });
+defineOptions({ name: 'Menu' });
 
 const props = withDefaults(defineProps<Props>(), {
   accordion: true,


### PR DESCRIPTION
## 说明
- 将 `packages/@core/ui-kit/menu-ui/src/components/menu.vue` 的组件名从 `MenuUI` 调整为 `Menu`，用于修复 issue #8003。
- 修复了 changeset 文件。

## 验证
- `pnpm turbo run typecheck`

## 关联
- Fixes #8003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an array editor component for managing dynamic form field arrays in form handling.

* **Updates**
  * Refined menu component naming conventions for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->