### PR TITLE
feat(@vben-core/popup-ui)!: add typed popup data contracts

### DIFF
--- a/apps/web-naive/src/views/demos/form/modal.vue
+++ b/apps/web-naive/src/views/demos/form/modal.vue
@@ -7,6 +7,10 @@ defineOptions({
   name: 'FormModelDemo',
 });
 
+interface FormModalData {
+  values?: Record<string, unknown>;
+}
+
 const [Form, formApi] = useVbenForm({
   schema: [
     {
@@ -44,7 +48,7 @@ const [Form, formApi] = useVbenForm({
   showDefaultActions: false,
 });
 
-const [Modal, modalApi] = useVbenModal({
+const [Modal, modalApi] = useVbenModal<FormModalData>({
   fullscreenButton: false,
   onCancel() {
     modalApi.close();
@@ -55,14 +59,16 @@ const [Modal, modalApi] = useVbenModal({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      const { values } = modalApi.getData<Record<string, any>>();
-      if (values) {
-        formApi.setValues(values);
+      const data = modalApi.getData();
+      if (data?.values) {
+        formApi.setValues(data.values);
       }
     }
   },
   title: '内嵌表单示例',
 });
+
+defineExpose({ modalApi });
 </script>
 <template>
   <Modal>

--- a/docs/src/components/common-ui/vben-drawer.md
+++ b/docs/src/components/common-ui/vben-drawer.md
@@ -50,6 +50,29 @@ Drawer 内的内容一般业务中，会比较复杂，所以我们可以将 dra
 
 <DemoPreview dir="demos/vben-drawer/shared-data" />
 
+### 数据类型约束
+
+推荐在 connected 子组件中声明一次数据类型并暴露 `drawerApi`，外部会从 `connectedComponent` 自动推导 `setData` 和 `getData` 的类型：
+
+```ts
+// connected 子组件
+const [Drawer, drawerApi] = useVbenDrawer<EditData>();
+defineExpose({ drawerApi });
+
+// 外部组件，无需重复声明 EditData
+const [Drawer, drawerApi] = useVbenDrawer({
+  connectedComponent: EditDrawer,
+});
+```
+
+无法从组件公开实例推导时，可以显式使用 `useVbenDrawer<EditData>()`。需要让多个文件共享同一契约时，可以在独立模块中预绑定：
+
+```ts
+export const useEditDrawer = createVbenDrawer<EditData>();
+```
+
+三种方式的优先级为：显式泛型、connected component 自动推导、`unknown`。普通 SFC 通过 `defineExpose` 支持自动推导；泛型 SFC、函数式组件或被标注为宽 `Component` 的组件应使用显式泛型或契约工厂。`getData()` 在尚未调用 `setData()` 时返回 `undefined`，业务允许 `null`、部分对象等值时，需要在数据泛型中准确声明。
+
 ::: info 注意
 
 - `VbenDrawer` 组件对于参数的处理优先级是 `slot` > `props` > `state`(通过api更新的状态以及useVbenDrawer参数)。如果你已经传入了 `slot` 或者 `props`，那么 `setState` 将不会生效，这种情况下你可以通过 `slot` 或者 `props` 来更新状态。
@@ -143,8 +166,8 @@ const [Drawer, drawerApi] = useVbenDrawer({
 | setState | 动态设置抽屉状态属性 | `(((prev: DrawerState) => Partial<DrawerState>)\| Partial<DrawerState>)=>drawerApi` |
 | open | 打开弹窗 | `()=>void` | --- |
 | close | 关闭弹窗 | `()=>void` | --- |
-| setData | 设置共享数据 | `<T>(data:T)=>drawerApi` | --- |
-| getData | 获取共享数据 | `<T>()=>T` | --- |
+| setData | 设置共享数据 | `(data:TData)=>drawerApi` | --- |
+| getData | 获取共享数据 | `()=>TData\|undefined` | --- |
 | useStore | 获取可响应式状态 | - | --- |
 | lock | 将抽屉标记为提交中，锁定当前状态 | `(isLock:boolean)=>drawerApi` | >5.5.3 |
 | unlock | lock方法的反操作，解除抽屉的锁定状态，也是lock(false)的别名 | `()=>drawerApi` | >5.5.3 |

--- a/docs/src/components/common-ui/vben-modal.md
+++ b/docs/src/components/common-ui/vben-modal.md
@@ -56,6 +56,29 @@ Modal 内的内容一般业务中，会比较复杂，所以我们可以将 moda
 
 <DemoPreview dir="demos/vben-modal/shared-data" />
 
+### 数据类型约束
+
+推荐在 connected 子组件中声明一次数据类型并暴露 `modalApi`，外部会从 `connectedComponent` 自动推导 `setData` 和 `getData` 的类型：
+
+```ts
+// connected 子组件
+const [Modal, modalApi] = useVbenModal<EditData>();
+defineExpose({ modalApi });
+
+// 外部组件，无需重复声明 EditData
+const [Modal, modalApi] = useVbenModal({
+  connectedComponent: EditModal,
+});
+```
+
+无法从组件公开实例推导时，可以显式使用 `useVbenModal<EditData>()`。需要让多个文件共享同一契约时，可以在独立模块中预绑定：
+
+```ts
+export const useEditModal = createVbenModal<EditData>();
+```
+
+三种方式的优先级为：显式泛型、connected component 自动推导、`unknown`。普通 SFC 通过 `defineExpose` 支持自动推导；泛型 SFC、函数式组件或被标注为宽 `Component` 的组件应使用显式泛型或契约工厂。`getData()` 在尚未调用 `setData()` 时返回 `undefined`，业务允许 `null`、部分对象等值时，需要在数据泛型中准确声明。
+
 ## 动画类型
 
 通过 `animationType` 属性可以控制弹窗的动画效果：
@@ -162,8 +185,8 @@ const [Modal, modalApi] = useVbenModal({
 | setState | 动态设置弹窗状态属性 | `(((prev: ModalState) => Partial<ModalState>)\| Partial<ModalState>)=>modalApi` | - |
 | open | 打开弹窗 | `()=>void` | - |
 | close | 关闭弹窗 | `()=>void` | - |
-| setData | 设置共享数据 | `<T>(data:T)=>modalApi` | - |
-| getData | 获取共享数据 | `<T>()=>T` | - |
+| setData | 设置共享数据 | `(data:TData)=>modalApi` | - |
+| getData | 获取共享数据 | `()=>TData\|undefined` | - |
 | useStore | 获取可响应式状态 | - | - |
 | lock | 将弹窗标记为提交中，锁定当前状态 | `(isLock:boolean)=>modalApi` | >5.5.2 |
 | unlock | lock方法的反操作，解除弹窗的锁定状态，也是lock(false)的别名 | `()=>modalApi` | >5.5.3 |

--- a/docs/src/demos/vben-drawer/shared-data/drawer.vue
+++ b/docs/src/demos/vben-drawer/shared-data/drawer.vue
@@ -3,9 +3,14 @@ import { ref } from 'vue';
 
 import { useVbenDrawer } from '@vben/common-ui';
 
-const data = ref();
+interface SharedData {
+  content: string;
+  payload: string;
+}
 
-const [Drawer, drawerApi] = useVbenDrawer({
+const data = ref<SharedData>();
+
+const [Drawer, drawerApi] = useVbenDrawer<SharedData>({
   onCancel() {
     drawerApi.close();
   },
@@ -14,10 +19,12 @@ const [Drawer, drawerApi] = useVbenDrawer({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      data.value = drawerApi.getData<Record<string, any>>();
+      data.value = drawerApi.getData();
     }
   },
 });
+
+defineExpose({ drawerApi });
 </script>
 <template>
   <Drawer title="数据共享示例">

--- a/docs/src/demos/vben-modal/shared-data/modal.vue
+++ b/docs/src/demos/vben-modal/shared-data/modal.vue
@@ -3,9 +3,14 @@ import { ref } from 'vue';
 
 import { useVbenModal } from '@vben/common-ui';
 
-const data = ref();
+interface SharedData {
+  content: string;
+  payload: string;
+}
 
-const [Modal, modalApi] = useVbenModal({
+const data = ref<SharedData>();
+
+const [Modal, modalApi] = useVbenModal<SharedData>({
   onCancel() {
     modalApi.close();
   },
@@ -14,10 +19,12 @@ const [Modal, modalApi] = useVbenModal({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      data.value = modalApi.getData<Record<string, any>>();
+      data.value = modalApi.getData();
     }
   },
 });
+
+defineExpose({ modalApi });
 </script>
 <template>
   <Modal title="数据共享示例">

--- a/docs/src/en/components/common-ui/vben-drawer.md
+++ b/docs/src/en/components/common-ui/vben-drawer.md
@@ -23,6 +23,29 @@ const [Drawer, drawerApi] = useVbenDrawer({
 - Default drawer behavior can be adjusted in `apps/<app>/src/bootstrap.ts` through `setDefaultDrawerProps(...)`.
 - `setState(...)` works on `DrawerState`, not `ModalState`.
 
+## Shared Data Types
+
+The recommended approach is to declare the data type once in the connected component and expose `drawerApi`. The outer call then infers the data contract from `connectedComponent`:
+
+```ts
+// Connected component
+const [Drawer, drawerApi] = useVbenDrawer<EditData>();
+defineExpose({ drawerApi });
+
+// Outer component, EditData is inferred
+const [Drawer, drawerApi] = useVbenDrawer({
+  connectedComponent: EditDrawer,
+});
+```
+
+Use `useVbenDrawer<EditData>()` explicitly when the component type cannot expose the contract. For larger features, pre-bind one reusable contract in a separate module:
+
+```ts
+export const useEditDrawer = createVbenDrawer<EditData>();
+```
+
+The precedence is explicit generic, connected component inference, then `unknown`. Plain SFCs support inference through `defineExpose`; generic SFCs, functional components, and components widened to `Component` should use an explicit generic or contract factory. `getData()` returns `undefined` before `setData()` is called. Include `null` or partial payloads in the data type when they are valid business values.
+
 ## Key Props
 
 | Prop | Description | Type |
@@ -50,7 +73,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
 | `setState(...)`         | updates drawer state                   |
 | `open()`                | opens the drawer                       |
 | `close()`               | closes the drawer                      |
-| `setData(data)`         | stores shared data                     |
-| `getData<T>()`          | reads shared data                      |
+| `setData(data: TData)`  | stores typed shared data               |
+| `getData()`             | returns `TData \| undefined`           |
 | `lock(isLocked = true)` | locks the drawer into submitting state |
 | `unlock()`              | alias for `lock(false)`                |

--- a/docs/src/en/components/common-ui/vben-modal.md
+++ b/docs/src/en/components/common-ui/vben-modal.md
@@ -23,6 +23,29 @@ const [Modal, modalApi] = useVbenModal({
 - When `connectedComponent` is present, avoid pushing extra modal props through the connected side. Prefer `useVbenModal(...)` or `modalApi.setState(...)`.
 - Default modal behavior can be adjusted in `apps/<app>/src/bootstrap.ts` through `setDefaultModalProps(...)`.
 
+## Shared Data Types
+
+The recommended approach is to declare the data type once in the connected component and expose `modalApi`. The outer call then infers the data contract from `connectedComponent`:
+
+```ts
+// Connected component
+const [Modal, modalApi] = useVbenModal<EditData>();
+defineExpose({ modalApi });
+
+// Outer component, EditData is inferred
+const [Modal, modalApi] = useVbenModal({
+  connectedComponent: EditModal,
+});
+```
+
+Use `useVbenModal<EditData>()` explicitly when the component type cannot expose the contract. For larger features, pre-bind one reusable contract in a separate module:
+
+```ts
+export const useEditModal = createVbenModal<EditData>();
+```
+
+The precedence is explicit generic, connected component inference, then `unknown`. Plain SFCs support inference through `defineExpose`; generic SFCs, functional components, and components widened to `Component` should use an explicit generic or contract factory. `getData()` returns `undefined` before `setData()` is called. Include `null` or partial payloads in the data type when they are valid business values.
+
 ## Key Props
 
 | Prop | Description | Type |
@@ -50,7 +73,7 @@ const [Modal, modalApi] = useVbenModal({
 | `setState(...)`         | updates modal state                   |
 | `open()`                | opens the modal                       |
 | `close()`               | closes the modal                      |
-| `setData(data)`         | stores shared data                    |
-| `getData<T>()`          | reads shared data                     |
+| `setData(data: TData)`  | stores typed shared data              |
+| `getData()`             | returns `TData \| undefined`          |
 | `lock(isLocked = true)` | locks the modal into submitting state |
 | `unlock()`              | alias for `lock(false)`               |

--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/drawer-api.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/drawer-api.test.ts
@@ -81,6 +81,16 @@ describe('drawerApi', () => {
     expect(drawerApi.getData()).toEqual(testData);
   });
 
+  it('should return undefined before shared data is set', () => {
+    expect(drawerApi.getData()).toBeUndefined();
+  });
+
+  it('should preserve null shared data', () => {
+    const nullableDrawerApi = new DrawerApi<null | Record<string, unknown>>();
+    nullableDrawerApi.setData(null);
+    expect(nullableDrawerApi.getData()).toBeNull();
+  });
+
   it('should set state correctly using an object', () => {
     drawerApi.setState({ title: 'New Title' });
     expect(drawerApi.store.state.title).toBe('New Title');

--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/drawer-types.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/drawer-types.test.ts
@@ -1,0 +1,59 @@
+import type { ExtendedDrawerApi, InferDrawerData } from '../drawer';
+import type { createVbenDrawer, useVbenDrawer } from '../use-drawer';
+import type TypedDrawer from './fixtures/typed-drawer.vue';
+
+import { describe, expectTypeOf, it } from 'vitest';
+
+interface TypedDrawerData {
+  id: number;
+  mode: 'edit' | 'view';
+}
+
+type DrawerData = null | TypedDrawerData;
+
+declare const createDrawer: typeof createVbenDrawer;
+declare const useDrawer: typeof useVbenDrawer;
+
+describe('drawer public data types', () => {
+  it('infers data from the connected component exposed api', () => {
+    function assertInferredData(connectedComponent: typeof TypedDrawer) {
+      const [, drawerApi] = useDrawer({ connectedComponent });
+
+      expectTypeOf(drawerApi).toEqualTypeOf<ExtendedDrawerApi<DrawerData>>();
+      expectTypeOf(drawerApi.getData()).toEqualTypeOf<DrawerData | undefined>();
+      expectTypeOf(drawerApi.setData).parameter(0).toEqualTypeOf<DrawerData>();
+      expectTypeOf(drawerApi.setData(null).open()).toBeVoid();
+      // @ts-expect-error invalid payload type
+      drawerApi.setData({ id: '1', mode: 'edit' });
+    }
+
+    expectTypeOf<
+      InferDrawerData<typeof TypedDrawer>
+    >().toEqualTypeOf<DrawerData>();
+    expectTypeOf(assertInferredData).toBeFunction();
+  });
+
+  it('supports explicit and pre-bound data contracts', () => {
+    function assertExplicitData() {
+      const [, explicitApi] = useDrawer<DrawerData>();
+      const useTypedDrawer = createDrawer<DrawerData>();
+      const [, preBoundApi] = useTypedDrawer();
+
+      expectTypeOf(explicitApi).toEqualTypeOf<ExtendedDrawerApi<DrawerData>>();
+      expectTypeOf(preBoundApi).toEqualTypeOf<ExtendedDrawerApi<DrawerData>>();
+    }
+
+    expectTypeOf(assertExplicitData).toBeFunction();
+  });
+
+  it('falls back to unknown without a data contract', () => {
+    function assertUnknownData() {
+      const [, drawerApi] = useDrawer();
+
+      expectTypeOf(drawerApi).toEqualTypeOf<ExtendedDrawerApi<unknown>>();
+      expectTypeOf(drawerApi.getData()).toBeUnknown();
+    }
+
+    expectTypeOf(assertUnknownData).toBeFunction();
+  });
+});

--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/fixtures/typed-drawer.vue
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/fixtures/typed-drawer.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useVbenDrawer } from '../../use-drawer';
+
+interface TypedDrawerData {
+  id: number;
+  mode: 'edit' | 'view';
+}
+
+const [, drawerApi] = useVbenDrawer<TypedDrawerData | null>();
+
+defineExpose({ drawerApi });
+</script>
+
+<template>
+  <div />
+</template>

--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/use-drawer.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/use-drawer.test.ts
@@ -79,6 +79,9 @@ describe('useVbenDrawer', () => {
     expect(initialApi).toBeDefined();
     if (!initialApi) return;
     expect(parentApi.store).toBe(initialApi.store);
+    const initialData = { id: 1 };
+    parentApi.setData(initialData);
+    expect(initialApi.getData()).toBe(initialData);
 
     await remountConsumer(consumerKey);
     const recreatedApi = getCurrentApi();
@@ -88,6 +91,9 @@ describe('useVbenDrawer', () => {
     expect(recreatedApi).not.toBe(initialApi);
     expect(recreatedApi.store.state.title).toBe('Parent drawer title');
     expect(parentApi.store).toBe(recreatedApi.store);
+    const recreatedData = { id: 2 };
+    parentApi.setData(recreatedData);
+    expect(recreatedApi.getData()).toBe(recreatedData);
 
     parentApi.open();
     expect(onOpenChange).toHaveBeenCalledWith(true);

--- a/packages/@core/ui-kit/popup-ui/src/drawer/drawer-api.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/drawer-api.ts
@@ -3,10 +3,10 @@ import type { DrawerApiOptions, DrawerState } from './drawer';
 import { Store } from '@vben-core/shared/store';
 import { bindMethods, isFunction } from '@vben-core/shared/utils';
 
-export class DrawerApi {
+export class DrawerApi<TData = unknown> {
   // 共享数据
-  public sharedData: Record<'payload', any> = {
-    payload: {},
+  public sharedData: Record<'payload', TData | undefined> = {
+    payload: undefined,
   };
   public store: Store<DrawerState>;
 
@@ -97,8 +97,8 @@ export class DrawerApi {
     }
   }
 
-  getData<T extends object = Record<string, any>>() {
-    return (this.sharedData?.payload ?? {}) as T;
+  getData(): TData | undefined {
+    return this.sharedData.payload;
   }
 
   /**
@@ -150,7 +150,7 @@ export class DrawerApi {
     this.store.setState((prev) => ({ ...prev, isOpen: true }));
   }
 
-  setData<T>(payload: T) {
+  setData(payload: TData) {
     this.sharedData.payload = payload;
     return this;
   }

--- a/packages/@core/ui-kit/popup-ui/src/drawer/drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/drawer.ts
@@ -130,23 +130,36 @@ export interface DrawerProps {
 export interface DrawerState extends DrawerProps {
   /** 弹窗打开状态 */
   isOpen?: boolean;
-  /**
-   * 共享数据
-   */
-  sharedData?: Record<string, any>;
 }
 
-export type ExtendedDrawerApi = DrawerApi & {
+export type ExtendedDrawerApi<TData = unknown> = DrawerApi<TData> & {
   useStore: <T = NoInfer<DrawerState>>(
     selector?: (state: NoInfer<DrawerState>) => T,
   ) => Readonly<Ref<T>>;
 };
 
-export interface DrawerApiOptions extends DrawerState {
+type DrawerComponentInstance<TComponent extends Component> =
+  TComponent extends abstract new (...args: any[]) => infer TInstance
+    ? TInstance
+    : never;
+
+export type InferDrawerData<TComponent extends Component> = [
+  DrawerComponentInstance<TComponent>,
+] extends [never]
+  ? unknown
+  : DrawerComponentInstance<TComponent> extends {
+        drawerApi: ExtendedDrawerApi<infer TData>;
+      }
+    ? TData
+    : unknown;
+
+export interface DrawerApiOptions<
+  TConnectedComponent extends Component = Component,
+> extends DrawerState {
   /**
    * 独立的抽屉组件
    */
-  connectedComponent?: Component;
+  connectedComponent?: TConnectedComponent;
   /**
    * 关闭前的回调，返回 false 可以阻止关闭
    * @returns

--- a/packages/@core/ui-kit/popup-ui/src/drawer/index.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/index.ts
@@ -1,3 +1,7 @@
 export type * from './drawer';
 export { default as VbenDrawer } from './drawer.vue';
-export { setDefaultDrawerProps, useVbenDrawer } from './use-drawer';
+export {
+  createVbenDrawer,
+  setDefaultDrawerProps,
+  useVbenDrawer,
+} from './use-drawer';

--- a/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/use-drawer.ts
@@ -1,7 +1,10 @@
+import type { Component } from 'vue';
+
 import type {
   DrawerApiOptions,
   DrawerProps,
   ExtendedDrawerApi,
+  InferDrawerData,
 } from './drawer';
 
 import {
@@ -24,6 +27,26 @@ import VbenDrawer from './drawer.vue';
 
 const USER_DRAWER_INJECT_KEY = Symbol('VBEN_DRAWER_INJECT');
 
+declare const DRAWER_DATA_NOT_PROVIDED: unique symbol;
+
+type DrawerDataNotProvided = {
+  readonly [DRAWER_DATA_NOT_PROVIDED]: true;
+};
+
+type ResolvedDrawerData<
+  TData,
+  TConnectedComponent extends Component,
+> = TData extends DrawerDataNotProvided
+  ? InferDrawerData<TConnectedComponent>
+  : TData;
+
+interface DrawerInjectData<TData> {
+  consumed?: boolean;
+  extendApi?: (api: ExtendedDrawerApi<TData>) => void;
+  options?: DrawerApiOptions;
+  reCreateDrawer?: () => Promise<void>;
+}
+
 const { globalEscapeShortcutKey } = usePreferences();
 
 /**
@@ -36,8 +59,11 @@ export function setDefaultDrawerProps(props: Partial<DrawerProps>) {
 }
 
 export function useVbenDrawer<
-  TParentDrawerProps extends DrawerProps = DrawerProps,
->(options: DrawerApiOptions = {}) {
+  TData = DrawerDataNotProvided,
+  TConnectedComponent extends Component = Component,
+>(options: DrawerApiOptions<TConnectedComponent> = {}) {
+  type TResolvedData = ResolvedDrawerData<TData, TConnectedComponent>;
+
   // Drawer一般会抽离出来，所以如果有传入 connectedComponent，则表示为外部调用，与内部组件进行连接
   // 外部的Drawer通过provide/inject传递api
 
@@ -47,11 +73,11 @@ export function useVbenDrawer<
   };
   const { connectedComponent } = options;
   if (connectedComponent) {
-    const extendedApi = shallowReactive({});
+    const extendedApi = shallowReactive({}) as ExtendedDrawerApi<TResolvedData>;
     const isDrawerReady = ref(true);
     const Drawer = defineComponent(
-      (props: TParentDrawerProps, { attrs, slots }) => {
-        function rebindApi(api: ExtendedDrawerApi) {
+      (props: DrawerProps, { attrs, slots }) => {
+        function rebindApi(api: ExtendedDrawerApi<TResolvedData>) {
           Object.setPrototypeOf(extendedApi, markRaw(api));
         }
 
@@ -65,7 +91,7 @@ export function useVbenDrawer<
             isDrawerReady.value = true;
           },
         });
-        checkProps(extendedApi as ExtendedDrawerApi, {
+        checkProps(extendedApi, {
           ...props,
           ...attrs,
           ...slots,
@@ -84,10 +110,13 @@ export function useVbenDrawer<
       },
     );
 
-    return [Drawer, extendedApi as ExtendedDrawerApi] as const;
+    return [Drawer, extendedApi] as const;
   }
 
-  const injectData = inject<any>(USER_DRAWER_INJECT_KEY, {});
+  const injectData = inject<DrawerInjectData<TResolvedData>>(
+    USER_DRAWER_INJECT_KEY,
+    {},
+  );
   const isConsumed = injectData.consumed;
   const effectiveOptions = isConsumed ? {} : injectData.options;
   if (!isConsumed && injectData.consumed !== undefined) {
@@ -122,9 +151,9 @@ export function useVbenDrawer<
       injectData.reCreateDrawer?.();
     }
   };
-  const api = new DrawerApi(mergedOptions);
+  const api = new DrawerApi<TResolvedData>(mergedOptions);
 
-  const extendedApi: ExtendedDrawerApi = api as never;
+  const extendedApi = api as ExtendedDrawerApi<TResolvedData>;
 
   extendedApi.useStore = (selector) => {
     return useSelector(api.store, selector);
@@ -145,7 +174,18 @@ export function useVbenDrawer<
   return [Drawer, extendedApi] as const;
 }
 
-async function checkProps(api: ExtendedDrawerApi, attrs: Record<string, any>) {
+export function createVbenDrawer<TData = unknown>() {
+  return function useTypedVbenDrawer<
+    TConnectedComponent extends Component = Component,
+  >(options: DrawerApiOptions<TConnectedComponent> = {}) {
+    return useVbenDrawer<TData, TConnectedComponent>(options);
+  };
+}
+
+async function checkProps<TData>(
+  api: ExtendedDrawerApi<TData>,
+  attrs: Record<string, any>,
+) {
   if (!attrs || Object.keys(attrs).length === 0) {
     return;
   }

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/fixtures/typed-modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/fixtures/typed-modal.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useVbenModal } from '../../use-modal';
+
+interface TypedModalData {
+  id: number;
+  mode: 'edit' | 'view';
+}
+
+const [, modalApi] = useVbenModal<TypedModalData | null>();
+
+defineExpose({ modalApi });
+</script>
+
+<template>
+  <div />
+</template>

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal-api.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal-api.test.ts
@@ -82,6 +82,16 @@ describe('modalApi', () => {
     expect(modalApi.getData()).toEqual(testData);
   });
 
+  it('should return undefined before shared data is set', () => {
+    expect(modalApi.getData()).toBeUndefined();
+  });
+
+  it('should preserve null shared data', () => {
+    const nullableModalApi = new ModalApi<null | Record<string, unknown>>();
+    nullableModalApi.setData(null);
+    expect(nullableModalApi.getData()).toBeNull();
+  });
+
   it('should set state correctly using an object', () => {
     modalApi.setState({ title: 'New Title' });
     expect(modalApi.store.state.title).toBe('New Title');

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal-types.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal-types.test.ts
@@ -1,0 +1,59 @@
+import type { ExtendedModalApi, InferModalData } from '../modal';
+import type { createVbenModal, useVbenModal } from '../use-modal';
+import type TypedModal from './fixtures/typed-modal.vue';
+
+import { describe, expectTypeOf, it } from 'vitest';
+
+interface TypedModalData {
+  id: number;
+  mode: 'edit' | 'view';
+}
+
+type ModalData = null | TypedModalData;
+
+declare const createModal: typeof createVbenModal;
+declare const useModal: typeof useVbenModal;
+
+describe('modal public data types', () => {
+  it('infers data from the connected component exposed api', () => {
+    function assertInferredData(connectedComponent: typeof TypedModal) {
+      const [, modalApi] = useModal({ connectedComponent });
+
+      expectTypeOf(modalApi).toEqualTypeOf<ExtendedModalApi<ModalData>>();
+      expectTypeOf(modalApi.getData()).toEqualTypeOf<ModalData | undefined>();
+      expectTypeOf(modalApi.setData).parameter(0).toEqualTypeOf<ModalData>();
+      expectTypeOf(modalApi.setData(null).open()).toBeVoid();
+      // @ts-expect-error invalid payload type
+      modalApi.setData({ id: '1', mode: 'edit' });
+    }
+
+    expectTypeOf<
+      InferModalData<typeof TypedModal>
+    >().toEqualTypeOf<ModalData>();
+    expectTypeOf(assertInferredData).toBeFunction();
+  });
+
+  it('supports explicit and pre-bound data contracts', () => {
+    function assertExplicitData() {
+      const [, explicitApi] = useModal<ModalData>();
+      const useTypedModal = createModal<ModalData>();
+      const [, preBoundApi] = useTypedModal();
+
+      expectTypeOf(explicitApi).toEqualTypeOf<ExtendedModalApi<ModalData>>();
+      expectTypeOf(preBoundApi).toEqualTypeOf<ExtendedModalApi<ModalData>>();
+    }
+
+    expectTypeOf(assertExplicitData).toBeFunction();
+  });
+
+  it('falls back to unknown without a data contract', () => {
+    function assertUnknownData() {
+      const [, modalApi] = useModal();
+
+      expectTypeOf(modalApi).toEqualTypeOf<ExtendedModalApi<unknown>>();
+      expectTypeOf(modalApi.getData()).toBeUnknown();
+    }
+
+    expectTypeOf(assertUnknownData).toBeFunction();
+  });
+});

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/use-modal.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/use-modal.test.ts
@@ -79,6 +79,9 @@ describe('useVbenModal', () => {
     expect(initialApi).toBeDefined();
     if (!initialApi) return;
     expect(toRaw(parentApi.store)).toBe(initialApi.store);
+    const initialData = { id: 1 };
+    parentApi.setData(initialData);
+    expect(initialApi.getData()).toBe(initialData);
 
     await remountConsumer(consumerKey);
     const recreatedApi = getCurrentApi();
@@ -88,6 +91,9 @@ describe('useVbenModal', () => {
     expect(recreatedApi).not.toBe(initialApi);
     expect(recreatedApi.store.state.title).toBe('Parent modal title');
     expect(toRaw(parentApi.store)).toBe(recreatedApi.store);
+    const recreatedData = { id: 2 };
+    parentApi.setData(recreatedData);
+    expect(recreatedApi.getData()).toBe(recreatedData);
 
     parentApi.open();
     expect(onOpenChange).toHaveBeenCalledWith(true);

--- a/packages/@core/ui-kit/popup-ui/src/modal/index.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/index.ts
@@ -1,3 +1,7 @@
 export type * from './modal';
 export { default as VbenModal } from './modal.vue';
-export { setDefaultModalProps, useVbenModal } from './use-modal';
+export {
+  createVbenModal,
+  setDefaultModalProps,
+  useVbenModal,
+} from './use-modal';

--- a/packages/@core/ui-kit/popup-ui/src/modal/modal-api.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal-api.ts
@@ -3,10 +3,10 @@ import type { ModalApiOptions, ModalState } from './modal';
 import { Store } from '@vben-core/shared/store';
 import { bindMethods, isFunction } from '@vben-core/shared/utils';
 
-export class ModalApi {
+export class ModalApi<TData = unknown> {
   // 共享数据
-  public sharedData: Record<'payload', any> = {
-    payload: {},
+  public sharedData: Record<'payload', TData | undefined> = {
+    payload: undefined,
   };
   public store: Store<ModalState>;
 
@@ -106,8 +106,8 @@ export class ModalApi {
     }
   }
 
-  getData<T extends object = Record<string, any>>() {
-    return (this.sharedData?.payload ?? {}) as T;
+  getData(): TData | undefined {
+    return this.sharedData.payload;
   }
 
   /**
@@ -163,7 +163,7 @@ export class ModalApi {
     }));
   }
 
-  setData<T>(payload: T) {
+  setData(payload: TData) {
     this.sharedData.payload = payload;
     return this;
   }

--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.ts
@@ -150,23 +150,36 @@ export interface ModalProps {
 export interface ModalState extends ModalProps {
   /** 弹窗打开状态 */
   isOpen?: boolean;
-  /**
-   * 共享数据
-   */
-  sharedData?: Record<string, any>;
 }
 
-export type ExtendedModalApi = ModalApi & {
+export type ExtendedModalApi<TData = unknown> = ModalApi<TData> & {
   useStore: <T = NoInfer<ModalState>>(
     selector?: (state: NoInfer<ModalState>) => T,
   ) => Readonly<Ref<T>>;
 };
 
-export interface ModalApiOptions extends ModalState {
+type ModalComponentInstance<TComponent extends Component> =
+  TComponent extends abstract new (...args: any[]) => infer TInstance
+    ? TInstance
+    : never;
+
+export type InferModalData<TComponent extends Component> = [
+  ModalComponentInstance<TComponent>,
+] extends [never]
+  ? unknown
+  : ModalComponentInstance<TComponent> extends {
+        modalApi: ExtendedModalApi<infer TData>;
+      }
+    ? TData
+    : unknown;
+
+export interface ModalApiOptions<
+  TConnectedComponent extends Component = Component,
+> extends ModalState {
   /**
    * 独立的弹窗组件
    */
-  connectedComponent?: Component;
+  connectedComponent?: TConnectedComponent;
   /**
    * 关闭前的回调，返回 false 可以阻止关闭
    * @returns

--- a/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/use-modal.ts
@@ -1,4 +1,11 @@
-import type { ExtendedModalApi, ModalApiOptions, ModalProps } from './modal';
+import type { Component } from 'vue';
+
+import type {
+  ExtendedModalApi,
+  InferModalData,
+  ModalApiOptions,
+  ModalProps,
+} from './modal';
 
 import {
   defineComponent,
@@ -20,6 +27,26 @@ import VbenModal from './modal.vue';
 
 const USER_MODAL_INJECT_KEY = Symbol('VBEN_MODAL_INJECT');
 
+declare const MODAL_DATA_NOT_PROVIDED: unique symbol;
+
+type ModalDataNotProvided = {
+  readonly [MODAL_DATA_NOT_PROVIDED]: true;
+};
+
+type ResolvedModalData<
+  TData,
+  TConnectedComponent extends Component,
+> = TData extends ModalDataNotProvided
+  ? InferModalData<TConnectedComponent>
+  : TData;
+
+interface ModalInjectData<TData> {
+  consumed?: boolean;
+  extendApi?: (api: ExtendedModalApi<TData>) => void;
+  options?: ModalApiOptions;
+  reCreateModal?: () => Promise<void>;
+}
+
 const { globalEscapeShortcutKey } = usePreferences();
 /**
  * 默认配置
@@ -30,9 +57,12 @@ export function setDefaultModalProps(props: Partial<ModalProps>) {
   Object.assign(DEFAULT_MODAL_PROPS, props);
 }
 
-export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
-  options: ModalApiOptions = {},
-) {
+export function useVbenModal<
+  TData = ModalDataNotProvided,
+  TConnectedComponent extends Component = Component,
+>(options: ModalApiOptions<TConnectedComponent> = {}) {
+  type TResolvedData = ResolvedModalData<TData, TConnectedComponent>;
+
   // Modal一般会抽离出来，所以如果有传入 connectedComponent，则表示为外部调用，与内部组件进行连接
   // 外部的Modal通过provide/inject传递api
 
@@ -42,11 +72,11 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   };
   const { connectedComponent } = options;
   if (connectedComponent) {
-    const extendedApi = shallowReactive({});
+    const extendedApi = shallowReactive({}) as ExtendedModalApi<TResolvedData>;
     const isModalReady = ref(true);
     const Modal = defineComponent(
-      (props: TParentModalProps, { attrs, slots }) => {
-        function rebindApi(api: ExtendedModalApi) {
+      (props: ModalProps, { attrs, slots }) => {
+        function rebindApi(api: ExtendedModalApi<TResolvedData>) {
           Object.setPrototypeOf(extendedApi, markRaw(api));
         }
 
@@ -60,7 +90,7 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
             isModalReady.value = true;
           },
         });
-        checkProps(extendedApi as ExtendedModalApi, {
+        checkProps(extendedApi, {
           ...props,
           ...attrs,
           ...slots,
@@ -82,10 +112,13 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
       },
     );
 
-    return [Modal, extendedApi as ExtendedModalApi] as const;
+    return [Modal, extendedApi] as const;
   }
 
-  const injectData = inject<any>(USER_MODAL_INJECT_KEY, {});
+  const injectData = inject<ModalInjectData<TResolvedData>>(
+    USER_MODAL_INJECT_KEY,
+    {},
+  );
   const isConsumed = injectData.consumed;
   const effectiveOptions = isConsumed ? {} : injectData.options;
   if (!isConsumed && injectData.consumed !== undefined) {
@@ -121,9 +154,9 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
     }
   };
 
-  const api = new ModalApi(mergedOptions);
+  const api = new ModalApi<TResolvedData>(mergedOptions);
 
-  const extendedApi: ExtendedModalApi = api as never;
+  const extendedApi = api as ExtendedModalApi<TResolvedData>;
 
   extendedApi.useStore = (selector) => {
     return useSelector(api.store, selector);
@@ -153,7 +186,18 @@ export function useVbenModal<TParentModalProps extends ModalProps = ModalProps>(
   return [Modal, extendedApi] as const;
 }
 
-async function checkProps(api: ExtendedModalApi, attrs: Record<string, any>) {
+export function createVbenModal<TData = unknown>() {
+  return function useTypedVbenModal<
+    TConnectedComponent extends Component = Component,
+  >(options: ModalApiOptions<TConnectedComponent> = {}) {
+    return useVbenModal<TData, TConnectedComponent>(options);
+  };
+}
+
+async function checkProps<TData>(
+  api: ExtendedModalApi<TData>,
+  attrs: Record<string, any>,
+) {
   if (!attrs || Object.keys(attrs).length === 0) {
     return;
   }

--- a/playground/src/views/examples/drawer/form-drawer-demo.vue
+++ b/playground/src/views/examples/drawer/form-drawer-demo.vue
@@ -7,6 +7,10 @@ defineOptions({
   name: 'FormDrawerDemo',
 });
 
+interface FormDrawerData {
+  values?: Record<string, unknown>;
+}
+
 const [Form, formApi] = useVbenForm({
   schema: [
     {
@@ -30,7 +34,7 @@ const [Form, formApi] = useVbenForm({
   ],
   showDefaultActions: false,
 });
-const [Drawer, drawerApi] = useVbenDrawer({
+const [Drawer, drawerApi] = useVbenDrawer<FormDrawerData>({
   onCancel() {
     drawerApi.close();
   },
@@ -40,14 +44,16 @@ const [Drawer, drawerApi] = useVbenDrawer({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      const { values } = drawerApi.getData<Record<string, any>>();
-      if (values) {
-        formApi.setValues(values);
+      const data = drawerApi.getData();
+      if (data?.values) {
+        formApi.setValues(data.values);
       }
     }
   },
   title: '内嵌表单示例',
 });
+
+defineExpose({ drawerApi });
 </script>
 <template>
   <Drawer>

--- a/playground/src/views/examples/drawer/form-drawer-demo.vue
+++ b/playground/src/views/examples/drawer/form-drawer-demo.vue
@@ -47,6 +47,8 @@ const [Drawer, drawerApi] = useVbenDrawer<FormDrawerData>({
       const data = drawerApi.getData();
       if (data?.values) {
         formApi.setValues(data.values);
+      } else {
+        formApi.reset();
       }
     }
   },

--- a/playground/src/views/examples/drawer/index.vue
+++ b/playground/src/views/examples/drawer/index.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import type { DrawerPlacement, DrawerState } from '@vben/common-ui';
 
+import type { ExplicitDrawerData } from './typed-data-contract';
+
 import { Page, useVbenDrawer } from '@vben/common-ui';
 
 import { Button, Card } from 'antdv-next';
@@ -12,6 +14,10 @@ import DynamicDemo from './dynamic-demo.vue';
 import FormDrawerDemo from './form-drawer-demo.vue';
 import inContentDemo from './in-content-demo.vue';
 import SharedDataDemo from './shared-data-demo.vue';
+import TypedDataAutoDemo from './typed-data-auto-demo.vue';
+import { useFactoryDrawer } from './typed-data-contract';
+import TypedDataExplicitDemo from './typed-data-explicit-demo.vue';
+import TypedDataFactoryDemo from './typed-data-factory-demo.vue';
 
 defineOptions({ name: 'DrawerExample' });
 const [BaseDrawer, baseDrawerApi] = useVbenDrawer({
@@ -40,6 +46,19 @@ const [SharedDataDrawer, sharedDrawerApi] = useVbenDrawer({
 
 const [FormDrawer, formDrawerApi] = useVbenDrawer({
   connectedComponent: FormDrawerDemo,
+});
+
+const [TypedDataAutoDrawer, typedDataAutoDrawerApi] = useVbenDrawer({
+  connectedComponent: TypedDataAutoDemo,
+});
+
+const [TypedDataExplicitDrawer, typedDataExplicitDrawerApi] =
+  useVbenDrawer<ExplicitDrawerData>({
+    connectedComponent: TypedDataExplicitDemo,
+  });
+
+const [TypedDataFactoryDrawer, typedDataFactoryDrawerApi] = useFactoryDrawer({
+  connectedComponent: TypedDataFactoryDemo,
 });
 
 function openBaseDrawer(placement: DrawerPlacement = 'right') {
@@ -93,6 +112,33 @@ function openFormDrawer() {
     })
     .open();
 }
+
+function openTypedDataAutoDrawer() {
+  typedDataAutoDrawerApi
+    .setData({
+      message: '外部无需声明泛型，由 connected component 自动推导。',
+      method: '自动推导',
+    })
+    .open();
+}
+
+function openTypedDataExplicitDrawer() {
+  typedDataExplicitDrawerApi
+    .setData({
+      message: '父子组件显式引用同一个数据类型。',
+      method: '显式泛型',
+    })
+    .open();
+}
+
+function openTypedDataFactoryDrawer() {
+  typedDataFactoryDrawerApi
+    .setData({
+      message: '父子组件复用预绑定的 typed composable。',
+      method: '契约工厂',
+    })
+    .open();
+}
 </script>
 
 <template>
@@ -110,6 +156,9 @@ function openFormDrawer() {
     <DynamicDrawer />
     <SharedDataDrawer />
     <FormDrawer />
+    <TypedDataAutoDrawer />
+    <TypedDataExplicitDrawer />
+    <TypedDataFactoryDrawer />
 
     <Card class="mb-4" title="基本使用">
       <p class="mb-3">一个基础的抽屉示例</p>
@@ -189,6 +238,31 @@ function openFormDrawer() {
       <p class="mb-3">打开抽屉并设置表单schema以及数据</p>
       <Button type="primary" @click="openFormDrawer">
         打开抽屉并设置表单schema以及数据
+      </Button>
+    </Card>
+
+    <Card class="mb-4" title="共享数据：自动推导">
+      <p class="mb-3">
+        子组件 expose API，父组件从 connected component 推导类型
+      </p>
+      <Button type="primary" @click="openTypedDataAutoDrawer">
+        打开自动推导示例
+      </Button>
+    </Card>
+
+    <Card class="mb-4" title="共享数据：显式泛型">
+      <p class="mb-3">无法自动推导时，父子组件显式引用同一个数据类型</p>
+      <Button type="primary" @click="openTypedDataExplicitDrawer">
+        打开显式泛型示例
+      </Button>
+    </Card>
+
+    <Card class="mb-4" title="共享数据：契约工厂">
+      <p class="mb-3">
+        通过 createVbenDrawer 预绑定类型并复用 typed composable
+      </p>
+      <Button type="primary" @click="openTypedDataFactoryDrawer">
+        打开契约工厂示例
       </Button>
     </Card>
   </Page>

--- a/playground/src/views/examples/drawer/shared-data-demo.vue
+++ b/playground/src/views/examples/drawer/shared-data-demo.vue
@@ -5,9 +5,14 @@ import { useVbenDrawer } from '@vben/common-ui';
 
 import { message } from 'antdv-next';
 
-const data = ref();
+interface SharedData {
+  content: string;
+  payload: string;
+}
 
-const [Drawer, drawerApi] = useVbenDrawer({
+const data = ref<SharedData>();
+
+const [Drawer, drawerApi] = useVbenDrawer<SharedData>({
   onCancel() {
     drawerApi.close();
   },
@@ -17,10 +22,12 @@ const [Drawer, drawerApi] = useVbenDrawer({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      data.value = drawerApi.getData<Record<string, any>>();
+      data.value = drawerApi.getData();
     }
   },
 });
+
+defineExpose({ drawerApi });
 </script>
 <template>
   <Drawer title="数据共享示例">

--- a/playground/src/views/examples/drawer/typed-data-auto-demo.vue
+++ b/playground/src/views/examples/drawer/typed-data-auto-demo.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+import { useVbenDrawer } from '@vben/common-ui';
+
+interface AutoDrawerData {
+  message: string;
+  method: '自动推导';
+}
+
+const data = ref<AutoDrawerData>();
+
+const [Drawer, drawerApi] = useVbenDrawer<AutoDrawerData>({
+  onOpenChange(isOpen) {
+    data.value = isOpen ? drawerApi.getData() : undefined;
+  },
+});
+
+defineExpose({ drawerApi });
+</script>
+
+<template>
+  <Drawer title="自动推导数据类型">
+    <div class="space-y-2 px-2">
+      <p>类型来源：{{ data?.method }}</p>
+      <p>接收内容：{{ data?.message }}</p>
+    </div>
+  </Drawer>
+</template>

--- a/playground/src/views/examples/drawer/typed-data-contract.ts
+++ b/playground/src/views/examples/drawer/typed-data-contract.ts
@@ -1,0 +1,13 @@
+import { createVbenDrawer } from '@vben/common-ui';
+
+export interface ExplicitDrawerData {
+  message: string;
+  method: '显式泛型';
+}
+
+export interface FactoryDrawerData {
+  message: string;
+  method: '契约工厂';
+}
+
+export const useFactoryDrawer = createVbenDrawer<FactoryDrawerData>();

--- a/playground/src/views/examples/drawer/typed-data-explicit-demo.vue
+++ b/playground/src/views/examples/drawer/typed-data-explicit-demo.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { ExplicitDrawerData } from './typed-data-contract';
+
+import { ref } from 'vue';
+
+import { useVbenDrawer } from '@vben/common-ui';
+
+const data = ref<ExplicitDrawerData>();
+
+const [Drawer, drawerApi] = useVbenDrawer<ExplicitDrawerData>({
+  onOpenChange(isOpen) {
+    data.value = isOpen ? drawerApi.getData() : undefined;
+  },
+});
+</script>
+
+<template>
+  <Drawer title="显式泛型数据类型">
+    <div class="space-y-2 px-2">
+      <p>类型来源：{{ data?.method }}</p>
+      <p>接收内容：{{ data?.message }}</p>
+    </div>
+  </Drawer>
+</template>

--- a/playground/src/views/examples/drawer/typed-data-factory-demo.vue
+++ b/playground/src/views/examples/drawer/typed-data-factory-demo.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { FactoryDrawerData } from './typed-data-contract';
+
+import { ref } from 'vue';
+
+import { useFactoryDrawer } from './typed-data-contract';
+
+const data = ref<FactoryDrawerData>();
+
+const [Drawer, drawerApi] = useFactoryDrawer({
+  onOpenChange(isOpen) {
+    data.value = isOpen ? drawerApi.getData() : undefined;
+  },
+});
+</script>
+
+<template>
+  <Drawer title="契约工厂数据类型">
+    <div class="space-y-2 px-2">
+      <p>类型来源：{{ data?.method }}</p>
+      <p>接收内容：{{ data?.message }}</p>
+    </div>
+  </Drawer>
+</template>

--- a/playground/src/views/examples/modal/form-modal-demo.vue
+++ b/playground/src/views/examples/modal/form-modal-demo.vue
@@ -9,6 +9,10 @@ defineOptions({
   name: 'FormModelDemo',
 });
 
+interface FormModalData {
+  values?: Record<string, unknown>;
+}
+
 const [Form, formApi] = useVbenForm({
   handleSubmit: onSubmit,
   schema: [
@@ -48,7 +52,7 @@ const [Form, formApi] = useVbenForm({
   showDefaultActions: false,
 });
 
-const [Modal, modalApi] = useVbenModal({
+const [Modal, modalApi] = useVbenModal<FormModalData>({
   fullscreenButton: false,
   onCancel() {
     modalApi.close();
@@ -59,14 +63,16 @@ const [Modal, modalApi] = useVbenModal({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      const { values } = modalApi.getData<Record<string, any>>();
-      if (values) {
-        formApi.setValues(values);
+      const data = modalApi.getData();
+      if (data?.values) {
+        formApi.setValues(data.values);
       }
     }
   },
   title: '内嵌表单示例',
 });
+
+defineExpose({ modalApi });
 
 function onSubmit(values: Record<string, any>) {
   message.loading({

--- a/playground/src/views/examples/modal/index.vue
+++ b/playground/src/views/examples/modal/index.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import type { ExplicitModalData } from './typed-data-contract';
+
 import { onBeforeUnmount } from 'vue';
 
 import {
@@ -22,6 +24,10 @@ import FormModalDemo from './form-modal-demo.vue';
 import InContentModalDemo from './in-content-demo.vue';
 import NestedDemo from './nested-demo.vue';
 import SharedDataDemo from './shared-data-demo.vue';
+import TypedDataAutoDemo from './typed-data-auto-demo.vue';
+import { useFactoryModal } from './typed-data-contract';
+import TypedDataExplicitDemo from './typed-data-explicit-demo.vue';
+import TypedDataFactoryDemo from './typed-data-factory-demo.vue';
 
 defineOptions({ name: 'ModalExample' });
 
@@ -53,6 +59,19 @@ const [SharedDataModal, sharedModalApi] = useVbenModal({
 
 const [FormModal, formModalApi] = useVbenModal({
   connectedComponent: FormModalDemo,
+});
+
+const [TypedDataAutoModal, typedDataAutoModalApi] = useVbenModal({
+  connectedComponent: TypedDataAutoDemo,
+});
+
+const [TypedDataExplicitModal, typedDataExplicitModalApi] =
+  useVbenModal<ExplicitModalData>({
+    connectedComponent: TypedDataExplicitDemo,
+  });
+
+const [TypedDataFactoryModal, typedDataFactoryModalApi] = useFactoryModal({
+  connectedComponent: TypedDataFactoryDemo,
 });
 
 const [NestedModal, nestedModalApi] = useVbenModal({
@@ -109,6 +128,33 @@ function openFormModal() {
     .setData({
       // 表单值
       values: { field1: 'abc', field2: '123', field3: '1' },
+    })
+    .open();
+}
+
+function openTypedDataAutoModal() {
+  typedDataAutoModalApi
+    .setData({
+      message: '外部无需声明泛型，由 connected component 自动推导。',
+      method: '自动推导',
+    })
+    .open();
+}
+
+function openTypedDataExplicitModal() {
+  typedDataExplicitModalApi
+    .setData({
+      message: '父子组件显式引用同一个数据类型。',
+      method: '显式泛型',
+    })
+    .open();
+}
+
+function openTypedDataFactoryModal() {
+  typedDataFactoryModalApi
+    .setData({
+      message: '父子组件复用预绑定的 typed composable。',
+      method: '契约工厂',
     })
     .open();
 }
@@ -188,6 +234,9 @@ async function openPrompt() {
     <DynamicModal />
     <SharedDataModal />
     <FormModal />
+    <TypedDataAutoModal />
+    <TypedDataExplicitModal />
+    <TypedDataFactoryModal />
     <NestedModal />
     <BlurModal />
     <Flex wrap="wrap" class="w-full" gap="10">
@@ -246,6 +295,33 @@ async function openPrompt() {
         <p>弹窗与表单结合</p>
         <template #actions>
           <Button type="primary" @click="openFormModal"> 打开表单弹窗 </Button>
+        </template>
+      </Card>
+
+      <Card class="w-75" title="共享数据：自动推导">
+        <p>子组件 expose API，父组件从 connected component 推导类型</p>
+        <template #actions>
+          <Button type="primary" @click="openTypedDataAutoModal">
+            打开自动推导示例
+          </Button>
+        </template>
+      </Card>
+
+      <Card class="w-75" title="共享数据：显式泛型">
+        <p>无法自动推导时，父子组件显式引用同一个数据类型</p>
+        <template #actions>
+          <Button type="primary" @click="openTypedDataExplicitModal">
+            打开显式泛型示例
+          </Button>
+        </template>
+      </Card>
+
+      <Card class="w-75" title="共享数据：契约工厂">
+        <p>通过 createVbenModal 预绑定类型并复用 typed composable</p>
+        <template #actions>
+          <Button type="primary" @click="openTypedDataFactoryModal">
+            打开契约工厂示例
+          </Button>
         </template>
       </Card>
 

--- a/playground/src/views/examples/modal/shared-data-demo.vue
+++ b/playground/src/views/examples/modal/shared-data-demo.vue
@@ -5,9 +5,14 @@ import { useVbenModal } from '@vben/common-ui';
 
 import { message } from 'antdv-next';
 
-const data = ref();
+interface SharedData {
+  content: string;
+  payload: string;
+}
 
-const [Modal, modalApi] = useVbenModal({
+const data = ref<SharedData>();
+
+const [Modal, modalApi] = useVbenModal<SharedData>({
   onCancel() {
     modalApi.close();
   },
@@ -17,10 +22,12 @@ const [Modal, modalApi] = useVbenModal({
   },
   onOpenChange(isOpen: boolean) {
     if (isOpen) {
-      data.value = modalApi.getData<Record<string, any>>();
+      data.value = modalApi.getData();
     }
   },
 });
+
+defineExpose({ modalApi });
 </script>
 <template>
   <Modal title="数据共享示例">

--- a/playground/src/views/examples/modal/typed-data-auto-demo.vue
+++ b/playground/src/views/examples/modal/typed-data-auto-demo.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+import { useVbenModal } from '@vben/common-ui';
+
+interface AutoModalData {
+  message: string;
+  method: '自动推导';
+}
+
+const data = ref<AutoModalData>();
+
+const [Modal, modalApi] = useVbenModal<AutoModalData>({
+  onOpenChange(isOpen) {
+    data.value = isOpen ? modalApi.getData() : undefined;
+  },
+});
+
+defineExpose({ modalApi });
+</script>
+
+<template>
+  <Modal title="自动推导数据类型">
+    <div class="space-y-2 px-2">
+      <p>类型来源：{{ data?.method }}</p>
+      <p>接收内容：{{ data?.message }}</p>
+    </div>
+  </Modal>
+</template>

--- a/playground/src/views/examples/modal/typed-data-contract.ts
+++ b/playground/src/views/examples/modal/typed-data-contract.ts
@@ -1,0 +1,13 @@
+import { createVbenModal } from '@vben/common-ui';
+
+export interface ExplicitModalData {
+  message: string;
+  method: '显式泛型';
+}
+
+export interface FactoryModalData {
+  message: string;
+  method: '契约工厂';
+}
+
+export const useFactoryModal = createVbenModal<FactoryModalData>();

--- a/playground/src/views/examples/modal/typed-data-explicit-demo.vue
+++ b/playground/src/views/examples/modal/typed-data-explicit-demo.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { ExplicitModalData } from './typed-data-contract';
+
+import { ref } from 'vue';
+
+import { useVbenModal } from '@vben/common-ui';
+
+const data = ref<ExplicitModalData>();
+
+const [Modal, modalApi] = useVbenModal<ExplicitModalData>({
+  onOpenChange(isOpen) {
+    data.value = isOpen ? modalApi.getData() : undefined;
+  },
+});
+</script>
+
+<template>
+  <Modal title="显式泛型数据类型">
+    <div class="space-y-2 px-2">
+      <p>类型来源：{{ data?.method }}</p>
+      <p>接收内容：{{ data?.message }}</p>
+    </div>
+  </Modal>
+</template>

--- a/playground/src/views/examples/modal/typed-data-factory-demo.vue
+++ b/playground/src/views/examples/modal/typed-data-factory-demo.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { FactoryModalData } from './typed-data-contract';
+
+import { ref } from 'vue';
+
+import { useFactoryModal } from './typed-data-contract';
+
+const data = ref<FactoryModalData>();
+
+const [Modal, modalApi] = useFactoryModal({
+  onOpenChange(isOpen) {
+    data.value = isOpen ? modalApi.getData() : undefined;
+  },
+});
+</script>
+
+<template>
+  <Modal title="契约工厂数据类型">
+    <div class="space-y-2 px-2">
+      <p>类型来源：{{ data?.method }}</p>
+      <p>接收内容：{{ data?.message }}</p>
+    </div>
+  </Modal>
+</template>

--- a/playground/src/views/system/dept/modules/form.vue
+++ b/playground/src/views/system/dept/modules/form.vue
@@ -15,6 +15,11 @@ import { useSchema } from '../data';
 
 const emit = defineEmits(['success']);
 const formData = ref<SystemDeptApi.SystemDept>();
+type DeptModalData =
+  | null
+  | SystemDeptApi.SystemDept
+  | { pid: SystemDeptApi.SystemDept['pid'] };
+
 const getTitle = computed(() => {
   return formData.value?.id
     ? $t('ui.actionTitle.edit', [$t('system.dept.name')])
@@ -32,7 +37,7 @@ function resetForm() {
   formApi.setValues(formData.value || {});
 }
 
-const [Modal, modalApi] = useVbenModal({
+const [Modal, modalApi] = useVbenModal<DeptModalData>({
   async onConfirm() {
     const { valid } = await formApi.validate();
     if (valid) {
@@ -51,17 +56,22 @@ const [Modal, modalApi] = useVbenModal({
   },
   onOpenChange(isOpen) {
     if (isOpen) {
-      const data = modalApi.getData<SystemDeptApi.SystemDept>();
+      const data = modalApi.getData();
       if (data) {
         if (data.pid === 0) {
           data.pid = undefined;
         }
-        formData.value = data;
-        formApi.setValues(formData.value);
+        formData.value = 'id' in data ? data : undefined;
+        formApi.setValues(data);
+      } else {
+        formData.value = undefined;
+        formApi.reset();
       }
     }
   },
 });
+
+defineExpose({ modalApi });
 </script>
 
 <template>

--- a/playground/src/views/system/dept/modules/form.vue
+++ b/playground/src/views/system/dept/modules/form.vue
@@ -58,11 +58,12 @@ const [Modal, modalApi] = useVbenModal<DeptModalData>({
     if (isOpen) {
       const data = modalApi.getData();
       if (data) {
-        if (data.pid === 0) {
-          data.pid = undefined;
-        }
         formData.value = 'id' in data ? data : undefined;
-        formApi.setValues(data);
+        const formValues = {
+          ...data,
+          ...(data.pid === 0 ? { pid: undefined } : {}),
+        };
+        formApi.setValues(formValues);
       } else {
         formData.value = undefined;
         formApi.reset();

--- a/playground/src/views/system/menu/modules/form.vue
+++ b/playground/src/views/system/menu/modules/form.vue
@@ -32,6 +32,9 @@ const emit = defineEmits<{
 const formData = ref<SystemMenuApi.SystemMenu>();
 const titleSuffix = ref<string>();
 
+type MenuDrawerData =
+  | SystemMenuApi.SystemMenu
+  | { pid?: SystemMenuApi.SystemMenu['pid'] };
 type MenuSubmitValues = Omit<SystemMenuApi.SystemMenu, 'children' | 'id'>;
 type MenuFormValues = MenuSubmitValues & { linkSrc?: string };
 
@@ -479,24 +482,28 @@ const [Form, formApi] = useVbenForm({
   showDefaultActions: false,
   wrapperClass: 'grid-cols-2 gap-x-4',
 });
-const [Drawer, drawerApi] = useVbenDrawer({
+const [Drawer, drawerApi] = useVbenDrawer<MenuDrawerData>({
   onConfirm: onSubmit,
   async onOpenChange(isOpen) {
     if (isOpen) {
-      const data = drawerApi.getData<SystemMenuApi.SystemMenu>();
-      if (data) {
+      const data = drawerApi.getData();
+      if (data && 'id' in data) {
         formData.value = data;
         await formApi.setSubmitValues(data);
         titleSuffix.value = formData.value.meta?.title
           ? $t(formData.value.meta.title)
           : '';
       } else {
+        formData.value = undefined;
         formApi.reset();
+        await formApi.setValues(data ?? {});
         titleSuffix.value = '';
       }
     }
   },
 });
+
+defineExpose({ drawerApi });
 
 async function onSubmit() {
   const { valid } = await formApi.validate();

--- a/playground/src/views/system/role/list.vue
+++ b/playground/src/views/system/role/list.vue
@@ -161,7 +161,7 @@ function onRefresh() {
 }
 
 function onCreate() {
-  formDrawerApi.setData({}).open();
+  formDrawerApi.setData(null).open();
 }
 </script>
 <template>

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -32,7 +32,7 @@ const permissions = ref<DataNode[]>([]);
 const loadingPermissions = ref(false);
 
 const id = ref();
-const [Drawer, drawerApi] = useVbenDrawer({
+const [Drawer, drawerApi] = useVbenDrawer<null | SystemRoleApi.SystemRole>({
   async onConfirm() {
     const { valid } = await formApi.validate();
     if (!valid) return;
@@ -50,7 +50,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
 
   async onOpenChange(isOpen) {
     if (isOpen) {
-      const data = drawerApi.getData<SystemRoleApi.SystemRole>();
+      const data = drawerApi.getData();
       formApi.reset();
 
       if (data) {
@@ -71,6 +71,8 @@ const [Drawer, drawerApi] = useVbenDrawer({
     }
   },
 });
+
+defineExpose({ drawerApi });
 
 async function loadPermissions() {
   loadingPermissions.value = true;

--- a/playground/src/views/system/role/modules/form.vue
+++ b/playground/src/views/system/role/modules/form.vue
@@ -57,6 +57,7 @@ const [Drawer, drawerApi] = useVbenDrawer<null | SystemRoleApi.SystemRole>({
         formData.value = data;
         id.value = data.id;
       } else {
+        formData.value = undefined;
         id.value = undefined;
       }
 

--- a/playground/src/views/system/user/list.vue
+++ b/playground/src/views/system/user/list.vue
@@ -162,7 +162,7 @@ function onRefresh() {
 }
 
 function onCreate() {
-  formDrawerApi.setData({}).open();
+  formDrawerApi.setData(null).open();
 }
 
 async function loadDeptList() {

--- a/playground/src/views/system/user/modules/detail.vue
+++ b/playground/src/views/system/user/modules/detail.vue
@@ -13,13 +13,15 @@ const detailData = ref<SystemUserApi.SystemUser>();
 
 const items = computed(() => useDescriptionItems(detailData.value));
 
-const [Drawer, drawerApi] = useVbenDrawer({
+const [Drawer, drawerApi] = useVbenDrawer<SystemUserApi.SystemUser>({
   onOpenChange(isOpen) {
     if (isOpen) {
-      detailData.value = drawerApi.getData<SystemUserApi.SystemUser>();
+      detailData.value = drawerApi.getData();
     }
   },
 });
+
+defineExpose({ drawerApi });
 </script>
 <template>
   <Drawer :footer="false" :title="$t('common.detail')">

--- a/playground/src/views/system/user/modules/form.vue
+++ b/playground/src/views/system/user/modules/form.vue
@@ -31,7 +31,7 @@ const permissions = ref<DataNode[]>([]);
 const loadingPermissions = ref(false);
 
 const id = ref();
-const [Drawer, drawerApi] = useVbenDrawer({
+const [Drawer, drawerApi] = useVbenDrawer<null | SystemUserApi.SystemUser>({
   async onConfirm() {
     const { valid } = await formApi.validate();
     if (!valid) return;
@@ -49,7 +49,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
 
   async onOpenChange(isOpen) {
     if (isOpen) {
-      const data = drawerApi.getData<SystemUserApi.SystemUser>();
+      const data = drawerApi.getData();
       formApi.reset();
 
       if (data) {
@@ -70,6 +70,8 @@ const [Drawer, drawerApi] = useVbenDrawer({
     }
   },
 });
+
+defineExpose({ drawerApi });
 
 async function loadPermissions() {
   loadingPermissions.value = true;

--- a/playground/src/views/system/user/modules/form.vue
+++ b/playground/src/views/system/user/modules/form.vue
@@ -56,6 +56,7 @@ const [Drawer, drawerApi] = useVbenDrawer<null | SystemUserApi.SystemUser>({
         formData.value = data;
         id.value = data.id;
       } else {
+        formData.value = undefined;
         id.value = undefined;
       }
 


### PR DESCRIPTION
## Description

### Functional changes

- Add a single typed shared-data contract for `useVbenModal` and `useVbenDrawer`.
- Support three entry points: inference from an exposed connected SFC, an explicit generic, and a pre-bound contract factory.
- Make `setData` accept the contract type and make `getData()` return the contract type or `undefined`.
- Preserve `null` payloads, migrate existing playground and Naive UI consumers, and add interactive examples for all three patterns.

### Breaking changes

- The generic `getData` overload is removed; use `getData()`.
- Shared data defaults to `unknown`; callers must declare a contract when reading or writing structured data.
- `getData()` returns `undefined` before `setData()` instead of an empty object.

### Impact scope

- `@vben-core/popup-ui`: public Modal and Drawer API types, factories, runtime shared-data behavior, and tests.
- `@vben/playground`: system consumers plus Modal and Drawer examples.
- `@vben/web-naive`: embedded form modal demo.
- Documentation: English and Chinese Modal/Drawer API references and shared-data demos.
- No dependency or lockfile changes. No changeset was added for this branch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Validation performed:

- `pnpm check:type` via the project pre-commit hook.
- `git diff --check`.
- Manual browser verification of the three Modal and three Drawer playground examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type-safe shared data handling for modals and drawers, including automatic inference and reusable typed factories.
  * Modal and drawer APIs now validate payloads and return `undefined` when no data is available.
  * Added interactive examples demonstrating automatic, explicit, and factory-based data typing.

* **Bug Fixes**
  * Improved form initialization and reset behavior when modal or drawer data is missing or partially provided.

* **Documentation**
  * Added English and Chinese guidance for typed shared modal and drawer data.

* **Tests**
  * Added coverage for type inference, invalid payloads, null values, missing data, and data persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->