### PR TITLE
fix(@vben/styles): 修复弹窗内 tooltip 层级被遮挡问题

### DIFF
--- a/packages/styles/src/antdv-next/index.css
+++ b/packages/styles/src/antdv-next/index.css
@@ -78,3 +78,8 @@
 .ant-app .form-valid-error .ant-picker-focused {
   box-shadow: 0 0 0 2px rgb(255 38 5 / 6%);
 }
+
+/** 弹窗内tooltip层级问题 */
+.css-var-root.ant-tooltip-css-var {
+  --ant-tooltip-z-index-popup: 2001;
+}


### PR DESCRIPTION
## Description

将 antd-tooltip 的 z-index 提升至 2001，避免在 Modal/弹窗等高 z-index 容器内的 tooltip 被遮挡

<img width="603" height="276" alt="1db8c95a0a19bedc0caaf899f10f53ef" src="https://github.com/user-attachments/assets/f90a1b11-a1b6-4303-ad6f-7fc45dcb7b6f" />

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ✅ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ✅ ] Run the tests with `pnpm test`.
- [ ✅ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ✅ ] My code follows the style guidelines of this project
- [ ✅ ] I have performed a self-review of my own code
- [ ✅ ] I have commented my code, particularly in hard-to-understand areas
- [ ✅ ] I have made corresponding changes to the documentation
- [ ✅ ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works
- [ ✅ ] New and existing unit tests pass locally with my changes
- [ ✅ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tooltip layering so tooltips appear above other interface elements when displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->