### PR TITLE
fix(@vben-core/popup-ui): rebind popup api after HMR

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/use-drawer.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/use-drawer.test.ts
@@ -26,6 +26,7 @@ let activeApp: App | undefined;
 async function mountRebindingHarness() {
   const consumerKey = ref(0);
   let currentApi: ExtendedDrawerApi | undefined;
+  const onOpenChange = vi.fn();
 
   const Consumer = defineComponent(() => {
     const [Drawer, drawerApi] = useVbenDrawer();
@@ -39,6 +40,8 @@ async function mountRebindingHarness() {
 
   const [ParentDrawer, parentApi] = useVbenDrawer({
     connectedComponent: ConnectedDrawer,
+    onOpenChange,
+    title: 'Parent drawer title',
   });
   const host = document.createElement('div');
   document.body.append(host);
@@ -50,6 +53,7 @@ async function mountRebindingHarness() {
   return {
     consumerKey,
     getCurrentApi: () => currentApi,
+    onOpenChange,
     parentApi,
   };
 }
@@ -68,7 +72,7 @@ afterEach(() => {
 
 describe('useVbenDrawer', () => {
   it('rebinds the parent api when the consumer is recreated', async () => {
-    const { consumerKey, getCurrentApi, parentApi } =
+    const { consumerKey, getCurrentApi, onOpenChange, parentApi } =
       await mountRebindingHarness();
     const initialApi = getCurrentApi();
 
@@ -82,9 +86,11 @@ describe('useVbenDrawer', () => {
     expect(recreatedApi).toBeDefined();
     if (!recreatedApi) return;
     expect(recreatedApi).not.toBe(initialApi);
+    expect(recreatedApi.store.state.title).toBe('Parent drawer title');
     expect(parentApi.store).toBe(recreatedApi.store);
 
     parentApi.open();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
     expect(recreatedApi.store.state.isOpen).toBe(true);
     expect(initialApi.store.state.isOpen).toBe(false);
 

--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/use-drawer.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/use-drawer.test.ts
@@ -1,0 +1,94 @@
+import type { App, Ref } from 'vue';
+
+import type { ExtendedDrawerApi } from '../drawer';
+
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useVbenDrawer } from '../use-drawer';
+
+vi.mock('@vben-core/preferences', () => ({
+  usePreferences: () => ({
+    globalEscapeShortcutKey: { value: true },
+  }),
+}));
+
+vi.mock('../drawer.vue', () => ({
+  default: {
+    name: 'VbenDrawerStub',
+    render: () => null,
+  },
+}));
+
+let activeApp: App | undefined;
+
+async function mountRebindingHarness() {
+  const consumerKey = ref(0);
+  let currentApi: ExtendedDrawerApi | undefined;
+
+  const Consumer = defineComponent(() => {
+    const [Drawer, drawerApi] = useVbenDrawer();
+    currentApi = drawerApi;
+    return () => h(Drawer);
+  });
+
+  const ConnectedDrawer = defineComponent(() => {
+    return () => h(Consumer, { key: consumerKey.value });
+  });
+
+  const [ParentDrawer, parentApi] = useVbenDrawer({
+    connectedComponent: ConnectedDrawer,
+  });
+  const host = document.createElement('div');
+  document.body.append(host);
+
+  activeApp = createApp(() => h(ParentDrawer));
+  activeApp.mount(host);
+  await nextTick();
+
+  return {
+    consumerKey,
+    getCurrentApi: () => currentApi,
+    parentApi,
+  };
+}
+
+async function remountConsumer(consumerKey: Ref<number>) {
+  consumerKey.value += 1;
+  await nextTick();
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('useVbenDrawer', () => {
+  it('rebinds the parent api when the consumer is recreated', async () => {
+    const { consumerKey, getCurrentApi, parentApi } =
+      await mountRebindingHarness();
+    const initialApi = getCurrentApi();
+
+    expect(initialApi).toBeDefined();
+    if (!initialApi) return;
+    expect(parentApi.store).toBe(initialApi.store);
+
+    await remountConsumer(consumerKey);
+    const recreatedApi = getCurrentApi();
+
+    expect(recreatedApi).toBeDefined();
+    if (!recreatedApi) return;
+    expect(recreatedApi).not.toBe(initialApi);
+    expect(parentApi.store).toBe(recreatedApi.store);
+
+    parentApi.open();
+    expect(recreatedApi.store.state.isOpen).toBe(true);
+    expect(initialApi.store.state.isOpen).toBe(false);
+
+    await parentApi.close();
+    expect(recreatedApi.store.state.isOpen).toBe(false);
+  });
+});

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -8,10 +8,11 @@ import {
   defineComponent,
   h,
   inject,
+  markRaw,
   nextTick,
   provide,
-  reactive,
   ref,
+  shallowReactive,
 } from 'vue';
 
 import { usePreferences } from '@vben-core/preferences';
@@ -45,16 +46,17 @@ export function useVbenDrawer<
   };
   const { connectedComponent } = options;
   if (connectedComponent) {
-    const extendedApi = reactive({});
+    const extendedApi = shallowReactive({});
     const isDrawerReady = ref(true);
     const Drawer = defineComponent(
       (props: TParentDrawerProps, { attrs, slots }) => {
+        function rebindApi(api: ExtendedDrawerApi) {
+          Object.setPrototypeOf(extendedApi, markRaw(api));
+        }
+
         provide(USER_DRAWER_INJECT_KEY, {
-          extendApi(api: ExtendedDrawerApi) {
-            // 不能直接给 reactive 赋值，会丢失响应
-            // 不能用 Object.assign,会丢失 api 的原型函数
-            Object.setPrototypeOf(extendedApi, api);
-          },
+          extendApi: rebindApi,
+          consumed: false,
           options: defaultOptions,
           async reCreateDrawer() {
             isDrawerReady.value = false;
@@ -85,22 +87,32 @@ export function useVbenDrawer<
   }
 
   const injectData = inject<any>(USER_DRAWER_INJECT_KEY, {});
+  const isConsumed = injectData.consumed;
+  const effectiveOptions = isConsumed ? {} : injectData.options;
+  if (!isConsumed && injectData.consumed !== undefined) {
+    injectData.consumed = true;
+  }
 
   const mergedOptions = {
     ...DEFAULT_DRAWER_PROPS,
-    ...injectData.options,
+    ...effectiveOptions,
     ...defaultOptions,
   } as DrawerApiOptions;
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {
     options.onOpenChange?.(isOpen);
-    injectData.options?.onOpenChange?.(isOpen);
+    if (!isConsumed) {
+      injectData.options?.onOpenChange?.(isOpen);
+    }
   };
 
   const onClosed = mergedOptions.onClosed;
   mergedOptions.onClosed = () => {
     onClosed?.();
     if (mergedOptions.destroyOnClose) {
+      if (injectData.consumed !== undefined) {
+        injectData.consumed = false;
+      }
       injectData.reCreateDrawer?.();
     }
   };

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -10,6 +10,7 @@ import {
   inject,
   markRaw,
   nextTick,
+  onBeforeUnmount,
   provide,
   ref,
   shallowReactive,
@@ -92,6 +93,11 @@ export function useVbenDrawer<
   if (!isConsumed && injectData.consumed !== undefined) {
     injectData.consumed = true;
   }
+  onBeforeUnmount(() => {
+    if (!isConsumed && injectData.consumed !== undefined) {
+      injectData.consumed = false;
+    }
+  });
 
   const mergedOptions = {
     ...DEFAULT_DRAWER_PROPS,
@@ -109,7 +115,7 @@ export function useVbenDrawer<
   const onClosed = mergedOptions.onClosed;
   mergedOptions.onClosed = () => {
     onClosed?.();
-    if (mergedOptions.destroyOnClose) {
+    if (mergedOptions.destroyOnClose && !isConsumed) {
       if (injectData.consumed !== undefined) {
         injectData.consumed = false;
       }

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/use-modal.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/use-modal.test.ts
@@ -26,6 +26,7 @@ let activeApp: App | undefined;
 async function mountRebindingHarness() {
   const consumerKey = ref(0);
   let currentApi: ExtendedModalApi | undefined;
+  const onOpenChange = vi.fn();
 
   const Consumer = defineComponent(() => {
     const [Modal, modalApi] = useVbenModal();
@@ -39,6 +40,8 @@ async function mountRebindingHarness() {
 
   const [ParentModal, parentApi] = useVbenModal({
     connectedComponent: ConnectedModal,
+    onOpenChange,
+    title: 'Parent modal title',
   });
   const host = document.createElement('div');
   document.body.append(host);
@@ -50,6 +53,7 @@ async function mountRebindingHarness() {
   return {
     consumerKey,
     getCurrentApi: () => currentApi,
+    onOpenChange,
     parentApi,
   };
 }
@@ -68,7 +72,7 @@ afterEach(() => {
 
 describe('useVbenModal', () => {
   it('rebinds the parent api when the consumer is recreated', async () => {
-    const { consumerKey, getCurrentApi, parentApi } =
+    const { consumerKey, getCurrentApi, onOpenChange, parentApi } =
       await mountRebindingHarness();
     const initialApi = getCurrentApi();
 
@@ -82,9 +86,11 @@ describe('useVbenModal', () => {
     expect(recreatedApi).toBeDefined();
     if (!recreatedApi) return;
     expect(recreatedApi).not.toBe(initialApi);
+    expect(recreatedApi.store.state.title).toBe('Parent modal title');
     expect(toRaw(parentApi.store)).toBe(recreatedApi.store);
 
     parentApi.open();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
     expect(recreatedApi.store.state.isOpen).toBe(true);
     expect(initialApi.store.state.isOpen).toBe(false);
 

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/use-modal.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/use-modal.test.ts
@@ -1,0 +1,94 @@
+import type { App, Ref } from 'vue';
+
+import type { ExtendedModalApi } from '../modal';
+
+import { createApp, defineComponent, h, nextTick, ref, toRaw } from 'vue';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useVbenModal } from '../use-modal';
+
+vi.mock('@vben-core/preferences', () => ({
+  usePreferences: () => ({
+    globalEscapeShortcutKey: { value: true },
+  }),
+}));
+
+vi.mock('../modal.vue', () => ({
+  default: {
+    name: 'VbenModalStub',
+    render: () => null,
+  },
+}));
+
+let activeApp: App | undefined;
+
+async function mountRebindingHarness() {
+  const consumerKey = ref(0);
+  let currentApi: ExtendedModalApi | undefined;
+
+  const Consumer = defineComponent(() => {
+    const [Modal, modalApi] = useVbenModal();
+    currentApi = modalApi;
+    return () => h(Modal);
+  });
+
+  const ConnectedModal = defineComponent(() => {
+    return () => h(Consumer, { key: consumerKey.value });
+  });
+
+  const [ParentModal, parentApi] = useVbenModal({
+    connectedComponent: ConnectedModal,
+  });
+  const host = document.createElement('div');
+  document.body.append(host);
+
+  activeApp = createApp(() => h(ParentModal));
+  activeApp.mount(host);
+  await nextTick();
+
+  return {
+    consumerKey,
+    getCurrentApi: () => currentApi,
+    parentApi,
+  };
+}
+
+async function remountConsumer(consumerKey: Ref<number>) {
+  consumerKey.value += 1;
+  await nextTick();
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('useVbenModal', () => {
+  it('rebinds the parent api when the consumer is recreated', async () => {
+    const { consumerKey, getCurrentApi, parentApi } =
+      await mountRebindingHarness();
+    const initialApi = getCurrentApi();
+
+    expect(initialApi).toBeDefined();
+    if (!initialApi) return;
+    expect(toRaw(parentApi.store)).toBe(initialApi.store);
+
+    await remountConsumer(consumerKey);
+    const recreatedApi = getCurrentApi();
+
+    expect(recreatedApi).toBeDefined();
+    if (!recreatedApi) return;
+    expect(recreatedApi).not.toBe(initialApi);
+    expect(toRaw(parentApi.store)).toBe(recreatedApi.store);
+
+    parentApi.open();
+    expect(recreatedApi.store.state.isOpen).toBe(true);
+    expect(initialApi.store.state.isOpen).toBe(false);
+
+    await parentApi.close();
+    expect(recreatedApi.store.state.isOpen).toBe(false);
+  });
+});

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -6,6 +6,7 @@ import {
   inject,
   markRaw,
   nextTick,
+  onBeforeUnmount,
   provide,
   ref,
   shallowReactive,
@@ -90,6 +91,11 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   if (!isConsumed && injectData.consumed !== undefined) {
     injectData.consumed = true;
   }
+  onBeforeUnmount(() => {
+    if (!isConsumed && injectData.consumed !== undefined) {
+      injectData.consumed = false;
+    }
+  });
 
   const mergedOptions = {
     ...DEFAULT_MODAL_PROPS,
@@ -107,7 +113,7 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   const onClosed = mergedOptions.onClosed;
   mergedOptions.onClosed = () => {
     onClosed?.();
-    if (mergedOptions.destroyOnClose) {
+    if (mergedOptions.destroyOnClose && !isConsumed) {
       if (injectData.consumed !== undefined) {
         injectData.consumed = false;
       }

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -4,10 +4,11 @@ import {
   defineComponent,
   h,
   inject,
+  markRaw,
   nextTick,
   provide,
-  reactive,
   ref,
+  shallowReactive,
 } from 'vue';
 
 import { usePreferences } from '@vben-core/preferences';
@@ -40,16 +41,16 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   };
   const { connectedComponent } = options;
   if (connectedComponent) {
-    const extendedApi = reactive({});
+    const extendedApi = shallowReactive({});
     const isModalReady = ref(true);
     const Modal = defineComponent(
       (props: TParentModalProps, { attrs, slots }) => {
+        function rebindApi(api: ExtendedModalApi) {
+          Object.setPrototypeOf(extendedApi, markRaw(api));
+        }
+
         provide(USER_MODAL_INJECT_KEY, {
-          extendApi(api: ExtendedModalApi) {
-            // 不能直接给 reactive 赋值，会丢失响应
-            // 不能用 Object.assign,会丢失 api 的原型函数
-            Object.setPrototypeOf(extendedApi, api);
-          },
+          extendApi: rebindApi,
           consumed: false,
           options: defaultOptions,
           async reCreateModal() {
@@ -83,30 +84,33 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
     return [Modal, extendedApi as ExtendedModalApi] as const;
   }
 
-  let injectData = inject<any>(USER_MODAL_INJECT_KEY, {});
-  // 这个数据已经被使用了，说明这个弹窗是嵌套的弹窗，不应该merge上层的配置
-  if (injectData.consumed) {
-    injectData = {};
-  } else {
+  const injectData = inject<any>(USER_MODAL_INJECT_KEY, {});
+  const isConsumed = injectData.consumed;
+  const effectiveOptions = isConsumed ? {} : injectData.options;
+  if (!isConsumed && injectData.consumed !== undefined) {
     injectData.consumed = true;
   }
 
   const mergedOptions = {
     ...DEFAULT_MODAL_PROPS,
-    ...injectData.options,
+    ...effectiveOptions,
     ...defaultOptions,
   } as ModalApiOptions;
 
   mergedOptions.onOpenChange = (isOpen: boolean) => {
     options.onOpenChange?.(isOpen);
-    injectData.options?.onOpenChange?.(isOpen);
+    if (!isConsumed) {
+      injectData.options?.onOpenChange?.(isOpen);
+    }
   };
 
   const onClosed = mergedOptions.onClosed;
   mergedOptions.onClosed = () => {
     onClosed?.();
     if (mergedOptions.destroyOnClose) {
-      injectData.consumed = false;
+      if (injectData.consumed !== undefined) {
+        injectData.consumed = false;
+      }
       injectData.reCreateModal?.();
     }
   };


### PR DESCRIPTION
## Description

Fixes Modal and Drawer parent APIs retaining stale internal instances after connected components are recreated by HMR.

- Rebinds the stable parent API to the latest raw popup API instance.
- Preserves the injected popup context during recreation while keeping nested popup options isolated.
- Adds lifecycle regression tests covering API rebinding and parent `open`/`close` behavior.
- Verifies HMR and reopen behavior for Modal, Drawer, and `appendToMain` playground examples.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- No changes were made to `pnpm-lock.yaml`.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vbenjs/vue-vben-admin/pull/contributing.md).

- [x] Relevant tests pass locally: `pnpm exec vitest run --dom packages/@core/ui-kit/popup-ui/src`
- [x] The PR title explains the change and uses the `fix:` prefix.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing popup-ui unit tests pass locally.

## Summary by CodeRabbit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connected modal and drawer behavior when nested content is recreated.
  * Parent APIs now correctly control the recreated modal or drawer instance.
  * Preserved titles and open-state callbacks across recreated instances.
  * Improved cleanup and state reset behavior when closing or unmounting components.

* **Tests**
  * Added coverage for modal and drawer rebinding, callbacks, titles, and open/close state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->