### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -128,7 +128,7 @@ Tailwind CSS v4.0 is designed for Safari 16.4+, Chrome 111+, and Firefox 128+
 
 ## スター歴史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vbenjs/vue-vben-admin&type=Date)](https://star-history.com/#vbenjs/vue-vben-admin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vbenjs/vue-vben-admin&type=Date)](https://star-history.dera.page/#vbenjs/vue-vben-admin&Date)
 
 ## 寄付
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Support modern browsers, not IE
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vbenjs/vue-vben-admin&type=Date)](https://star-history.com/#vbenjs/vue-vben-admin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vbenjs/vue-vben-admin&type=Date)](https://star-history.dera.page/#vbenjs/vue-vben-admin&Date)
 
 ## Donate
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,7 +128,7 @@ Tailwind CSS v4.0 is designed for Safari 16.4+, Chrome 111+, and Firefox 128+
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vbenjs/vue-vben-admin&type=Date)](https://star-history.com/#vbenjs/vue-vben-admin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vbenjs/vue-vben-admin&type=Date)](https://star-history.dera.page/#vbenjs/vue-vben-admin&Date)
 
 ## 捐赠
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream service is affected by GitHub stargazer API restrictions and can no longer load the data.

This updates the chart image and link to the star-history.dera.page endpoint, which uses a data source that requires no API token and serves both the API and frontend from the same domain, so the chart displays correctly again.

The same fix is applied to all README language versions (English, Chinese, and Japanese).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Star History chart links in the English, Japanese, and Simplified Chinese README files.
  - Charts now use the updated Star History service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->