### PR TITLE
docs: update nitro mock server url

### DIFF
--- a/docs/src/en/guide/essentials/server.md
+++ b/docs/src/en/guide/essentials/server.md
@@ -4,7 +4,7 @@
 
 This document explains how to use Mock data and interact with the server in a development environment, involving technologies such as:
 
-- [Nitro](https://nitro.unjs.io/) A lightweight backend server that can be deployed anywhere, used as a Mock server in the project.
+- [Nitro](https://nitro.build/) A lightweight backend server that can be deployed anywhere, used as a Mock server in the project.
 - [axios](https://axios-http.com/docs/intro) Used to send HTTP requests to interact with the server.
 
 :::
@@ -340,13 +340,13 @@ The new version no longer supports mock in the production environment. Please us
 
 Mock data is an indispensable part of frontend development, serving as a key link in separating frontend and backend development. By agreeing on interfaces with the server side in advance and simulating request data and even logic, frontend development can proceed independently, without being blocked by the backend development process.
 
-The project uses [Nitro](https://nitro.unjs.io/) for local mock data processing. The principle is to start an additional backend service locally, which is a real backend service that can handle requests and return data.
+The project uses [Nitro](https://nitro.build/) for local mock data processing. The principle is to start an additional backend service locally, which is a real backend service that can handle requests and return data.
 
 ### Using Nitro
 
 The mock service code is located in the `apps/backend-mock` directory. It does not need to be started manually and is already integrated into the project. You only need to run `pnpm dev` in the project root directory. After running successfully, the console will print `http://localhost:5320/api`, and you can access this address to view the mock service.
 
-[Nitro](https://nitro.unjs.io/) syntax is simple, and you can configure and develop according to your needs. For specific configurations, you can refer to the [Nitro documentation](https://nitro.unjs.io/).
+[Nitro](https://nitro.build/) syntax is simple, and you can configure and develop according to your needs. For specific configurations, you can refer to the [Nitro documentation](https://nitro.build/docs/).
 
 ## Disabling Mock Service
 

--- a/docs/src/en/index.md
+++ b/docs/src/en/index.md
@@ -69,7 +69,7 @@ features:
     icon:
       src: /logos/nitro.svg
     details: Built-in Nitro Mock service makes your mock service more powerful.
-    link: https://nitro.unjs.io/
+    link: https://nitro.build/
     linkText: Official Site
 ---
 

--- a/docs/src/guide/essentials/server.md
+++ b/docs/src/guide/essentials/server.md
@@ -4,7 +4,7 @@
 
 本文档介绍如何在开发环境下使用 Mock 数据和与服务端进行交互，涉及到的技术有：
 
-- [Nitro](https://nitro.unjs.io/) 轻量级后端服务器，可部署在任何地方，项目用作于 Mock 服务器。
+- [Nitro](https://nitro.build/) 轻量级后端服务器，可部署在任何地方，项目用作于 Mock 服务器。
 - [axios](https://axios-http.com/docs/intro) 用于发送 HTTP 请求与服务端进行交互。
 
 :::
@@ -371,13 +371,13 @@ async function doRefreshToken() {
 
 Mock 数据是前端开发过程中必不可少的一环，是分离前后端开发的关键链路。通过预先跟服务器端约定好的接口，模拟请求数据甚至逻辑，能够让前端开发独立自主，不会被服务端的开发进程所阻塞。
 
-项目使用 [Nitro](https://nitro.unjs.io/) 来进行本地 mock 数据处理。其原理是本地额外启动一个后端服务，是一个真实的后端服务，可以处理请求，返回数据。
+项目使用 [Nitro](https://nitro.build/) 来进行本地 mock 数据处理。其原理是本地额外启动一个后端服务，是一个真实的后端服务，可以处理请求，返回数据。
 
 ### Nitro 使用
 
 Mock 服务代码位于`apps/backend-mock`目录下，无需手动启动，已经集成在项目中，只需要在项目根目录下运行`pnpm dev`即可，运行成功之后，控制台会打印 `http://localhost:5320/api`, 访问该地址即可查看 mock 服务。
 
-[Nitro](https://nitro.unjs.io/) 语法简单，可以根据自己的需求进行配置及开发，具体配置可以查看 [Nitro 文档](https://nitro.unjs.io/)。
+[Nitro](https://nitro.build/) 语法简单，可以根据自己的需求进行配置及开发，具体配置可以查看 [Nitro 文档](https://nitro.build/docs/)。
 
 ## 关闭 Mock 服务
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,7 +72,7 @@ features:
     icon:
       src: /logos/nitro.svg
     details: 内置 Nitro Mock 服务，让你的 mock 服务更加强大。
-    link: https://nitro.unjs.io/
+    link: https://nitro.build/
     linkText: 官方站点
 ---
 


### PR DESCRIPTION
closed 8113

## Description

<!-- Please describe the change as necessary. If it's a feature or enhancement please be as detailed as possible. If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

 -->

<!-- You can also add additional context here -->

nitro mock server 链接替换

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nitro-related links across the docs and homepage to point to the new `nitro.build` site.
  * Kept the surrounding guidance intact while improving link consistency in the server, data mocking, and feature sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->