### PR TITLE
fix: 调整format执行顺序

### DIFF
--- a/internal/lint-configs/oxlint-config/src/configs/javascript.ts
+++ b/internal/lint-configs/oxlint-config/src/configs/javascript.ts
@@ -28,6 +28,8 @@ const javascript: OxlintConfig = {
     'default-case-last': 'error',
     eqeqeq: ['error', 'always'],
     'eslint/no-unreachable': 'error',
+    // 抛出嵌套三元运算格式错误，禁止使用嵌套三元运算。
+    'no-nested-ternary': 'error',
     'new-cap': [
       'error',
       {

--- a/internal/lint-configs/oxlint-config/src/configs/unicorn.ts
+++ b/internal/lint-configs/oxlint-config/src/configs/unicorn.ts
@@ -43,7 +43,8 @@ const unicorn: OxlintConfig = {
     'unicorn/no-magic-array-flat-depth': 'error',
     'unicorn/no-negated-condition': 'error',
     'unicorn/no-negation-in-equality-check': 'error',
-    'unicorn/no-nested-ternary': 'error',
+    // 禁止通过“添加括号”自动修复嵌套三元运算
+    'unicorn/no-nested-ternary': 'off',
     'unicorn/no-new-array': 'error',
     'unicorn/no-new-buffer': 'error',
     'unicorn/no-object-as-default-parameter': 'error',

--- a/scripts/vsh/src/lint/index.ts
+++ b/scripts/vsh/src/lint/index.ts
@@ -112,17 +112,17 @@ async function runLint({ format, threads }: LintCommandOptions) {
 
   if (format) {
     await runSerial([
-      ['stylelint', ['**/*.{vue,css,less,scss}', '--cache', '--fix']],
-      ['oxfmt', [threadsArg]],
       ['oxlint', ['--fix', '--type-aware', threadsArg]],
+      ['oxfmt', [threadsArg]],
       ['eslint', ['.', '--cache', '--fix']],
+      ['stylelint', ['**/*.{vue,css,less,scss}', '--cache', '--fix']],
     ]);
     return;
   }
 
   const commands: Command[] = [
-    ['oxfmt', ['--check', threadsArg]],
     ['oxlint', ['--type-aware', threadsArg]],
+    ['oxfmt', ['--check', threadsArg]],
     ['eslint', ['.', '--cache']],
     ['stylelint', ['**/*.{vue,css,less,scss}', '--cache']],
   ];


### PR DESCRIPTION

## Description

- 使用核心 no-nested-ternary 规则替代 Unicorn 自动修复，避免嵌套三元表达式被加括号 
- 调整format的执行顺序为 oxlint、oxfmt、eslint 和 stylelint ，保证与commit的流程一致

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting rules to flag nested ternary expressions consistently.
  * Standardized the order of formatting and lint checks for more predictable validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->