### PR TITLE
fix(@vben-core/form-ui)!: group field slot component props

### DIFF
--- a/docs/src/components/common-ui/vben-form.md
+++ b/docs/src/components/common-ui/vben-form.md
@@ -385,7 +385,9 @@ async function fillForm() {
 </template>
 ```
 
-字段命名插槽提供 `field`、`componentField`、`modelValue`、`name`、`disabled`、`isInValid`、`values` 和 `formApi`。默认插槽提供 `shapes`、`values` 和 `formApi`；`reset-before`、`submit-before`、`expand-before`、`expand-after` 提供 `values` 和 `formApi`。未声明 `TValues` 时仍兼容任意字段名，但 slot props 会回退为宽泛类型。
+字段命名插槽提供完整控件绑定 `componentProps`，以及 `field`、`componentField`、`modelValue`、`name`、`disabled`、`isInValid`、`values` 和 `formApi`。默认插槽提供 `shapes`、`values` 和 `formApi`；`reset-before`、`submit-before`、`expand-before`、`expand-after` 提供 `values` 和 `formApi`。
+
+建议为表单声明没有字符串索引签名的精确接口，使每个字段插槽都能推导自己的值类型。使用 `Record<string, unknown>` 等宽泛类型时，slot props 仍保持完整结构，不再整体退化为 `any`，但字段值只能推导为索引值类型。
 
 ### FormApi
 
@@ -746,6 +748,18 @@ import { z } from '#/adapter/form';
 
 ::: tip 字段插槽
 
-除了以上内置插槽之外，`schema`属性中每个字段的`fieldName`都可以作为插槽名称，这些字段插槽的优先级高于`component`定义的组件。也就是说，当提供了与`fieldName`同名的插槽时，这些插槽的内容将会作为这些字段的组件，此时`component`的值将会被忽略。
+除了以上内置插槽之外，`schema` 属性中每个字段的 `fieldName` 都可以作为插槽名称。这些字段插槽的优先级高于 `component` 定义的组件。
+
+字段 slot 的控件绑定统一收拢在 `componentProps` 中，其中包含模型值、对应的 `update:*` 事件、schema/common/dependencies props 和 disabled 状态：
+
+```vue
+<Form>
+  <template #fieldName="slotProps">
+    <Input v-bind="slotProps.componentProps" />
+  </template>
+</Form>
+```
+
+这是字段 slot 的破坏性边界：旧写法 `v-bind="slotProps"` 必须迁移为 `v-bind="slotProps.componentProps"`。`field`、`componentField`、`modelValue`、`name`、`disabled`、`isInValid`、`values` 和 `formApi` 仍保留在 slot 根级，供模板逻辑使用，不会自动传入实际控件。
 
 :::

--- a/docs/src/demos/vben-form/custom/index.vue
+++ b/docs/src/demos/vben-form/custom/index.vue
@@ -62,7 +62,7 @@ function onSubmit(values: Record<string, any>) {
 <template>
   <Form>
     <template #field3="slotProps">
-      <Input placeholder="请输入" v-bind="slotProps" />
+      <Input placeholder="请输入" v-bind="slotProps.componentProps" />
     </template>
   </Form>
 </template>

--- a/docs/src/en/components/common-ui/vben-form.md
+++ b/docs/src/en/components/common-ui/vben-form.md
@@ -252,7 +252,23 @@ async function fillForm() {
 </template>
 ```
 
-Named field slots expose `field`, `componentField`, `modelValue`, `name`, `disabled`, `isInValid`, `values`, and `formApi`. The default slot exposes `shapes`, `values`, and `formApi`; action slots expose `values` and `formApi`. Forms without an explicit `TValues` remain compatible with arbitrary slot names and broad props.
+Named field slots expose grouped control bindings through `componentProps`, together with `field`, `componentField`, `modelValue`, `name`, `disabled`, `isInValid`, `values`, and `formApi`. The default slot exposes `shapes`, `values`, and `formApi`; action slots expose `values` and `formApi`.
+
+Use a precise form-value interface without a string index signature to infer each field value. A broad type such as `Record<string, unknown>` keeps the complete slot-prop structure instead of degrading the whole scope to `any`, but field values can only use the declared index value type.
+
+## Field Slot Migration
+
+Control bindings are grouped under `componentProps`. It contains the model value, matching `update:*` event, schema/common/dependency props, and disabled state:
+
+```vue
+<Form>
+  <template #fieldName="slotProps">
+    <Input v-bind="slotProps.componentProps" />
+  </template>
+</Form>
+```
+
+This is the breaking boundary for named field slots: migrate `v-bind="slotProps"` to `v-bind="slotProps.componentProps"`. Root metadata remains available for template logic through `field`, `componentField`, `modelValue`, `name`, `disabled`, `isInValid`, `values`, and `formApi`; it is no longer forwarded automatically to the rendered control.
 
 ## Form Codec
 

--- a/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils';
 
-import type { FormSchemaRuleType } from '../src/types';
+import type { FormSchemaRuleType, VbenFormFieldSlotProps } from '../src/types';
 
 import { flushPromises, mount } from '@vue/test-utils';
 import { defineComponent, h, nextTick } from 'vue';
@@ -130,6 +130,58 @@ describe('useVbenForm integration', () => {
     await flushPromises();
 
     expect(wrapper.get('.slot-value').text()).toBe('Grace');
+  });
+
+  it('groups control bindings in field slot componentProps', async () => {
+    interface SlotFormValues {
+      name: string;
+    }
+
+    let latestSlotProps:
+      | undefined
+      | VbenFormFieldSlotProps<SlotFormValues, 'name'>;
+    const [Form, formApi] = useVbenForm<SlotFormValues>({
+      schema: [
+        {
+          component: TestInput,
+          defaultValue: 'Ada',
+          fieldName: 'name',
+        },
+      ],
+    });
+    const wrapper = mount(Form, {
+      slots: {
+        name(slotProps: VbenFormFieldSlotProps<SlotFormValues, 'name'>) {
+          latestSlotProps = slotProps;
+          return h(TestInput, {
+            ...slotProps.componentProps,
+            class: 'slot-component',
+          });
+        },
+      },
+    });
+    wrappers.push(wrapper);
+    await flushPromises();
+
+    expect(latestSlotProps).toBeDefined();
+    if (!latestSlotProps) return;
+    expect(latestSlotProps.formApi).toBe(formApi);
+    expect(latestSlotProps.values).toEqual({ name: 'Ada' });
+    expect(latestSlotProps.modelValue).toBe('Ada');
+    expect(latestSlotProps.componentProps.modelValue).toBe('Ada');
+    expect(latestSlotProps.componentProps.disabled).toBe(false);
+    expect(latestSlotProps.componentProps).toHaveProperty(
+      'onUpdate:modelValue',
+    );
+    expect(latestSlotProps.componentProps).not.toHaveProperty('formApi');
+    expect(latestSlotProps.componentProps).not.toHaveProperty('values');
+    expect(latestSlotProps).not.toHaveProperty('onUpdate:modelValue');
+
+    await wrapper.get('.slot-component').setValue('Grace');
+    await flushPromises();
+
+    expect(latestSlotProps.modelValue).toBe('Grace');
+    expect(latestSlotProps.values.name).toBe('Grace');
   });
 
   it('supports a field-level change event fallback for legacy components', async () => {

--- a/packages/@core/ui-kit/form-ui/__tests__/form-types.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-types.test.ts
@@ -141,12 +141,26 @@ describe('form public types', () => {
       EmailSlotProps['field']['state']['value']
     >().toEqualTypeOf<string>();
     expectTypeOf<EmailSlotProps['values']>().toEqualTypeOf<AccountFormValues>();
+    expectTypeOf<
+      EmailSlotProps['componentProps']['modelValue']
+    >().toEqualTypeOf<string | undefined>();
     expectTypeOf<EmailSlotProps['formApi']>().toEqualTypeOf<
       ExtendedFormApi<AccountFormValues>
     >();
     expectTypeOf<
       DefaultSlotProps['values']
     >().toEqualTypeOf<AccountFormValues>();
+
+    const [WideForm] = useVbenForm<Record<string, unknown>>({ schema: [] });
+    type WideFormSlots = InstanceType<typeof WideForm>['$slots'];
+    type WideFieldSlot = NonNullable<WideFormSlots['dynamic-field']>;
+    type WideFieldSlotProps = Parameters<WideFieldSlot>[0];
+
+    expectTypeOf<WideFieldSlotProps>().not.toBeAny();
+    expectTypeOf<WideFieldSlotProps['modelValue']>().toEqualTypeOf<unknown>();
+    expectTypeOf<WideFieldSlotProps['values']>().toEqualTypeOf<
+      Record<string, unknown>
+    >();
   });
 
   it('keeps form and submit values distinct with a codec', () => {

--- a/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
@@ -264,7 +264,7 @@ watch(
 );
 
 const shouldDisabled = computed(() => {
-  return isDisabled.value || disabled || computedProps.value?.disabled;
+  return Boolean(isDisabled.value || disabled || computedProps.value?.disabled);
 });
 
 const customContentRender = computed(() => {
@@ -354,6 +354,7 @@ function createComponentProps(slotProps: RuntimeFieldSlotProps) {
     ...normalizedSlotProps.componentField,
     ...computedProps.value,
     ...bindEvents,
+    disabled: shouldDisabled.value,
     ...(Reflect.has(computedProps.value, 'onChange')
       ? { onChange: computedProps.value.onChange }
       : {}),
@@ -363,6 +364,17 @@ function createComponentProps(slotProps: RuntimeFieldSlotProps) {
   };
 
   return binds;
+}
+
+function createFieldSlotScope(slotProps: RuntimeFieldSlotProps) {
+  return {
+    ...createFieldSlotProps(slotProps),
+    componentProps: createComponentProps(slotProps),
+    disabled: shouldDisabled.value,
+    isInValid: isInValid.value,
+    modelValue: fieldValue.value,
+    name: fieldName,
+  };
 }
 
 function autofocus() {
@@ -470,14 +482,7 @@ onUnmounted(() => {
                 :class="cn('relative flex w-full items-center', wrapperClass)"
               >
                 <FormControl :class="cn(controlClass)">
-                  <slot
-                    v-bind="{
-                      ...createFieldSlotProps(slotProps),
-                      ...createComponentProps(slotProps),
-                      disabled: shouldDisabled,
-                      isInValid,
-                    }"
-                  >
+                  <slot v-bind="createFieldSlotScope(slotProps)">
                     <component
                       :is="FieldComponent"
                       ref="fieldComponentRef"
@@ -486,7 +491,6 @@ onUnmounted(() => {
                           shouldApplyInvalidStyle,
                       }"
                       v-bind="createComponentProps(slotProps)"
-                      :disabled="shouldDisabled"
                     >
                       <template
                         v-for="name in renderContentKey"

--- a/packages/@core/ui-kit/form-ui/src/index.ts
+++ b/packages/@core/ui-kit/form-ui/src/index.ts
@@ -19,6 +19,7 @@ export type {
   VbenFormFieldArrayProps,
   VbenFormFieldSlotProps,
   VbenFormProps,
+  VbenFormResolvedComponentProps,
   FormSchema as VbenFormSchema,
   VbenFormSlots,
 } from './types';

--- a/packages/@core/ui-kit/form-ui/src/types.ts
+++ b/packages/@core/ui-kit/form-ui/src/types.ts
@@ -235,18 +235,35 @@ export interface VbenFormDefaultSlotProps<
 
 export interface VbenFormFieldSlotProps<
   TValues extends FormValues = FormValues,
-  TFieldName extends KnownFormFieldName<TValues> = KnownFormFieldName<TValues>,
+  TFieldName extends FormFieldName<TValues> = FormFieldName<TValues>,
   T extends BaseFormComponentType = BaseFormComponentType,
   P extends Record<string, any> = Record<never, never>,
   TSubmitValues extends FormValues = TValues,
 > extends VbenFormActionSlotProps<TValues, T, P, TSubmitValues> {
-  componentField: FormComponentField<TValues[TFieldName], TFieldName>;
+  componentField: FormComponentField<
+    FormFieldValue<TValues, TFieldName>,
+    TFieldName
+  >;
+  componentProps: VbenFormResolvedComponentProps<
+    FormFieldValue<TValues, TFieldName>,
+    TFieldName
+  >;
   disabled: boolean;
-  field: FormRuntimeField<TValues[TFieldName]>;
+  field: FormRuntimeField<FormFieldValue<TValues, TFieldName>>;
   isInValid: boolean;
-  modelValue: TValues[TFieldName];
+  modelValue: FormFieldValue<TValues, TFieldName>;
   name: TFieldName;
 }
+
+export type VbenFormResolvedComponentProps<
+  TValue = unknown,
+  TFieldName extends string = string,
+> = MaybeComponentProps & {
+  disabled: boolean;
+  modelValue?: TValue;
+  name: TFieldName;
+  'onUpdate:modelValue'?: (value: TValue) => void;
+};
 
 type VbenFormFieldSlots<
   TValues extends FormValues,
@@ -255,7 +272,19 @@ type VbenFormFieldSlots<
   TSubmitValues extends FormValues,
 > =
   string extends Extract<keyof TValues, string>
-    ? Record<string, ((props: any) => any) | undefined>
+    ? Record<
+        string,
+        | ((
+            props: VbenFormFieldSlotProps<
+              TValues,
+              FormFieldName<TValues>,
+              T,
+              P,
+              TSubmitValues
+            >,
+          ) => any)
+        | undefined
+      >
     : {
         [TFieldName in KnownFormFieldName<TValues>]?: (
           props: VbenFormFieldSlotProps<

--- a/playground/src/views/demos/badge/index.vue
+++ b/playground/src/views/demos/badge/index.vue
@@ -91,7 +91,7 @@ function updateMenuBadge() {
     <Card title="徽标更新">
       <Form>
         <template #badgeVariants="slotProps">
-          <RadioGroup v-bind="slotProps">
+          <RadioGroup v-bind="slotProps.componentProps">
             <Radio
               v-for="color in colors"
               :key="color.value"

--- a/playground/src/views/examples/form/custom.vue
+++ b/playground/src/views/examples/form/custom.vue
@@ -124,7 +124,7 @@ function onSubmit(values: CustomSubmitValues) {
     <Card title="基础示例">
       <Form>
         <template #field3="slotProps">
-          <Input placeholder="请输入" v-bind="slotProps" />
+          <Input placeholder="请输入" v-bind="slotProps.componentProps" />
         </template>
       </Form>
     </Card>

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -108,7 +108,7 @@ function getNodeClass(node: Recordable<any>) {
             bordered
             :default-expanded-level="2"
             :get-node-class="getNodeClass"
-            v-bind="slotProps"
+            v-bind="slotProps.componentProps"
             value-field="id"
             label-field="meta.title"
             icon-field="meta.icon"

--- a/playground/src/views/system/user/modules/form.vue
+++ b/playground/src/views/system/user/modules/form.vue
@@ -107,7 +107,7 @@ function getNodeClass(node: Recordable<any>) {
             bordered
             :default-expanded-level="2"
             :get-node-class="getNodeClass"
-            v-bind="slotProps"
+            v-bind="slotProps.componentProps"
             value-field="id"
             label-field="name"
           />


### PR DESCRIPTION
## Description

This PR introduces an explicit breaking contract for named form-field slots by separating **control bindings** from **form metadata**.

It was extracted from #8208 so that the dynamic-component feature can remain non-breaking and be reviewed independently. PR #8208 now preserves the existing flattened field-slot runtime contract; this PR contains only the slot-contract cleanup, repository migrations, tests, and documentation.

### Why this change is needed

A named field slot currently receives one flattened object containing two different categories of data:

1. bindings intended for the rendered control, such as the model prop, `update:*` listener, `onBlur`, `onChange`, schema/common/dependency props, and disabled state;
2. form metadata intended for template logic, such as `field`, `componentField`, `modelValue`, validation state, `values`, and `formApi`.

The usual `v-bind="slotProps"` pattern forwards both categories to the control. That leaks form internals and full-form context into custom components or native elements, can produce fallthrough attributes and warnings, couples controls to the form engine, and makes the public type impossible to model faithfully because arbitrary component props are mixed with a fixed metadata contract.

This PR groups only the control-facing bindings under `slotProps.componentProps`. Root slot props remain the stable form-context surface.

```vue
<template #fieldName="slotProps">
  <Input v-bind="slotProps.componentProps" />
</template>
```

### Exact breaking boundary

#### Runtime

The following values are no longer flattened onto the field slot root:

- component-specific model props such as `value` or `checked`;
- `onUpdate:*`, `onBlur`, `onChange`, and `onInput` control listeners;
- schema, common, and dependency-resolved component props;
- other attributes intended only for the rendered control.

They are available through `slotProps.componentProps` instead.

The following metadata remains available at the field slot root:

- `field` and `componentField`;
- `modelValue`, `name`, `disabled`, and `isInValid`;
- `values` and the public `ExtendedFormApi` exposed as `formApi`.

`formApi` and `values` are deliberately **not** copied into `componentProps`, so custom controls do not receive the full form context implicitly.

#### TypeScript

- `VbenFormFieldSlotProps` now declares the grouped `componentProps` contract.
- Forms using broad value types such as `Record<string, unknown>` no longer degrade the entire field slot scope to `any`; field values instead use the declared index value type.
- `VbenFormResolvedComponentProps` is exported for consumers that need to describe the resolved control-binding object.

#### Migration

```vue
<!-- Before -->
<Input v-bind="slotProps" />

<!-- After -->
<Input v-bind="slotProps.componentProps" />
```

The repository consumers in the badge demo, custom-form demo, role form, user form, and documentation demo are migrated in this PR.

### Why not use the alternatives

#### Keep flattened props and add `componentProps` as a duplicate

This is runtime-compatible, but it creates two sources for the same model props and listeners. Consumers can bind both accidentally, precedence becomes unclear, metadata continues leaking into controls, and the old unsafe pattern remains the easiest pattern to copy. It postpones rather than resolves the contract problem.

#### Add a compatibility flag or deprecation period

A per-form or global flag would require maintaining two slot shapes through every forwarding layer. It increases test combinations, makes component-library behavior depend on configuration, and still cannot give one accurate static slot type. Because this change is already isolated into its own breaking PR, an explicit migration is easier to review and maintain than a long-lived dual contract.

#### Automatically filter metadata while preserving `v-bind="slotProps"`

An allowlist or denylist is not reliable for arbitrary registered components. Business components may legitimately define props named `values`, `name`, `disabled`, or `field`; future form metadata would also require filter maintenance. A proxy or runtime filter would hide the boundary rather than make it explicit and would remain difficult to type.

#### Put `formApi` and `values` inside `componentProps`

That would make access convenient but couples every custom control to the complete form, forwards methods and reactive full-form state unnecessarily, and can cause broad reactive subscriptions. Form context belongs to the slot template, and controls should receive only explicitly selected business props.

#### Fix only the TypeScript `any` fallback

Changing types without changing runtime would claim that the root has a stable structure while arbitrary control props are still merged into it. That produces false type safety and preserves the accidental forwarding behavior.

#### Use only `componentField`

`componentField` contains the form-engine field bridge, but it does not include schema/common/dependency-resolved component props or the normalized disabled state. It therefore cannot represent the complete binding object expected by a custom rendered control.

### `formApi` and `values` ownership

The public field-slot type exposes an `ExtendedFormApi`. `form-field.vue` owns only the internal `FormContextApi`, so it must not inject that internal object as the public `formApi`. The public `vben-use-form.vue` wrapper supplies the external controller and live `form.values` while forwarding named slots. Integration tests assert the external object identity and verify that neither value enters `componentProps`.

### Validation

- `pnpm test:unit` — 47 test files and 414 tests passed.
- Focused Form UI suite — 31 tests passed.
- `pnpm --filter @vben/playground typecheck` passed.
- `pnpm --filter @vben/docs build` passed.
- Scoped ESLint and oxfmt checks passed.
- Pre-commit oxlint, oxfmt, ESLint, stylelint, repository type checks, and commitlint passed.

A direct standalone `vue-tsc -p packages/@core/ui-kit/form-ui/tsconfig.json` invocation also scans the existing benchmark source and currently reports the pre-existing implicit-`any` diagnostic at `form-component-performance.benchmark.ts:68`; that file is unchanged by this PR and the repository's configured typecheck gate passes.

No changeset or `pnpm-lock.yaml` change is included.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test:unit`.
- [x] Changes in changelog are generated from PR name. The title explicitly marks the breaking contract with `!`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The API boundary and alternatives are documented where explanation is required
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A; this PR is independently based on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved form field slot bindings by grouping control props and events under `componentProps`.
  * Preserved field metadata for template logic while preventing unintended props from reaching rendered controls.
  * Strengthened TypeScript inference for field values and slot properties.
  * Added a public type for resolved component props.

* **Documentation**
  * Added migration guidance for updating slot bindings to `v-bind="slotProps.componentProps"`.
  * Updated examples and demos to use the new binding format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->