### PR TITLE
fix(@vben-core/menu-ui): menu badge overflow, font-size & default color

### DIFF
--- a/packages/@core/ui-kit/menu-ui/src/components/menu-badge.vue
+++ b/packages/@core/ui-kit/menu-ui/src/components/menu-badge.vue
@@ -14,7 +14,7 @@ interface Props extends MenuRecordBadgeRaw {
 const props = withDefaults(defineProps<Props>(), {});
 
 const variantsMap: Record<string, string> = {
-  default: 'bg-green-500',
+  default: 'bg-gray-500',
   destructive: 'bg-destructive',
   primary: 'bg-primary',
   success: 'bg-green-500',

--- a/packages/@core/ui-kit/menu-ui/src/components/menu-item.vue
+++ b/packages/@core/ui-kit/menu-ui/src/components/menu-item.vue
@@ -131,7 +131,9 @@ onBeforeUnmount(() => {
         />
         <VbenIcon :class="nsMenu.e('icon')" :icon="menuIcon" />
         <slot></slot>
-        <slot name="title"></slot>
+        <span v-if="$slots.title" :class="nsMenu.e('name')">
+          <slot name="title"></slot>
+        </span>
       </div>
     </a>
   </router-link>

--- a/packages/@core/ui-kit/menu-ui/src/components/menu.vue
+++ b/packages/@core/ui-kit/menu-ui/src/components/menu.vue
@@ -747,7 +747,7 @@ $namespace: vben;
     width: 100%;
     height: var(--menu-item-height);
 
-    span {
+    .#{$namespace}-menu__name {
       @include menu-title;
     }
   }

--- a/packages/@core/ui-kit/menu-ui/src/components/menu.vue
+++ b/packages/@core/ui-kit/menu-ui/src/components/menu.vue
@@ -824,10 +824,6 @@ $namespace: vben;
 
   @include menu-item;
 
-  * {
-    font-size: inherit !important;
-  }
-
   &__icon-arrow {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
## Description

This PR fixes three `MenuBadge` issues in `@vben-core/menu-ui`. All are small correctness bugs in the menu badge rendering.

### Issue 1: Badge ping ring clipped by `overflow` (leaf menu items)

The menu badge **dot** (`badgeType: 'dot'`) renders an `animate-ping` expanding ring. For **leaf menu items** (rendered via `MenuItem` → `.vben-menu-item__content`), this ring is clipped to the dot's own size, so the badge only *pulses* (opacity fade) instead of *pinging* (expanding radar ring). For **sub-menus / directories** (rendered via `SubMenuContent` → `.vben-sub-menu-content`), the ping works correctly — causing a visible animation inconsistency between the two.

#### Root cause

In `menu.vue`:

```scss
.vben-menu-item__content {
  ...
  span {                    // matches ALL descendant spans
    @include menu-title;    // includes overflow:hidden (for title ellipsis)
  }
}
```

The `span` selector matches **all descendant spans**, including the badge dot spans nested inside `MenuBadge`. The `menu-title` mixin's `overflow: hidden` (intended for title text ellipsis) is applied to the ping ring and its ancestor spans, clipping the 2× expanding ring back to the dot size. `.vben-sub-menu-content` does not have this `span` rule, so its badge pings correctly.

Verified via DevTools (computed style) before fix:
- leaf badge ping span: `overflow: hidden` (ring clipped) → looks like a pulse
- sub-menu badge ping span: `overflow: visible` (ring expands) → correct ping

#### Fix

Scope the `menu-title` mixin to the title span only (`.vben-menu__name`), and wrap the `MenuItem` title slot with that class. This is consistent with the existing `collapse-show-title` branch which already uses `nsMenu.e('name')`.

```diff
   &__content {
     ...
-    span {
+    .#{$namespace}-menu__name {
       @include menu-title;
     }
   }
```

```diff
-        <slot name="title"></slot>
+        <span v-if="$slots.title" :class="nsMenu.e('name')">
+          <slot name="title"></slot>
+        </span>
```

### Issue 2: Badge font-size forced to inherit on sub-menu content (directories)

The menu badge **text** (`badgeType: 'normal'`) renders with a custom font-size (e.g. `text-[10px]`) for a compact pill. For **sub-menus / directories** (`.vben-sub-menu-content`), this custom font-size is overridden, so the same badge renders noticeably larger than on **leaf menu items** (`.vben-menu-item__content`) — a size inconsistency between the two.

#### Root cause

In `menu.vue`:

```scss
.vben-sub-menu-content {
  ...
  * {
    font-size: inherit !important;   // forces ALL descendants to inherit parent font-size
  }
}
```

The `*` selector + `!important` forces every descendant of `.vben-sub-menu-content` to inherit the menu font-size (14px), overriding any explicit font-size on the badge. `.vben-menu-item__content` (leaf) has **no** such rule, so its badge honors `text-[10px]`.

Verified via DevTools (computed style) before fix:
- sub-menu badge text: `font-size: 14px` (forced inherit) → renders 68×26px
- leaf badge text: `font-size: 10px` (`text-[10px]` honored) → renders 52×20px

#### Fix

Remove the `* { font-size: inherit !important }` block. This aligns `.vben-sub-menu-content` with `.vben-menu-item__content` (which never had this rule). Descendants without an explicit font-size still inherit the menu font-size via natural CSS inheritance, while badges with explicit `text-[10px]` now render at the intended size.

```diff
 .#{$namespace}-sub-menu-content {
   ...
   @include menu-item;

-  * {
-    font-size: inherit !important;
-  }
-
   &__icon-arrow {
```

No behavioral change to the sub-menu title or arrow icon:
- `&__title` sets its own font-size via `@include menu-title` (`var(--menu-font-size)`)
- `&__icon-arrow` has no explicit font-size and still inherits the parent's

### Issue 3: Default badge variant renders green (same as success)

The `default` badge variant is mapped to `bg-green-500`, identical to the `success` variant. This makes default badges indistinguishable from success badges, and gives default badges an unintended "success" (green) connotation when they should be visually neutral.

#### Root cause

In `menu-badge.vue`:

```ts
const variantsMap: Record<string, string> = {
  default: 'bg-green-500',   // same as success below
  destructive: 'bg-destructive',
  primary: 'bg-primary',
  success: 'bg-green-500',
  warning: 'bg-yellow-500',
};
```

The `default` and `success` entries are identical (`bg-green-500`), so a badge with no explicit `badgeVariants` (falling back to `default`) renders in the success color.

#### Fix

Map `default` to a neutral gray, giving each variant a distinct, semantically correct color:

```diff
 const variantsMap: Record<string, string> = {
-  default: 'bg-green-500',
+  default: 'bg-gray-500',
   destructive: 'bg-destructive',
   primary: 'bg-primary',
   success: 'bg-green-500',
   warning: 'bg-yellow-500',
 };
```

Result: default = neutral gray, destructive = red, primary = brand, success = green, warning = yellow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [x] The title has been created using the [conventional commit](https://conventionalcommits.org/) standard.
- [x] I have followed the [code style](https://github.com/vbenjs/vue-vben-admin/blob/main/packages/@core/base/design/src/design/hooks/README.md) of this project.
- [x] I have reviewed my own code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes. (lefthook pre-commit: oxlint / oxfmt / eslint / stylelint / typecheck all green)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu item title rendering when titles are provided through slots.
  * Updated menu styling to apply more precisely to menu names, preventing unintended formatting of other text.
  * Removed unwanted font-size inheritance from submenu content.
  * Updated the default menu badge color from green to gray.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->