### PR TITLE
fix: 修复 demos/antd 中 message/notification duration 单位错误导致提示框不消失

### DIFF
--- a/apps/web-antd/src/views/demos/antd/index.vue
+++ b/apps/web-antd/src/views/demos/antd/index.vue
@@ -12,7 +12,8 @@ function info() {
 function error() {
   message.error({
     content: 'Once upon a time you dressed so fine',
-    duration: 2500,
+    // ant-design-vue 的 message.duration 单位是「秒」, 不是毫秒
+    duration: 2.5,
   });
 }
 
@@ -25,7 +26,8 @@ function success() {
 
 function notify(type: NotificationType) {
   notification[type]({
-    duration: 2500,
+    // ant-design-vue 的 notification.duration 单位是「秒」, 不是毫秒
+    duration: 2.5,
     message: '说点啥呢',
     type,
   });


### PR DESCRIPTION
## Description

修复 #8144

在 `apps/web-antd/src/views/demos/antd/index.vue` 中,`error()` (Message) 和 `notify()` (Notification) 函数传入了 `duration: 2500`,本意是 2.5 秒。但 ant-design-vue 的 `message` / `notification` 的 `duration` 单位是**秒**而不是毫秒,所以 `2500` 被解释为 2500 秒(约 41 分钟),导致提示框看起来一直不消失。

### 根因
- `ant-design-vue@4.2.6` 的 `message/index.js`: `let defaultDuration = 3;`(单位:秒)
- `vc-notification/Notice.js`: `setTimeout(..., duration.value * 1000)` —— 库内部把秒转成毫秒再喂给 setTimeout
- demo 误把单位当成毫秒,写了 `2500`,被库当成 2500 秒

### 改动内容
- `message.error`: `duration: 2500` → `2.5`
- `notification[type]`(信息/错误/警告/成功四个按钮共用同一个 `notify()` 函数): `duration: 2500` → `2.5`
- 两处均补充注释,说明 ant-design-vue 的 `duration` 单位是秒,避免后续再次误改

### 关于 issue 影响范围
issue 只反馈了 Message 卡片的"错误"按钮,但 Notification 卡片(信息/错误/警告/成功)存在完全相同的 bug —— 四个按钮共用 `notify()` 且都传了 `duration: 2500`。本 PR 一并修复。

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected message and notification display durations in the Ant Design Vue demo to use seconds, ensuring they disappear at the intended time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->