### PR TITLE
fix(@vben/common-ui): prevent footer slot from overlapping content when Page contains Grid

### DIFF
--- a/packages/effects/common-ui/src/components/page/page.vue
+++ b/packages/effects/common-ui/src/components/page/page.vue
@@ -56,7 +56,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="relative flex min-h-full flex-col">
+  <div class="relative flex h-full flex-col">
     <div
       v-if="
         description ||
@@ -92,7 +92,7 @@ onMounted(() => {
       </div>
     </div>
 
-    <div :class="cn('h-full p-4', contentClass)" :style="contentStyle">
+    <div :class="cn(autoContentHeight ? 'h-full' : 'flex-1', 'p-4', contentClass)" :style="contentStyle">
       <slot></slot>
     </div>
     <div


### PR DESCRIPTION
## Description

When a Page component contains a Grid (vxe-table) and uses the `#footer` slot, the footer content overlaps the table/grid content.

**Root cause**: The Page container used `min-h-full` (no explicit height) while the content div used `h-full`. In a `flex-col` layout, `h-full` on a child requires the parent to have an explicit height — otherwise it resolves to 0. This caused the flex layout to not properly distribute space between the content and footer, leading to the overlap.

**Fix**:
1. Changed outer container from `min-h-full` to `h-full` — gives the flex container an explicit height matching the layout content area, so percentage-based heights on children resolve correctly.
2. Changed content area from static `h-full` to `flex-1` when `autoContentHeight` is `false` — lets the flex layout naturally allocate remaining space after the header and footer, regardless of their heights.

When `autoContentHeight` is `true`, the existing calc-based height (which already includes `footerHeight`) is preserved.

**Testing**:
1. Create a Page component with `<template #footer>` containing any content and a Grid (vxe-table) in the default slot.
2. Before the fix: footer text overlaps the bottom rows of the table.
3. After the fix: footer appears below the table as expected, table fills the remaining space.

Closes #5494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Page component layout behavior to improve height handling based on the `autoContentHeight` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->