### PR TITLE
fix(style): 1.修复ToggleGroupItem边框样式问题 2.修复用户头像下拉框Badge背景颜色

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/ui/toggle-group/ToggleGroupItem.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/toggle-group/ToggleGroupItem.vue
@@ -46,7 +46,7 @@ const forwardedProps = useForwardProps(delegatedProps);
           size: context?.size || size,
         }),
         'w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10',
-        'data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l',
+        'data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[variant=outline]:[&:not(:first-child)]:-ml-px data-[spacing=0]:data-[variant=outline]:first:border-l',
         props.class,
       )
     "

--- a/packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue
+++ b/packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue
@@ -237,7 +237,11 @@ if (enableShortcutKey.value) {
             >
               {{ text }}
               <slot name="tagText">
-                <Badge v-if="tagText" class="ml-2 text-green-400">
+                <Badge
+                  v-if="tagText"
+                  variant="secondary"
+                  class="ml-2 text-green-400"
+                >
                   {{ tagText }}
                 </Badge>
               </slot>


### PR DESCRIPTION
1. 修复ToggleGroupItem边框样式，解决偏好设置部分按钮边框缺失问题
2. 修复用户头像下拉框，将蓝色更换为灰色

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted toggle group item spacing and border styling for improved visual consistency when using outline variant with no spacing.

* **Refactor**
  * Improved user dropdown badge rendering to conditionally display based on content availability, enhancing component flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->