### PR TITLE
fix: 修复弹窗关闭动画异常导致 UI 卡死，以及生产构建下组件库 CSS 层顺序错误导致样式丢失

### DIFF
--- a/internal/tailwind-config/src/theme.css
+++ b/internal/tailwind-config/src/theme.css
@@ -1,11 +1,14 @@
 /*
  * 级联层顺序声明（必须先于 @import 'tailwindcss' 首次出现）：
- * preflight(base) < UI 库组件样式(antd / el / td) < Tailwind 工具类，
+ * properties(Tailwind 的 --tw-* 回退变量层) < preflight(base) <
+ * UI 库组件样式(antd / el / td) < Tailwind 工具类，
  * 使组件库样式（antdv-next 经 StyleProvider layer 注入 @layer antd；
  * element-plus / tdesign 经各自应用的 vite css-layer 插件包入对应层）
- * 能被工具类覆盖
+ * 能被工具类覆盖。
+ * 与 internal/vite-config/src/plugins/css-layer.ts 中的 LAYER_ORDER_STATEMENT
+ * 保持一致。
  */
-@layer theme, base, ant, antd, el, td, components, utilities;
+@layer properties, theme, base, ant, antd, el, td, components, utilities;
 
 @import 'tailwindcss';
 @import 'tw-animate-css';

--- a/internal/vite-config/src/plugins/css-layer.test.ts
+++ b/internal/vite-config/src/plugins/css-layer.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { viteCssLayerPlugin } from './css-layer';
+
+interface FakeAsset {
+  fileName: string;
+  source: string;
+  type: string;
+}
+
+function createBundle(assets: FakeAsset[]) {
+  return Object.fromEntries(assets.map((asset) => [asset.fileName, asset]));
+}
+
+const LAYER_ORDER_STATEMENT =
+  '@layer properties, theme, base, ant, antd, el, td, components, utilities;';
+
+describe('viteCssLayerPlugin', () => {
+  it('wraps matching css modules in the target layer', () => {
+    const plugin = viteCssLayerPlugin({
+      layerName: 'el',
+      packageName: 'element-plus',
+    });
+    const transform = plugin.transform;
+
+    if (typeof transform !== 'function') return;
+
+    const result = transform.call(
+      undefined as never,
+      '.el-button { color: red; }',
+      '/node_modules/element-plus/es/components/button/style/css/index.css?used',
+    );
+
+    expect(result).toEqual({
+      code: '@layer el {\n.el-button { color: red; }\n}',
+      map: null,
+    });
+  });
+
+  it('does not wrap css modules outside the target package', () => {
+    const plugin = viteCssLayerPlugin({
+      layerName: 'el',
+      packageName: 'element-plus',
+    });
+    const transform = plugin.transform;
+
+    if (typeof transform !== 'function') return;
+
+    const result = transform.call(
+      undefined as never,
+      '.local { color: red; }',
+      '/src/views/home/index.css',
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('injects the layer order statement into matching css assets', () => {
+    const plugin = viteCssLayerPlugin({
+      layerName: 'el',
+      packageName: 'element-plus',
+    });
+    const generateBundle = plugin.generateBundle;
+
+    if (typeof generateBundle !== 'function') return;
+
+    const bundle = createBundle([
+      {
+        fileName: 'element-x.css',
+        source: '@layer el{.el-button{color:red}}',
+        type: 'asset',
+      },
+      {
+        fileName: 'theme-x.css',
+        source: '.local { color: blue; }',
+        type: 'asset',
+      },
+    ]);
+
+    generateBundle.call(undefined as never, {} as never, bundle);
+
+    expect(bundle['element-x.css'].source).toBe(
+      `${LAYER_ORDER_STATEMENT}\n@layer el{.el-button{color:red}}`,
+    );
+    expect(bundle['theme-x.css'].source).toBe('.local { color: blue; }');
+  });
+
+  it('does not inject the statement twice when already present', () => {
+    const plugin = viteCssLayerPlugin({
+      layerName: 'el',
+      packageName: 'element-plus',
+    });
+    const generateBundle = plugin.generateBundle;
+
+    if (typeof generateBundle !== 'function') return;
+
+    const bundle = createBundle([
+      {
+        fileName: 'element-x.css',
+        source: `${LAYER_ORDER_STATEMENT}\n@layer el{.el-button{color:red}}`,
+        type: 'asset',
+      },
+    ]);
+
+    generateBundle.call(undefined as never, {} as never, bundle);
+
+    expect(bundle['element-x.css'].source).toBe(
+      `${LAYER_ORDER_STATEMENT}\n@layer el{.el-button{color:red}}`,
+    );
+  });
+
+  it('injects the statement even when the asset starts with a BOM', () => {
+    const plugin = viteCssLayerPlugin({
+      layerName: 'el',
+      packageName: 'element-plus',
+    });
+    const generateBundle = plugin.generateBundle;
+
+    if (typeof generateBundle !== 'function') return;
+
+    const bundle = createBundle([
+      {
+        fileName: 'element-x.css',
+        source: `\uFEFF@layer el{.el-button{color:red}}`,
+        type: 'asset',
+      },
+    ]);
+
+    generateBundle.call(undefined as never, {} as never, bundle);
+
+    expect(bundle['element-x.css'].source).toBe(
+      `${LAYER_ORDER_STATEMENT}\n\uFEFF@layer el{.el-button{color:red}}`,
+    );
+  });
+
+  it('ignores non-css assets', () => {
+    const plugin = viteCssLayerPlugin({
+      layerName: 'el',
+      packageName: 'element-plus',
+    });
+    const generateBundle = plugin.generateBundle;
+
+    if (typeof generateBundle !== 'function') return;
+
+    const bundle = createBundle([
+      {
+        fileName: 'element-x.js',
+        source: '@layer el{.el-button{color:red}}',
+        type: 'chunk',
+      },
+    ]);
+
+    generateBundle.call(undefined as never, {} as never, bundle);
+
+    expect(bundle['element-x.js'].source).toBe(
+      '@layer el{.el-button{color:red}}',
+    );
+  });
+});

--- a/internal/vite-config/src/plugins/css-layer.ts
+++ b/internal/vite-config/src/plugins/css-layer.ts
@@ -12,10 +12,31 @@ function escapeRegExp(value: string): string {
 }
 
 /**
+ * 与 internal/tailwind-config/src/theme.css 中的层顺序保持一致：
+ * properties(Tailwind 的 --tw-* 回退变量层) < preflight(base) <
+ * UI 库组件样式(antd / el / td) < Tailwind 工具类。
+ * 该声明必须在打包后注入：生产构建下 css 按 chunk 注入，若组件库的 css
+ * chunk 先于含层顺序声明的 theme.css 加载，层名会先被注册为最低优先级，
+ * 导致 Tailwind base/utilities 覆盖组件样式。打包后在每个含组件库层的
+ * css 产物顶部补上该声明，无论 chunk 加载顺序如何，层优先级都正确
+ * （theme.css 先加载时该声明是幂等的 no-op）。
+ * 注意 properties 必须排在首位：它是 Tailwind 为不支持 @property 的旧
+ * 浏览器准备的 --tw-* 回退变量层，必须始终是最低优先级，否则其回退声明
+ * 会覆盖工具类写入的变量。
+ */
+const LAYER_ORDER_STATEMENT =
+  '@layer properties, theme, base, ant, antd, el, td, components, utilities;';
+
+/**
  * 把指定包内的 css 包进 @layer：
  * 组件库的 css 是无层样式，无层样式在级联中永远压过 @layer 内的 Tailwind 工具类；
  * 包层后由 theme.css 的层声明决定顺序（utilities 排在组件库层之后），
  * 使 Tailwind 工具类可以覆盖组件库样式。
+ *
+ * 注意：层顺序声明不能在 transform 阶段随包层 css 一起输出——rolldown-vite
+ * 的 css 合并会将「层顺序声明 + @layer 规则」形式的模块拆层（规则被脱层），
+ * 且产物压缩阶段也会丢弃该声明。因此改在 generateBundle 阶段对最终 css
+ * 产物统一注入（见 LAYER_ORDER_STATEMENT）。
  *
  * @example
  * ```ts
@@ -39,6 +60,29 @@ export function viteCssLayerPlugin(
       const matched = matchers.find((m) => m.regex.test(file));
       if (matched) {
         return { code: `@layer ${matched.layerName} {\n${code}\n}`, map: null };
+      }
+    },
+    generateBundle(_options, bundle) {
+      for (const file of Object.values(bundle)) {
+        if (file.type !== 'asset' || !file.fileName.endsWith('.css')) {
+          continue;
+        }
+        const css = file.source.toString();
+        const matched = matchers.some((m) =>
+          css.includes(`@layer ${m.layerName}`),
+        );
+        if (!matched) {
+          continue;
+        }
+        // 先去除可能的 BOM 再判断，避免重复注入层顺序声明
+        const hasStatement = css
+          .replace(/^\uFEFF/, '')
+          .trimStart()
+          .startsWith(LAYER_ORDER_STATEMENT);
+        if (hasStatement) {
+          continue;
+        }
+        file.source = `${LAYER_ORDER_STATEMENT}\n${css}`;
       }
     },
   };

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
@@ -16,18 +16,21 @@ vi.mock('@vben-core/preferences', () => ({
 
 let activeApp: App | undefined;
 
-async function mountModal() {
+async function mountModal(options: { onClosed?: () => void } = {}) {
   const mainContent = document.createElement('main');
   mainContent.id = ELEMENT_ID_MAIN_CONTENT;
   mainContent.innerHTML = '<div><div></div></div>';
   document.body.append(mainContent);
 
+  let capturedApi: ReturnType<typeof useVbenModal>[1] | undefined;
   const Consumer = defineComponent(() => {
     const [Modal, modalApi] = useVbenModal({
       appendToMain: true,
       draggable: true,
       title: 'Draggable modal',
+      ...(options.onClosed ? { onClosed: options.onClosed } : {}),
     });
+    capturedApi = modalApi;
     onMounted(() => {
       modalApi.open();
     });
@@ -41,7 +44,10 @@ async function mountModal() {
   await nextTick();
   await nextTick();
 
-  return mainContent;
+  if (!capturedApi) {
+    throw new Error('modal api was not captured');
+  }
+  return { mainContent, modalApi: capturedApi };
 }
 
 afterEach(() => {
@@ -53,7 +59,7 @@ afterEach(() => {
 
 describe('vben modal', () => {
   it('mounts an open modal directly in the main content', async () => {
-    const mainContent = await mountModal();
+    const { mainContent } = await mountModal();
     const dialog = document.querySelector('[role="dialog"]');
     const overlay = document.querySelector('[data-dismissable-modal]');
 
@@ -66,7 +72,7 @@ describe('vben modal', () => {
   });
 
   it('constrains dragging to the main content', async () => {
-    const mainContent = await mountModal();
+    const { mainContent } = await mountModal();
     const dialog = document.querySelector('[role="dialog"]');
     const header = document.querySelector('.cursor-move');
 
@@ -98,5 +104,55 @@ describe('vben modal', () => {
 
     expect(dialog.style.transform).toBe('translate(200px, 200px)');
     document.dispatchEvent(new MouseEvent('mouseup'));
+  });
+
+  it('fires onClosed via the fallback when no animation event arrives', async () => {
+    vi.useFakeTimers({
+      toFake: [
+        'cancelAnimationFrame',
+        'clearTimeout',
+        'requestAnimationFrame',
+        'setTimeout',
+      ],
+    });
+    try {
+      const onClosed = vi.fn();
+      const { modalApi } = await mountModal({ onClosed });
+      // happy-dom fires no animation events — without the fallback the
+      // `closed` event (and with it `onClosed`) would never fire and the
+      // close chain would hang. The fallback timer must acknowledge it.
+      await modalApi.close();
+      await vi.advanceTimersByTimeAsync(400);
+      expect(onClosed).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('emits closed exactly once when the animation event and the fallback both fire', async () => {
+    vi.useFakeTimers({
+      toFake: [
+        'cancelAnimationFrame',
+        'clearTimeout',
+        'requestAnimationFrame',
+        'setTimeout',
+      ],
+    });
+    try {
+      const onClosed = vi.fn();
+      const { modalApi } = await mountModal({ onClosed });
+      await modalApi.close();
+      // The exit animation ends normally — acknowledged immediately...
+      const dialog = document.querySelector('[role="dialog"]');
+      if (!(dialog instanceof HTMLElement)) {
+        throw new Error('dialog content not found');
+      }
+      dialog.dispatchEvent(new Event('animationend'));
+      // ...and the fallback must not emit a second `closed`.
+      await vi.advanceTimersByTimeAsync(400);
+      expect(onClosed).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/alert-dialog/AlertDialogContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/alert-dialog/AlertDialogContent.vue
@@ -14,6 +14,7 @@ import {
   useForwardPropsEmits,
 } from 'reka-ui';
 
+import { useDialogStateEvents } from '../dialog/use-dialog-state-events';
 import AlertDialogOverlay from './AlertDialogOverlay.vue';
 
 defineOptions({
@@ -48,16 +49,14 @@ const delegatedProps = reactiveOmit(props, 'class');
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 
 const contentRef = ref<InstanceType<typeof AlertDialogContent> | null>(null);
-function onAnimationEnd(event: AnimationEvent) {
-  // 只有在 contentRef 的动画结束时才触发 opened/closed 事件
-  if (event.target === contentRef.value?.$el) {
-    if (props.open) {
-      emits('opened');
-    } else {
-      emits('closed');
-    }
-  }
-}
+
+const { handleAnimationEvent } = useDialogStateEvents({
+  contentRef,
+  isOpen: () => props.open,
+  onClosed: () => emits('closed'),
+  onOpened: () => emits('opened'),
+});
+
 defineExpose({
   getContentRef: () => contentRef.value,
 });
@@ -78,7 +77,8 @@ defineExpose({
       data-slot="alert-dialog-content"
       ref="contentRef"
       :style="{ ...(zIndex ? { zIndex } : {}), position: 'fixed' }"
-      @animationend="onAnimationEnd"
+      @animationend="handleAnimationEvent"
+      @animationcancel="handleAnimationEvent"
       v-bind="{ ...$attrs, ...forwarded }"
       :class="
         cn(

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogContent.vue
@@ -18,6 +18,7 @@ import {
 } from 'reka-ui';
 
 import DialogOverlay from './DialogOverlay.vue';
+import { useDialogStateEvents } from './use-dialog-state-events';
 
 defineOptions({
   inheritAttrs: false,
@@ -81,16 +82,14 @@ const position = computed(() => {
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 
 const contentRef = ref<InstanceType<typeof DialogContent> | null>(null);
-function onAnimationEnd(event: AnimationEvent) {
-  // 只有在 contentRef 的动画结束时才触发 opened/closed 事件
-  if (event.target === contentRef.value?.$el) {
-    if (props.open) {
-      emits('opened');
-    } else {
-      emits('closed');
-    }
-  }
-}
+
+const { handleAnimationEvent } = useDialogStateEvents({
+  contentRef,
+  isOpen: () => props.open,
+  onClosed: () => emits('closed'),
+  onOpened: () => emits('opened'),
+});
+
 defineExpose({
   getContentRef: () => contentRef.value,
 });
@@ -111,7 +110,8 @@ defineExpose({
       ref="contentRef"
       :style="{ ...(zIndex ? { zIndex } : {}), position }"
       data-slot="dialog-content"
-      @animationend="onAnimationEnd"
+      @animationend="handleAnimationEvent"
+      @animationcancel="handleAnimationEvent"
       v-bind="forwarded"
       :class="
         cn(

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/use-dialog-state-events.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/dialog/use-dialog-state-events.ts
@@ -1,0 +1,84 @@
+import type { Ref } from 'vue';
+
+import { onScopeDispose, watch } from 'vue';
+
+/**
+ * 弹窗的 `closed`/`opened` 事件由内容元素自身的退出动画（`animationend`）确认。
+ * 当动画被跳过或取消（reduced motion、动画被中断、关闭过程中 class 变化）时，
+ * 事件永远不会触发——弹窗会一直保持可见，`hidden` class 不会被应用，
+ * destroy-on-close 重挂载和 `onClosed` 监听器会一直挂起。这里对齐 reka-ui
+ * Presence 的行为（`animationcancel` 视为结束），并在动画窗口结束后增加兜底
+ * 触发，保证关闭链路始终恰好完成一次。
+ */
+
+/** 本仓库弹窗的退出动画时长为 150ms；300ms 可以安全覆盖。 */
+const CLOSED_EVENT_FALLBACK_MS = 300;
+
+export function useDialogStateEvents(options: {
+  contentRef: Ref<null | { $el: Element | null }>;
+  isOpen: () => boolean;
+  onClosed: () => void;
+  onOpened: () => void;
+}) {
+  const { contentRef, isOpen, onClosed, onOpened } = options;
+
+  let closeFallbackTimer: null | ReturnType<typeof setTimeout> = null;
+  let closeAcknowledged = false;
+
+  function emitOpenStateChange() {
+    if (closeFallbackTimer !== null) {
+      clearTimeout(closeFallbackTimer);
+      closeFallbackTimer = null;
+    }
+    if (isOpen()) {
+      onOpened();
+      return;
+    }
+    // 关闭已由动画事件或兜底确认——同一关闭周期内 `closed` 只触发一次。
+    if (closeAcknowledged) {
+      return;
+    }
+    closeAcknowledged = true;
+    onClosed();
+  }
+
+  /**
+   * 同时监听内容元素的 `animationend` 和 `animationcancel` ——被取消的动画
+   * 同样视为结束（reka-ui 的 Presence 也是这么处理的），关闭链路不会一直等待。
+   */
+  function handleAnimationEvent(event: AnimationEvent) {
+    if (event.target === contentRef.value?.$el) {
+      emitOpenStateChange();
+    }
+  }
+
+  watch(isOpen, (open) => {
+    if (open) {
+      closeAcknowledged = false;
+      if (closeFallbackTimer !== null) {
+        clearTimeout(closeFallbackTimer);
+        closeFallbackTimer = null;
+      }
+      return;
+    }
+    // 启动兜底定时器：如果没有动画事件确认关闭（退出动画被跳过/取消），
+    // 则在动画窗口结束后触发 `closed`。
+    if (closeFallbackTimer === null) {
+      closeFallbackTimer = setTimeout(() => {
+        closeFallbackTimer = null;
+        if (!isOpen()) {
+          emitOpenStateChange();
+        }
+      }, CLOSED_EVENT_FALLBACK_MS);
+    }
+  });
+
+  onScopeDispose(() => {
+    if (closeFallbackTimer !== null) {
+      clearTimeout(closeFallbackTimer);
+      closeFallbackTimer = null;
+    }
+  });
+
+  return { handleAnimationEvent };
+}

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/sheet/SheetContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/sheet/SheetContent.vue
@@ -9,6 +9,7 @@ import { cn } from '@vben-core/shared/utils';
 
 import { DialogContent, useForwardPropsEmits } from 'reka-ui';
 
+import { useDialogStateEvents } from '../dialog/use-dialog-state-events';
 import { sheetVariants } from './sheet';
 import SheetOverlay from './SheetOverlay.vue';
 
@@ -60,16 +61,13 @@ const position = computed(() => {
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 const contentRef = ref<InstanceType<typeof DialogContent> | null>(null);
-function onAnimationEnd(event: AnimationEvent) {
-  // 只有在 contentRef 的动画结束时才触发 opened/closed 事件
-  if (event.target === contentRef.value?.$el) {
-    if (props.open) {
-      emits('opened');
-    } else {
-      emits('closed');
-    }
-  }
-}
+
+const { handleAnimationEvent } = useDialogStateEvents({
+  contentRef,
+  isOpen: () => props.open,
+  onClosed: () => emits('closed'),
+  onOpened: () => emits('opened'),
+});
 </script>
 
 <template>
@@ -92,7 +90,8 @@ function onAnimationEnd(event: AnimationEvent) {
         ...(zIndex ? { zIndex } : {}),
         position,
       }"
-      @animationend="onAnimationEnd"
+      @animationend="handleAnimationEvent"
+      @animationcancel="handleAnimationEvent"
       v-bind="{ ...forwarded, ...$attrs }"
     >
       <slot></slot>


### PR DESCRIPTION
## 背景（Background）

本仓库（vue-vben-admin）采用 `@vben-core/shadcn-ui` 自研的弹窗体系（modal / drawer / alert），其打开/关闭状态由内容元素自身的 CSS 退出动画事件驱动；同时生产构建使用 Tailwind CSS v4 的级联层（`@layer`）机制来协调「Tailwind 工具类」与「组件库（element-plus / tdesign）样式」之间的优先级关系。

我们在自己的业务项目中长期同步本仓库并大规模使用上述两条链路，分别发现了两个**仅在特定条件下触发、但一旦触发即为严重缺陷**的问题：

1. 弹窗在关闭动画被跳过/取消时永久卡死（`closed` 事件永不触发）；
2. 生产构建下 element-plus 组件样式整体丢失（`@layer` 注册顺序错误）。

两条缺陷均经过生产环境实机构建与回归验证，现将修复回馈上游。

---

## 缺陷一：弹窗关闭动画异常时 `closed` 事件丢失，弹窗卡死

### 问题描述

`DialogContent` / `AlertDialogContent` / `SheetContent` 三个组件中，`closed`/`opened` 事件**仅依赖内容元素自身的 `animationend` 事件**来确认关闭完成。当以下任一情况发生时，`animationend` 永远不会触发：

- 系统开启「减少动态效果」（reduced motion）导致动画被跳过；
- 关闭过程中元素 class 被修改、动画被中断（`animationcancel`）；
- 快速连续开关、路由切换等打断动画的场景。

**后果**：`closed` 事件永不发出 → `modal.vue` / `drawer.vue` / `alert.vue` 中的关闭处理永远不执行 → `hidden` class 永不应用 → **弹窗保持可见且无法关闭**，`destroy-on-close` 重挂载逻辑与 `onClosed` 监听器永久挂起。这是典型的「只在真机上偶现、开发环境难以复现」的缺陷。

### 根因分析

`closed` 事件的确认完全绑定在「动画完成」这一单一信号上，而 CSS 动画的完成并不总是可靠（动画可被取消、跳过、禁用）。reka-ui 自身的 `Presence` 组件早已处理了这一问题——它将 `animationcancel` 也视为动画结束。本项目由于 `forceMount` 的引入（弹窗内容常驻挂载，由自身管理显隐），绕过了 reka-ui 的 Presence，因此必须自行补全该语义。

### 解决方案

新增共享组合式函数 `useDialogStateEvents`（`packages/@core/ui-kit/shadcn-ui/src/ui/dialog/use-dialog-state-events.ts`），并统一应用到三个内容组件：

1. **同时监听 `animationend` 与 `animationcancel`** —— 与 reka-ui Presence 语义对齐，被取消的动画同样视为结束，关闭链路不会无限等待；
2. **300ms 兜底触发** —— 在关闭后动画窗口之外（本仓库退出动画固定 150ms，300ms 安全覆盖）兜底发出 `closed`，保证关闭链路**无论如何都能完成**；
3. **exactly-once 守卫** —— 动画事件与兜底定时器竞争触发时，同一关闭周期内 `closed` 只发出一次；
4. **`onScopeDispose` 清理** —— 组件销毁时清理定时器，无内存泄漏；
5. 顺带将三个组件中**三份完全重复**的 `onAnimationEnd` 实现收敛为一份共享逻辑（DRY）。

配套新增 popup-ui 端到端单测，覆盖「无动画事件时的兜底路径」与「动画事件与兜底同时触发时恰好一次」两条关键路径。

---

## 缺陷二：生产构建下组件库 CSS 层顺序错误，element-plus 样式整体丢失

### 问题描述

`viteCssLayerPlugin`（`internal/vite-config/src/plugins/css-layer.ts`）将组件库（element-plus / tdesign）的 CSS 包进 `@layer el` / `@layer td`，以允许 Tailwind 工具类覆盖组件样式。其正确性**依赖 `theme.css` 中 `@layer theme, base, ant, antd, el, td, components, utilities;` 这一顺序声明先于组件库 CSS 被注册**。

开发环境正常工作，但**生产构建（`pnpm build:ele`）下 element-plus 样式整体丢失**：按钮/输入框变扁平、边框消失、头部/TabBar 样式异常。经查生产 bundle，组件库 CSS chunk 与 theme CSS chunk 的加载顺序不稳定——当组件库 chunk 先于含顺序声明的 theme chunk 注入时，按 CSS 级联规范，层名在首次出现时即被注册，后续的顺序声明**只能追加新层名、无法调整已注册层的顺序**，于是 `el` 层成为最低优先级，Tailwind 的 `base`（preflight，如 `*{border-width:0}`）与 `utilities` 覆盖了所有 element-plus 规则。

### 根因分析

顺序声明与组件库规则分属两个 CSS 产物，加载顺序不受控制（`cssCodeSplit` 下按 chunk 注入）。这不是 CSS 写法问题，而是构建产物的天然不确定性——任何将声明「搬个位置」的尝试都不可靠。

### 方案探索与最终方案

| 方案 | 结果 |
| --- | --- |
| 直接在 `transform` 阶段把顺序声明前置输出到组件库 CSS | 失败：rolldown-vite 的 CSS 合并会剥离「顺序声明 + `@layer` 规则」模块的层（规则被脱层）；产物压缩阶段也会丢弃该声明 |
| 从 `vite.config.ts` 移除插件（让组件库 CSS 无层化） | 可行但不推荐：会回退上游引入的「工具类覆盖组件样式」能力，且 web-tdesign 仍带相同隐患 |

**最终方案**：在 `generateBundle` 阶段（合并 + 压缩**之后**）向所有包含组件库层（`@layer el` / `@layer td`）的最终 CSS 产物顶部注入完整顺序声明：

```css
@layer properties, theme, base, ant, antd, el, td, components, utilities;
- 声明位于产物顶部，无论 chunk 加载顺序如何，层优先级都正确（theme 先加载时该声明为幂等 no-op）；
- properties（Tailwind 为不支持 @property 的旧浏览器准备的 --tw-* 回退变量层）必须排在首位保持最低优先级，否则其回退声明会覆盖工具类写入的变量（如 translate-x-4）；theme.css 中的声明同步更新以保持一致；
- 插件签名与 transform 行为完全不变，仅新增兜底注入逻辑。
验证结果
- web-ele / web-tdesign 生产构建：所有含 el / td 层的 CSS 产物均以顺序声明开头（无缺失、无重复注入）；bootstrap / theme chunk 内部层块顺序与修复前完全一致（properties 仍为最低优先级）；
- 非插件应用（web-naive）字节级对比：修复前/后分别构建，203 个 CSS 产物逐字节一致（JS 产物除构建时间戳外一致），证明共享的 theme.css 变更对所有不使用插件的应用零影响；
- 产物哈希不受影响：注入发生在产物哈希计算之后，运行时 CSS 引用文件名不变，无缓存失效问题；
- CI 缓存：turbo.json 已声明 internal/vite-config/src/**/*.ts 为 globalDependencies，插件改动会正确失效所有应用构建缓存。
回归风险评估（Regression Risk）
缺陷一（弹窗）：
- 全仓库扫描确认仅此 3 个组件存在该模式，修复覆盖完整（DialogScrollContent 使用 reka-ui 原生 Presence，本身不受影响）；
- 行为变更方向为「closed 保证在 300ms 内发出」，对现有消费者（modal / drawer / alert 均已在处理 closed）为纯增强；
- 快速开关窗、组件销毁等边界场景均有守卫与清理逻辑。
缺陷二（CSS 层）：
- 插件仅在 web-ele、web-tdesign 两个应用注册，其余应用（web-antd / web-naive / web-antdv-next / playground）构建时根本不加载该钩子；
- 唯一共享改动 theme.css 已通过字节级对比证明对非插件应用零产物差异；
- 对已正确加载的应用（demo 场景）为幂等 no-op，无视觉变化。
已知限制（Known Limitations）
- 300ms 兜底时间为硬编码（本仓库退出动画固定 150ms）；如外部使用者自定义了超过 300ms 的退出动画，closed 会提前发出，属可接受的权衡；
- opened 事件暂无对称兜底（本次修复聚焦关闭链路）；打开动画被取消时 opened 仍可能不触发；
- destroyOnClose 模式下（forceMount=false）reka-ui 自身的 closed 与组件自定义事件可能双发，此为修复前已存在的行为，本次未改变。
测试（Tests）
- 新增 packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts 两条单测（兜底路径 + exactly-once）—— 全部通过；
- 新增 internal/vite-config/src/plugins/css-layer.test.ts 六条单测（transform 包裹回归、注入、去重、BOM、非 CSS / 非匹配跳过）—— 全部通过；
- 全仓 pnpm check:type、oxlint、oxfmt、eslint、stylelint 全部通过；
- web-ele / web-tdesign / web-naive 生产构建全部成功并通过产物校验。
改动文件（Files Changed）
Commit 1 — fix(@vben-core/shadcn-ui)：
- packages/@core/ui-kit/shadcn-ui/src/ui/dialog/use-dialog-state-events.ts（新增）
- packages/@core/ui-kit/shadcn-ui/src/ui/dialog/DialogContent.vue
- packages/@core/ui-kit/shadcn-ui/src/ui/alert-dialog/AlertDialogContent.vue
- packages/@core/ui-kit/shadcn-ui/src/ui/sheet/SheetContent.vue
- packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
Commit 2 — fix(@vben/vite-config)：
- internal/vite-config/src/plugins/css-layer.ts
- internal/vite-config/src/plugins/css-layer.test.ts（新增）
- internal/tailwind-config/src/theme.css

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal, dialog, alert dialog, and sheet lifecycle events to reliably report when components open and close.
  * Added fallback handling when animations are interrupted or do not complete, preventing missed or duplicate close events.
  * Improved CSS layer ordering and bundle output to ensure component styles override fallback variables consistently.
* **Tests**
  * Expanded coverage for dialog close behavior and CSS layer handling across supported asset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->