### PR TITLE
fix(@vben-core/shadcn-ui): 补全 ScrollArea onScroll 滚动事件透传

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/ui/scroll-area/ScrollArea.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/scroll-area/ScrollArea.vue
@@ -11,10 +11,13 @@ import { ScrollAreaCorner, ScrollAreaRoot, ScrollAreaViewport } from 'reka-ui';
 import ScrollBar from './ScrollBar.vue';
 
 const props = defineProps<
-  ScrollAreaRootProps & { class?: HTMLAttributes['class'] }
+  ScrollAreaRootProps & {
+    class?: HTMLAttributes['class'];
+    onScroll?: (event: Event) => void;
+  }
 >();
 
-const delegatedProps = reactiveOmit(props, 'class');
+const delegatedProps = reactiveOmit(props, 'class', 'onScroll');
 </script>
 
 <template>
@@ -27,6 +30,7 @@ const delegatedProps = reactiveOmit(props, 'class');
       as-child
       data-slot="scroll-area-viewport"
       class="h-full w-full rounded-[inherit] focus:outline-hidden"
+      @scroll="props.onScroll"
     >
       <slot></slot>
     </ScrollAreaViewport>


### PR DESCRIPTION
## Description

修复 shadcn v4 升级后`ScrollArea` 组件未透传 `onScroll` 滚动事件的问题，该问题导致`Tabs`组件滚动无法联动。

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ScrollArea component now exposes an `onScroll` prop to enable handling of scroll events on scroll areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->