### PR TITLE
fix: stabilize content popups across route changes

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/drawer.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/__tests__/drawer.test.ts
@@ -1,0 +1,65 @@
+import type { App } from 'vue';
+
+import { createApp, defineComponent, h, nextTick } from 'vue';
+
+import { ELEMENT_ID_MAIN_CONTENT } from '@vben-core/shared/constants';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useVbenDrawer } from '../use-drawer';
+
+vi.mock('@vben-core/preferences', () => ({
+  usePreferences: () => ({
+    globalEscapeShortcutKey: { value: true },
+  }),
+}));
+
+let activeApp: App | undefined;
+
+async function mountPreopenedDrawer() {
+  const mainContent = document.createElement('main');
+  mainContent.id = ELEMENT_ID_MAIN_CONTENT;
+  mainContent.innerHTML = '<div><div></div></div>';
+  document.body.append(mainContent);
+
+  const Consumer = defineComponent(() => {
+    const [Drawer, drawerApi] = useVbenDrawer({ appendToMain: true });
+    drawerApi.open();
+    return () => h(Drawer);
+  });
+  const host = document.createElement('div');
+  document.body.append(host);
+
+  activeApp = createApp(() => h(Consumer));
+  activeApp.mount(host);
+  await nextTick();
+
+  return mainContent;
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('vben drawer', () => {
+  it('mounts an initially open drawer directly in the main content', async () => {
+    const mainContent = await mountPreopenedDrawer();
+    const dialog = document.querySelector('[role="dialog"]');
+
+    expect(dialog).toBeInstanceOf(HTMLElement);
+    if (!(dialog instanceof HTMLElement)) return;
+    expect(dialog.parentElement).toBe(mainContent);
+  });
+
+  it('shows a drawer that is opened before mounting', async () => {
+    await mountPreopenedDrawer();
+    const dialog = document.querySelector('[role="dialog"]');
+
+    expect(dialog).toBeInstanceOf(HTMLElement);
+    if (!(dialog instanceof HTMLElement)) return;
+    expect(dialog.classList.contains('hidden')).toBe(false);
+  });
+});

--- a/packages/@core/ui-kit/popup-ui/src/drawer/drawer.vue
+++ b/packages/@core/ui-kit/popup-ui/src/drawer/drawer.vue
@@ -148,9 +148,7 @@ function handleFocusOutside(e: Event) {
 }
 
 const getAppendTo = computed(() => {
-  return appendToMain.value
-    ? `#${ELEMENT_ID_MAIN_CONTENT}>div:not(.absolute)>div`
-    : undefined;
+  return appendToMain.value ? `#${ELEMENT_ID_MAIN_CONTENT}` : undefined;
 });
 
 /**
@@ -167,6 +165,7 @@ watch(
       hasOpened.value = true;
     }
   },
+  { immediate: true },
 );
 function handleClosed() {
   isClosed.value = true;

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
@@ -1,0 +1,102 @@
+import type { App } from 'vue';
+
+import { createApp, defineComponent, h, nextTick, onMounted } from 'vue';
+
+import { ELEMENT_ID_MAIN_CONTENT } from '@vben-core/shared/constants';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useVbenModal } from '../use-modal';
+
+vi.mock('@vben-core/preferences', () => ({
+  usePreferences: () => ({
+    globalEscapeShortcutKey: { value: true },
+  }),
+}));
+
+let activeApp: App | undefined;
+
+async function mountModal() {
+  const mainContent = document.createElement('main');
+  mainContent.id = ELEMENT_ID_MAIN_CONTENT;
+  mainContent.innerHTML = '<div><div></div></div>';
+  document.body.append(mainContent);
+
+  const Consumer = defineComponent(() => {
+    const [Modal, modalApi] = useVbenModal({
+      appendToMain: true,
+      draggable: true,
+      title: 'Draggable modal',
+    });
+    onMounted(() => {
+      modalApi.open();
+    });
+    return () => h(Modal);
+  });
+  const host = document.createElement('div');
+  document.body.append(host);
+
+  activeApp = createApp(() => h(Consumer));
+  activeApp.mount(host);
+  await nextTick();
+  await nextTick();
+
+  return mainContent;
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('vben modal', () => {
+  it('mounts an open modal directly in the main content', async () => {
+    const mainContent = await mountModal();
+    const dialog = document.querySelector('[role="dialog"]');
+    const overlay = document.querySelector('[data-dismissable-modal]');
+
+    expect(dialog).toBeInstanceOf(HTMLElement);
+    if (!(dialog instanceof HTMLElement)) return;
+    expect(overlay).toBeInstanceOf(HTMLElement);
+    if (!(overlay instanceof HTMLElement)) return;
+    expect(dialog.parentElement).toBe(mainContent);
+    expect(overlay.parentElement).toBe(mainContent);
+  });
+
+  it('constrains dragging to the main content', async () => {
+    const mainContent = await mountModal();
+    const dialog = document.querySelector('[role="dialog"]');
+    const header = document.querySelector('.cursor-move');
+
+    expect(dialog).toBeInstanceOf(HTMLElement);
+    if (!(dialog instanceof HTMLElement)) return;
+    expect(header).toBeInstanceOf(HTMLElement);
+    if (!(header instanceof HTMLElement)) return;
+
+    vi.spyOn(mainContent, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(100, 100, 800, 600),
+    );
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(300, 200, 400, 300),
+    );
+
+    header.dispatchEvent(
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: 400,
+        clientY: 300,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: 1400,
+        clientY: 1300,
+      }),
+    );
+
+    expect(dialog.style.transform).toBe('translate(200px, 200px)');
+    document.dispatchEvent(new MouseEvent('mouseup'));
+  });
+});

--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
@@ -107,9 +107,7 @@ const shouldCentered = computed(
 );
 
 const getAppendTo = computed(() => {
-  return appendToMain.value
-    ? `#${ELEMENT_ID_MAIN_CONTENT}>div:not(.absolute)>div`
-    : undefined;
+  return appendToMain.value ? `#${ELEMENT_ID_MAIN_CONTENT}` : undefined;
 });
 
 const { dragging, transform } = useModalDraggable(


### PR DESCRIPTION
## Description

Fixes #8210.

In-content popups previously teleported to a descendant of `#__vben_main_content` that resolves to the current route page root. Tab switches and route transitions can replace that node while popup API state is retained, leaving a Drawer hidden or rendering a popup into a stale target.

This change:

- mounts in-content Drawers and Modals directly to the persistent `#__vben_main_content` layout container;
- synchronizes Drawer visibility when its API is already open before the component mounts;
- adds real DOM regression coverage for Drawer/Modal teleport targets, pre-opened Drawers, overlays, and Modal drag bounds.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change does not modify `pnpm-lock.yaml`

## Verification

- Relevant Drawer/Modal Vitest suites: 28 tests passed.
- Pre-commit formatting, lint, stylelint, and type checks passed.
- Verified first open, repeated open, tab/route re-entry, and browser back/forward behavior in the playground.

## Checklist

- [x] No new functionality requiring documentation was introduced
- [x] Relevant tests have been run
- [x] The PR title clearly describes the changelog entry and uses the `fix:` prefix
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No additional comments are required for the straightforward changes
- [x] No documentation changes are required for this internal bug fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing related unit tests pass locally with my changes
- [x] No dependent downstream changes are required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drawer and modal placement when displayed within the main content area.
  - Ensured drawers correctly reflect their open state immediately when initialized.
  - Improved draggable modal behavior so movement remains constrained to the main content boundaries.

- **Tests**
  - Added coverage for drawer mounting, positioning, and visibility.
  - Added coverage for modal placement and drag constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->