### PR TITLE
fix: 修复弹框自定义宽度 class 被默认 max-w 覆盖的问题

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
@@ -243,7 +243,6 @@ function handleClosed() {
         cn(
           'inset-x-0 top-[10vh] mx-auto flex w-130 flex-col p-0',
           shouldFullscreen ? 'rounded-none' : 'rounded-(--radius)',
-          modalClass,
           {
             'border border-border': bordered,
             'shadow-3xl': !bordered,
@@ -255,6 +254,7 @@ function handleClosed() {
             'duration-300': !dragging,
             hidden: isClosed,
           },
+          modalClass,
         )
       "
       :force-mount="getForceMount"


### PR DESCRIPTION
将 modalClass 参数移至 cn() 末尾，确保用户通过 class 传入的宽度样式
优先于内置默认的 max-w-[calc(100vw-20px)] 生效，使 业务使用Modal 上的自定义的max-w-[50%] 等方式能正确控制弹框宽度。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the order of modal styling classes to keep layout and appearance rules applied consistently.
  * No user-facing behavior or interaction changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->