### PR TITLE
fix(@vben-core/form-ui): correct field slot props

### DIFF
--- a/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
@@ -104,6 +104,82 @@ describe('useVbenForm integration', () => {
     expect(validateValue).toHaveBeenCalledTimes(initialValidationCount + 1);
   });
 
+  it('keeps only the active model protocol and boolean disabled in field slots', async () => {
+    interface ModelProtocolValues {
+      defaultField: string;
+      valueField: string;
+    }
+
+    let defaultSlotProps: Record<string, any> | undefined;
+    let valueSlotProps: Record<string, any> | undefined;
+    const [Form, formApi] = useVbenForm<ModelProtocolValues>({
+      schema: [
+        {
+          component: TestInput,
+          defaultValue: 'default-initial',
+          fieldName: 'defaultField',
+        },
+        {
+          component: TestInput,
+          componentProps: {
+            eventMode: 'value-and-change',
+            modelValue: 'stale-model-value',
+          },
+          defaultValue: 'value-initial',
+          fieldName: 'valueField',
+          modelPropName: 'value',
+        },
+      ],
+    });
+    const wrapper = mount(Form, {
+      slots: {
+        defaultField(slotProps: Record<string, any>) {
+          defaultSlotProps = slotProps;
+          return h(TestInput, {
+            class: 'default-protocol-input',
+            modelValue: slotProps.modelValue,
+            'onUpdate:modelValue': slotProps['onUpdate:modelValue'],
+          });
+        },
+        valueField(slotProps: Record<string, any>) {
+          valueSlotProps = slotProps;
+          return h(TestInput, {
+            class: 'value-protocol-input',
+            eventMode: slotProps.eventMode,
+            value: slotProps.value,
+            'onUpdate:value': slotProps['onUpdate:value'],
+          });
+        },
+      },
+    });
+    wrappers.push(wrapper);
+    await flushPromises();
+
+    expect(defaultSlotProps).toBeDefined();
+    expect(valueSlotProps).toBeDefined();
+    if (!defaultSlotProps || !valueSlotProps) return;
+
+    expect(defaultSlotProps.disabled).toBe(false);
+    expect(defaultSlotProps.modelValue).toBe('default-initial');
+    expect(defaultSlotProps).toHaveProperty('onUpdate:modelValue');
+    expect(defaultSlotProps).not.toHaveProperty('value');
+
+    expect(valueSlotProps.disabled).toBe(false);
+    expect(valueSlotProps.value).toBe('value-initial');
+    expect(valueSlotProps).toHaveProperty('onUpdate:value');
+    expect(valueSlotProps).not.toHaveProperty('modelValue');
+    expect(valueSlotProps).not.toHaveProperty('onUpdate:modelValue');
+
+    await wrapper.get('.default-protocol-input').setValue('default-updated');
+    await wrapper.get('.value-protocol-input').setValue('value-updated');
+    await flushPromises();
+
+    expect(await formApi.getValues()).toEqual({
+      defaultField: 'default-updated',
+      valueField: 'value-updated',
+    });
+  });
+
   it('keeps values reactive when exposed through the default slot', async () => {
     const [Form, formApi] = useVbenForm({
       schema: [

--- a/packages/@core/ui-kit/form-ui/__tests__/form-types.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-types.test.ts
@@ -147,6 +147,24 @@ describe('form public types', () => {
     expectTypeOf<
       DefaultSlotProps['values']
     >().toEqualTypeOf<AccountFormValues>();
+
+    const [WideForm] = useVbenForm<Record<string, unknown>>({ schema: [] });
+    type WideFormSlots = InstanceType<typeof WideForm>['$slots'];
+    type WideFieldSlot = NonNullable<WideFormSlots['dynamic-field']>;
+    type WideFieldSlotProps = Parameters<WideFieldSlot>[0];
+
+    expectTypeOf<WideFieldSlotProps>().not.toBeAny();
+    expectTypeOf<WideFieldSlotProps['modelValue']>().toEqualTypeOf<unknown>();
+    expectTypeOf<
+      WideFieldSlotProps['field']['state']['value']
+    >().toEqualTypeOf<unknown>();
+    expectTypeOf<
+      WideFieldSlotProps['componentField']['modelValue']
+    >().toEqualTypeOf<unknown>();
+    expectTypeOf<WideFieldSlotProps['name']>().toBeString();
+    expectTypeOf<WideFieldSlotProps['values']>().toEqualTypeOf<
+      Record<string, unknown>
+    >();
   });
 
   it('keeps form and submit values distinct with a codec', () => {

--- a/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
@@ -264,7 +264,7 @@ watch(
 );
 
 const shouldDisabled = computed(() => {
-  return isDisabled.value || disabled || computedProps.value?.disabled;
+  return Boolean(isDisabled.value || disabled || computedProps.value?.disabled);
 });
 
 const customContentRender = computed(() => {
@@ -307,13 +307,19 @@ function createFieldSlotProps(slotProps: RuntimeFieldSlotProps) {
   };
 }
 
-function fieldBindEvent(componentField: Record<string, any>) {
+function resolveModelPropName() {
+  return (
+    modelPropName ||
+    (isString(component) ? componentBindEventMap.value?.[component] : null)
+  );
+}
+
+function fieldBindEvent(
+  componentField: Record<string, any>,
+  bindEventField: null | string | undefined,
+) {
   const modelValue = componentField.modelValue;
   const handler = componentField['onUpdate:modelValue'];
-
-  const bindEventField =
-    modelPropName ||
-    (isString(component) ? componentBindEventMap.value?.[component] : null);
 
   let value = modelValue;
   // antd design 的一些组件会传递一个 event 对象
@@ -348,7 +354,11 @@ function fieldBindEvent(componentField: Record<string, any>) {
 
 function createComponentProps(slotProps: RuntimeFieldSlotProps) {
   const normalizedSlotProps = createFieldSlotProps(slotProps);
-  const bindEvents = fieldBindEvent(normalizedSlotProps.componentField);
+  const bindEventField = resolveModelPropName();
+  const bindEvents = fieldBindEvent(
+    normalizedSlotProps.componentField,
+    bindEventField,
+  );
 
   const binds = {
     ...normalizedSlotProps.componentField,
@@ -361,6 +371,10 @@ function createComponentProps(slotProps: RuntimeFieldSlotProps) {
       ? { onInput: computedProps.value.onInput }
       : {}),
   };
+  if (bindEventField && bindEventField !== 'modelValue') {
+    Reflect.deleteProperty(binds, 'modelValue');
+    Reflect.deleteProperty(binds, 'onUpdate:modelValue');
+  }
 
   return binds;
 }

--- a/packages/@core/ui-kit/form-ui/src/types.ts
+++ b/packages/@core/ui-kit/form-ui/src/types.ts
@@ -235,16 +235,19 @@ export interface VbenFormDefaultSlotProps<
 
 export interface VbenFormFieldSlotProps<
   TValues extends FormValues = FormValues,
-  TFieldName extends KnownFormFieldName<TValues> = KnownFormFieldName<TValues>,
+  TFieldName extends FormFieldName<TValues> = FormFieldName<TValues>,
   T extends BaseFormComponentType = BaseFormComponentType,
   P extends Record<string, any> = Record<never, never>,
   TSubmitValues extends FormValues = TValues,
 > extends VbenFormActionSlotProps<TValues, T, P, TSubmitValues> {
-  componentField: FormComponentField<TValues[TFieldName], TFieldName>;
+  componentField: FormComponentField<
+    FormFieldValue<TValues, TFieldName>,
+    TFieldName
+  >;
   disabled: boolean;
-  field: FormRuntimeField<TValues[TFieldName]>;
+  field: FormRuntimeField<FormFieldValue<TValues, TFieldName>>;
   isInValid: boolean;
-  modelValue: TValues[TFieldName];
+  modelValue: FormFieldValue<TValues, TFieldName>;
   name: TFieldName;
 }
 
@@ -255,7 +258,19 @@ type VbenFormFieldSlots<
   TSubmitValues extends FormValues,
 > =
   string extends Extract<keyof TValues, string>
-    ? Record<string, ((props: any) => any) | undefined>
+    ? Record<
+        string,
+        | ((
+            props: VbenFormFieldSlotProps<
+              TValues,
+              FormFieldName<TValues>,
+              T,
+              P,
+              TSubmitValues
+            >,
+          ) => any)
+        | undefined
+      >
     : {
         [TFieldName in KnownFormFieldName<TValues>]?: (
           props: VbenFormFieldSlotProps<


### PR DESCRIPTION
## Description

This PR re-extracts only the field-slot bug fixes from the closed #8208. It intentionally contains no dynamic-component implementation, no field-slot `componentProps` grouping, and no consumer migration.

### Fixes

#### Keep broad field-slot scopes typed

`VbenFormFieldSlots` previously fell back to `props: any` whenever `TValues` had a string index signature. The fallback now keeps the complete `VbenFormFieldSlotProps` structure:

- precise form interfaces still infer literal field names and exact field values;
- `Record<string, unknown>` keeps typed slot metadata while field values correctly fall back to `unknown`;
- runtime slot behavior is unchanged.

This intentionally exposes TypeScript errors in code that relied on implicit `any` for broad field values. Such values must now be narrowed before use.

#### Bind only the active model protocol

Fields configured with `modelPropName: 'value'`, `modelPropName: 'checked'`, or a non-default adapter mapping previously received both the selected model prop/event and stale `modelValue`/`onUpdate:modelValue` bindings.

The rendered control and the existing flattened field-slot bindings now keep only the active model protocol. The default `modelValue` protocol remains unchanged.

#### Normalize field disabled state

When no disabled source was configured, `shouldDisabled` could evaluate to `undefined` even though the public field-slot contract declares `disabled: boolean`. It now consistently returns `false` or `true` without changing source precedence.

### Compatibility boundary

- The existing flattened named-field-slot runtime contract is preserved.
- Existing `v-bind="slotProps"` consumers continue to work.
- `formApi`, `values`, `field`, and `componentField` ownership is unchanged.
- No `dependencies.resolve().component` API is introduced.
- No dynamic or array-row component switching is introduced.
- The existing async dependency stale-result protection is unchanged; current `main` already guards it with per-field evaluation IDs.
- The breaking `componentProps` grouping remains isolated in #8215.

### Validation

- Focused Form UI type and integration tests: 31 passed.
- `pnpm test:unit`: 47 test files and 414 tests passed.
- Scoped oxfmt and ESLint checks passed for all four changed files.
- Pre-commit oxlint, oxfmt, ESLint, stylelint, repository typecheck, and commitlint passed.
- `git diff --check` passed; the branch contains one commit and four changed files.

A direct standalone `vue-tsc -p packages/@core/ui-kit/form-ui/tsconfig.json` invocation still reports the existing implicit-`any` diagnostic in `form-component-performance.benchmark.ts:68`. That file is unchanged by this PR, and the repository's configured typecheck gate passes.

No changeset or `pnpm-lock.yaml` change is included.

## Type of change

- [x] Bug fix (non-breaking runtime change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [x] No new functionality is introduced; no feature documentation is required.
- [x] Run the tests with `pnpm test:unit`.
- [x] The PR title describes the field-slot bug fix.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The non-obvious model-protocol behavior is covered by tests
- [x] No documentation migration is required because runtime slot compatibility is preserved
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fixes are effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A; this PR is independently based on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field binding for components that use custom value properties and update events.
  * Prevented conflicting model bindings when custom field protocols are used.
  * Ensured disabled states are consistently interpreted as true or false.

* **Type Improvements**
  * Enhanced form slot typings for dynamic and previously unknown field names.
  * Improved type inference for field values, component fields, and model values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->