### PR TITLE
修复：页脚遮挡页面内容 + echarts 按需注册缺少 GraphicComponent

### DIFF
--- a/.changeset/quick-planes-register-graphic.md
+++ b/.changeset/quick-planes-register-graphic.md
@@ -1,0 +1,5 @@
+---
+'@vben/plugins': patch
+---
+
+fix(@vben/plugins): register echarts GraphicComponent for empty-state text

--- a/.changeset/tall-otters-fix-footer.md
+++ b/.changeset/tall-otters-fix-footer.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/layout-ui': patch
+---
+
+fix(@vben-core/layout-ui): keep in-flow footer below page content

--- a/packages/@core/ui-kit/layout-ui/src/components/layout-content.vue
+++ b/packages/@core/ui-kit/layout-ui/src/components/layout-content.vue
@@ -45,7 +45,6 @@ const style = computed((): CSSProperties => {
   return {
     ...compactStyle,
     flex: 1,
-    minHeight: 0,
     minWidth: 0,
     padding: `${padding}px`,
     paddingBottom: `${paddingBottom}px`,
@@ -57,7 +56,7 @@ const style = computed((): CSSProperties => {
 </script>
 
 <template>
-  <main :style="style" class="relative min-h-0 min-w-0">
+  <main :style="style" class="relative min-w-0">
     <div
       v-if="$slots.overlay"
       data-layout-region="content-overlay"

--- a/packages/effects/plugins/src/echarts/echarts.ts
+++ b/packages/effects/plugins/src/echarts/echarts.ts
@@ -1,6 +1,7 @@
 import { BarChart, LineChart, PieChart, RadarChart } from 'echarts/charts';
 import {
   DatasetComponent,
+  GraphicComponent,
   GridComponent,
   LegendComponent,
   TitleComponent,
@@ -32,6 +33,7 @@ echarts.use([
   CanvasRenderer,
   LegendComponent,
   ToolboxComponent,
+  GraphicComponent,
 ]);
 export type { ECOption } from './types';
 


### PR DESCRIPTION
# 修复：页脚遮挡页面内容 + echarts 按需注册缺少 GraphicComponent

## 概述

本 PR 包含两个独立的上游缺陷修复（均为 `packages` 层修复，不影响业务代码）：

1. **布局页脚（Copyright）在页面变高后停留在原位并遮挡页面内容**
2. **echarts 按需注册缺少 `GraphicComponent`，导致图表空态（"暂无数据"）无法绘制**

---

## 修复一：非固定页脚应始终位于页面内容之后

### 问题描述

在 Preferences 中开启 Footer（Copyright）后，对于内容超过一屏的页面（例如数据加载后变高的报表页），Copyright 页脚停留在**首屏底部**，不会随内容高度变化移动到新位置，其不透明背景会**遮挡当前页面的元素**。

复现步骤：

1. Preferences 中开启 Footer 显示 Copyright；
2. 打开一个数据加载后高度超过一屏的页面（如报表页）；
3. Copyright 停留在首个视口底部，覆盖页面内容；滚动时页脚位于内容中间。

### 根因

布局滚动区域（`#__vben_layout_scroll`）是 flex 列容器，子元素依次为内容区（`LayoutContent`）与页脚（`LayoutFooter`，非固定模式下为 `position: static`）：

```html
<div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
  <LayoutContent>…页面内容…</LayoutContent>
  <LayoutFooter>Copyright</LayoutFooter>
</div>
```

提交 `89c05f82`（`refactor(@vben-core/layout-ui): move layout sizing and scrolling to CSS`）为内容元素新增了 `min-height: 0`（style 与 `min-h-0` class）。

作为 flex item，内容元素默认的 `min-height: auto` 保证其高度**不小于内容高度**，页脚因此始终排在全部内容之后；`min-height: 0` 允许内容盒子被压缩到视口高度，内容溢出盒子，页脚便停留在盒子底部（= 首屏底部），并罩住溢出内容。此为默认配置 `footer.fixed: false` 下的回归；固定页脚模式下，同样的 clamp 也会导致页面末尾内容被固定页脚永久遮挡（`padding-bottom` 补偿失效）。

### 修复

移除内容元素的 `min-height: 0` clamp（`layout-content.vue` 中的 `minHeight: 0` 与 `min-h-0` class），恢复内容盒子随内容增长的行为。滚动容器自身的视口 clamp 保持不变，内部滚动与固定 Header/Overlay 逻辑不受影响。

涉及文件：

- `packages/@core/ui-kit/layout-ui/src/components/layout-content.vue`

### 验证

**真实应用 A/B（playground + headless Chromium，1440x900）**：登录后开启 Footer/Copyright，在路由容器内追加 8 个 250px 数据块模拟数据加载后页面变高，统计滚动区域中被页脚遮挡的元素数量：

| 状态 | 页脚位置（视口坐标，scrollTop=0） | 被遮挡元素数 |
| --- | --- | --- |
| 修复前（min-height: 0） | top: 868, bottom: 900（首屏底部，原位置） | **94** |
| 修复后 | top: 3708, bottom: 3740（全部内容之后） | **0** |

修复后滚动到底部时，页脚恰好落在视口底部、最后一行内容之下，任何滚动位置都不会遮挡内容。

**隔离 DOM 复现**（4 组数据：静态/固定页脚 × 修复前/后）验证结论一致，详见 PR 附带的复现脚本。

---

## 修复二：echarts 按需注册补充 `GraphicComponent`

### 问题描述

`packages/effects/plugins/src/echarts/echarts.ts` 中 echarts 按需注册（`echarts.use([...])`）缺少 `GraphicComponent`，而图表空态普遍使用 `graphic` 配置绘制"暂无数据"文案。未注册时控制台报错：

```
[ECharts] Component graphic is used but not imported.
import { GraphicComponent } from 'echarts/components';
echarts.use([GraphicComponent]);
```

空态图表因此**连"暂无数据"都不绘制，显示为纯空白**。

### 根因

按需注册列表遗漏了 `GraphicComponent`（`echarts/components` 导出，echarts 6.x 核心组件）。

### 修复

在导入与 `echarts.use([...])` 注册列表中补充 `GraphicComponent`。

涉及文件：

- `packages/effects/plugins/src/echarts/echarts.ts`

### 验证

**Node SSR（echarts 6.1.0，svg renderer）**直接以空态 `graphic` 配置渲染：

| 状态 | graphic 相关报错 | "暂无数据"是否绘制 |
| --- | --- | --- |
| 修复前（未注册） | `Component graphic is used but not imported` | 否（空白） |
| 修复后（已注册） | 无 | 是 |

---

## Changeset

- `@vben-core/layout-ui` — patch
- `@vben/plugins` — patch

## 备注

- 全仓 `pnpm check:type` 仅 playground 的 vue-query demo（`concurrency-caching.vue`）存在**预先存在**的类型错误（依赖版本不匹配，与本次改动无关）。
- 本分支源自上游 main（`c5c8eb25`），未包含其他业务改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty-state text rendering in ECharts visualizations.
  * Improved footer positioning so it remains correctly aligned within the page layout.
  * Corrected content sizing behavior to prevent layout constraints from affecting in-flow content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->