### PR TITLE
fix: add includes in mock tsconfig

### DIFF
--- a/apps/backend-mock/tsconfig.json
+++ b/apps/backend-mock/tsconfig.json
@@ -6,5 +6,6 @@
       "~/*": ["./*"]
     }
   },
+  "include": ["**/*.ts", "**/.*.ts"],
   "exclude": ["node_modules", "dist", ".nitro"]
 }


### PR DESCRIPTION
## Description

修复 backend-mock 应用 `.post.ts` 文件被 TypeScript 的 include 规则漏掉问题。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration for improved compiler file inclusion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->