### PR TITLE
fix: 修复Tree组件不支持半选的问题（子节点全选时父节点选中图标为勾选状态，子节点部分选中时父节点图标为减号，也就是版勾选状态，子节…

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/ui/checkbox/Checkbox.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/checkbox/Checkbox.vue
@@ -5,16 +5,19 @@ import type { HTMLAttributes } from 'vue';
 
 import { cn } from '@vben-core/shared/utils';
 
-import { Check } from '@lucide/vue';
+import { Check, Minus } from '@lucide/vue';
 import { reactiveOmit } from '@vueuse/core';
 import { CheckboxIndicator, CheckboxRoot, useForwardPropsEmits } from 'reka-ui';
 
 const props = defineProps<
-  CheckboxRootProps & { class?: HTMLAttributes['class'] }
+  CheckboxRootProps & {
+    class?: HTMLAttributes['class'];
+    indeterminate?: boolean;
+  }
 >();
 const emits = defineEmits<CheckboxRootEmits>();
 
-const delegatedProps = reactiveOmit(props, 'class');
+const delegatedProps = reactiveOmit(props, 'class', 'indeterminate');
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 </script>
@@ -27,6 +30,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
     :class="
       cn(
         'peer border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        indeterminate && 'bg-primary text-primary-foreground border-primary',
         props.class,
       )
     "
@@ -34,9 +38,11 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
     <CheckboxIndicator
       data-slot="checkbox-indicator"
       class="grid place-content-center text-current transition-none"
+      :force-mount="indeterminate ? true : undefined"
     >
       <slot v-bind="slotProps">
-        <Check class="size-3.5" />
+        <Minus v-if="indeterminate" class="size-3.5" />
+        <Check v-else class="size-3.5" />
       </slot>
     </CheckboxIndicator>
   </CheckboxRoot>

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/tree/tree.vue
@@ -227,7 +227,7 @@ function onSelect(item: FlattenedItem<Recordable<any>>, isSelected: boolean) {
   }
 
   if (
-    !props.checkStrictly &&
+    props.checkStrictly &&
     props.multiple &&
     props.autoCheckParent &&
     isSelected
@@ -246,7 +246,7 @@ function onSelect(item: FlattenedItem<Recordable<any>>, isSelected: boolean) {
       });
   }
   if (
-    !props.checkStrictly &&
+    props.checkStrictly &&
     props.multiple &&
     props.autoCheckParent &&
     !isSelected
@@ -307,6 +307,7 @@ defineExpose({
     v-model:expanded="expanded as string[]"
     :default-expanded="defaultExpandedKeys as string[]"
     :propagate-select="!checkStrictly"
+    :bubble-select="!checkStrictly"
     :multiple="multiple"
     :disabled="disabled"
     :selection-behavior="allowClear || multiple ? 'toggle' : 'replace'"


### PR DESCRIPTION
…点未被选中时，父节点不被选中）

## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

<!-- You can also add additional context here -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indeterminate state support to checkbox component, displaying a dash icon when in that state.

* **Bug Fixes**
  * Fixed parent node auto-selection logic in tree component to correctly apply when strict checking mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->