### PR TITLE
fix(@vben-core/form-ui): 兼容 zod v4 的 ZodArray

### DIFF
--- a/packages/@core/ui-kit/form-ui/src/form-render/helper.ts
+++ b/packages/@core/ui-kit/form-ui/src/form-render/helper.ts
@@ -22,6 +22,15 @@ export function getBaseRules(schema?: null | string | ZodType): null | ZodType {
     return getBaseRules(rawSchema.in as ZodType);
   }
 
+  // In zod v4, ZodArray also has an unwrap() that returns its element type
+  // (not an outer wrapper). We must not unwrap it, otherwise z.array(T) loses
+  // its array shell and array values fail validation.
+  const defType = (rawSchema as unknown as { _zod?: { def: { type: string } } })
+    ._zod?.def?.type;
+  if (defType === 'array') {
+    return rawSchema;
+  }
+
   const unwrappedSchema = (rawSchema as UnwrappableZodType).unwrap?.();
   if (unwrappedSchema && unwrappedSchema !== rawSchema) {
     return getBaseRules(unwrappedSchema);


### PR DESCRIPTION
兼容 zod v4 的 ZodArray，避免误用 unwrap() 丢失数组外壳导致数组校验失败

## Description

### Bug

使用 `z.array(...)` 定义 `rules` 的表单字段，在提交校验时报 `"Invalid input: expected array, received undefined"`，即使字段值是合法数组也会失败。此问题影响所有 `rules` 为 `z.array(...)` 的字段（无论是否带 `.refine()`），常见于绑定多值自定义组件（如通过 `defineModel` 绑定 `[type, path]` 元组的输入组件）。

### Reproduction

```ts
// schema
{
  fieldName: 'skip',
  component: markRaw(MyArrayInput),
  rules: z
    .array(z.union([z.string(), z.number(), z.null(), z.undefined()]))
    .refine((v) => !!v[0], { message: '请选择跳转类型' })
    .refine((v) => !!v[1], { message: '请输入自定义跳转路径' }),
}

// set a valid array value, then validate
await formApi.setValues({ skip: [1, '/path'] });
const { valid } = await formApi.validate();
// valid === false, errors: { skip: 'Invalid input' }
```

直接调用 `rules.safeParse([1, '/path'])` 能通过，仅经过表单校验路径时才失败。

### Root Cause

`getBaseRules` (`packages/@core/ui-kit/form-ui/src/form-render/helper.ts`) 递归调用 `unwrap()` 来剥离 `optional` / `default` / `nullable` 等外层包装：

```ts
const unwrappedSchema = (rawSchema as UnwrappableZodType).unwrap?.();
if (unwrappedSchema && unwrappedSchema !== rawSchema) {
  return getBaseRules(unwrappedSchema);
}
```

在 zod v3 中，只有 `ZodOptional` / `ZodDefault` / `ZodNullable` 等包装类型实现了 `unwrap()`，语义是「去掉外层包装」。但在 **zod v4** 中，`ZodArray` **也**实现了 `unwrap()`，且语义不同——返回的是**元素类型**，而非去掉外层包装：

```ts
z.array(z.string()).unwrap() // → z.string()
```

因此对 `z.array(T).refine()` 的递归会变成：

```
z.array(T).refine().refine()
  → unwrap()  → z.array(T)
  → unwrap()  → T              ← array shell lost
```

解包后得到的 `T`（如 `z.union([...])`）随后在 `validateFieldValue` 中用于 `safeParseAsync(value)`。用非数组 schema 校验数组值，必然产生 `"Invalid input"`。

在 zod v4.4.3 下验证，以下类型均暴露 `unwrap()`：

| `_zod.def.type` | `unwrap()` semantics | should unwrap? |
|---|---|---|
| `optional` | strips optional wrapper | ✅ yes |
| `default` | strips default wrapper | ✅ yes |
| `nullable` | strips nullable wrapper | ✅ yes |
| `array` | **returns element type** | ❌ no |

### Fix

在 unwrap 递归前，当 `_zod.def.type === 'array'` 时直接返回原始 schema，跳过 unwrap，保留数组外壳：

```ts
const defType = (rawSchema as unknown as { _zod?: { def: { type: string } } })
  ._zod?.def?.type;
if (defType === 'array') {
  return rawSchema;
}
```

### Verification

- Before: `validate()` returns `{ valid: false, errors: { skip: 'Invalid input' } }` for value `[1, '/path']`
- After: `validate()` returns `{ valid: true, errors: {} }`
- Existing `optional` / `default` / `nullable` unwrapping behavior unchanged (only `array` is short-circuited)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of array validations when using Zod v4.
  * Prevented array-level validation rules from being lost during form processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->