### PR TITLE
fix(@vben/locales): fix ambiguous button text in lock screen modal

### DIFF
--- a/packages/locales/src/langs/en-US/ui.json
+++ b/packages/locales/src/langs/en-US/ui.json
@@ -149,7 +149,7 @@
     },
     "lockScreen": {
       "title": "Lock Screen",
-      "screenButton": "Unlock",
+      "screenButton": "Lock",
       "password": "Password",
       "placeholder": "Please enter password",
       "unlock": "Click to unlock",

--- a/packages/locales/src/langs/zh-CN/ui.json
+++ b/packages/locales/src/langs/zh-CN/ui.json
@@ -149,7 +149,7 @@
     },
     "lockScreen": {
       "title": "锁定屏幕",
-      "screenButton": "解锁",
+      "screenButton": "锁定",
       "password": "密码",
       "placeholder": "请输入锁屏密码",
       "unlock": "点击解锁",


### PR DESCRIPTION
## Description

The confirm button in the **lock screen setup modal** (`lock-screen-modal.vue`) currently shows **"解锁" / "Unlock"**, but clicking it calls `accessStore.lockScreen(password)` — i.e. its actual action is to **lock** the screen, not unlock it. This is contradictory to the modal title "锁定屏幕 / Lock Screen" and confuses users.

### Root cause

PR #7930 changed `ui.widgets.lockScreen.screenButton` from `锁定/Locking` → `解锁/Unlock`. This appears to be a mix-up with the sibling key `ui.widgets.lockScreen.unlock` ("点击解锁 / Click to unlock"), which is correctly used on the **already-locked full-screen unlock page** (`lock-screen.vue`).

The two keys serve different UIs:

| key | value (current) | used in | actual action | correct text |
|-----|-----------------|---------|---------------|--------------|
| `screenButton` | 解锁 / Unlock | `lock-screen-modal.vue` (lock setup modal) | `lockScreen()` → **lock** | should be 锁定 / Lock |
| `unlock` | 点击解锁 / Click to unlock | `lock-screen.vue` (locked screen unlock page) | `unlockScreen()` → **unlock** | correct, unchanged |

### Code evidence

`packages/effects/layouts/src/widgets/lock-screen/lock-screen-modal.vue`:
```vue
<VbenButton class="mt-1 w-full" @click="handleSubmit">
  {{ $t('ui.widgets.lockScreen.screenButton') }}
</VbenButton>
```
`handleSubmit()` → `emit('submit')` → `accessStore.lockScreen(lockScreenPassword)` (lock the screen).

### Changes

- `zh-CN/ui.json`: `screenButton` 「解锁」→ **「锁定」**
- `en-US/ui.json`: `screenButton` 「Unlock」→ **「Lock」**

The `unlock` key is left unchanged (it is semantically correct).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Please, don't make changes to \`pnpm-lock.yaml\` unless you introduce a new test example.

## Checklist

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with \`feat:\`, \`fix:\`, \`perf:\`, \`docs:\`, or \`chore:\`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the lock screen action button labels in English and Simplified Chinese to display “Lock” and “锁定” instead of unlock actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->