### PR TITLE
fix(project): 修复弹窗中表单上传组件预览图片层级问题

### DIFF
--- a/apps/web-antdv-next/src/adapter/component/index.ts
+++ b/apps/web-antdv-next/src/adapter/component/index.ts
@@ -295,7 +295,7 @@ async function previewImage(
         return h(
           PreviewGroupComponent,
           {
-            class: 'hidden',
+            classes: { popup: { root: '!z-2000' } },
             preview: {
               open: open.value,
               current: currentIndex,

--- a/playground/src/adapter/component/index.ts
+++ b/playground/src/adapter/component/index.ts
@@ -295,7 +295,7 @@ async function previewImage(
         return h(
           PreviewGroupComponent,
           {
-            class: 'hidden',
+            classes: { popup: { root: '!z-2000' } },
             preview: {
               open: open.value,
               current: currentIndex,


### PR DESCRIPTION
## Description

修复表单中的上传组件在弹窗（Modal/Drawer）内点击预览图片时，预览浮层被弹窗层级遮挡、无法正常显示的问题。

**根因**：`previewImage` 在渲染 `PreviewGroupComponent` 时使用了 `class: 'hidden'`，该属性在antdv中已不生效，并且antdv在预览图片时会自动给body添加 overflow: hidden，所以此处不需要配置hidden，但是弹窗的默认层级是2000会高于预览图片的1080。

**修复**：去掉 `hidden` class，改用组件库提供的 `classes.popup.root` 配置，为预览浮层根节点显式提升 `z-index`（`!z-2000`），因为预览图片的节点会在预览触发时加入到页面节点，所以一定会在弹窗节点之后，相同层级也会覆盖在弹窗之上，可最小影响程度修复层级问题。

涉及两个示例应用的组件适配器（共两处相同改动）：

- `apps/web-antdv-next/src/adapter/component/index.ts`
- `playground/src/adapter/component/index.ts`

非破坏性改动，仅修正预览行为，不影响其他逻辑。

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image preview popups so they appear above other interface elements.
  - Fixed preview visibility behavior by removing styling that could hide the popup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->