### PR TITLE
fix(form): 修正表单组件modelPropName优先级：组件定义处挂载的协议 > setup 配置的 modelPropNameMap > 全局默认协议

### DIFF
--- a/packages/@core/ui-kit/form-ui/__tests__/config.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/config.test.ts
@@ -1,8 +1,8 @@
 import type { BaseFormComponentType } from '../src/types';
 
-import { afterEach, describe, expect, it } from 'vitest';
-
 import { globalShareState } from '@vben-core/shared/global-state';
+
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { COMPONENT_BIND_EVENT_MAP, setupVbenForm } from '../src/config';
 

--- a/packages/@core/ui-kit/form-ui/__tests__/config.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/config.test.ts
@@ -1,0 +1,74 @@
+import type { BaseFormComponentType } from '../src/types';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { globalShareState } from '@vben-core/shared/global-state';
+
+import { COMPONENT_BIND_EVENT_MAP, setupVbenForm } from '../src/config';
+
+/** 模拟注册两个未挂载协议的组件，用于验证绑定协议的重建 */
+function registerTestComponents() {
+  globalShareState.setComponents({
+    MyCheckbox: {},
+    MyInput: {},
+  });
+}
+
+/** 清空绑定协议映射，恢复初始状态 */
+function resetBindEventMap() {
+  for (const key of Object.keys(COMPONENT_BIND_EVENT_MAP)) {
+    Reflect.deleteProperty(
+      COMPONENT_BIND_EVENT_MAP,
+      key as BaseFormComponentType,
+    );
+  }
+}
+
+afterEach(() => {
+  // 清理全局单例与映射，避免影响同文件其他用例
+  globalShareState.setComponents({});
+  resetBindEventMap();
+});
+
+describe('setup 绑定协议重建', () => {
+  it('重复 setup 后清理上一次遗留的旧绑定协议', () => {
+    registerTestComponents();
+
+    // 第一次 setup：自定义协议，两个组件分别命中映射与兜底
+    setupVbenForm({
+      config: {
+        baseModelPropName: 'value',
+        modelPropNameMap: { MyCheckbox: 'checked' },
+      },
+    });
+    expect(COMPONENT_BIND_EVENT_MAP.MyCheckbox).toBe('checked');
+    expect(COMPONENT_BIND_EVENT_MAP.MyInput).toBe('value');
+
+    // 第二次 setup：默认协议（组件均未挂载协议），旧条目应被清理，回退默认 modelValue
+    setupVbenForm({
+      config: {
+        baseModelPropName: 'modelValue',
+        modelPropNameMap: {},
+      },
+    });
+    expect(COMPONENT_BIND_EVENT_MAP.MyCheckbox).toBeUndefined();
+    expect(COMPONENT_BIND_EVENT_MAP.MyInput).toBeUndefined();
+  });
+
+  it('重复 setup 时组件定义处挂载的协议始终优先', () => {
+    globalShareState.setComponents({
+      MyCheckbox: { modelPropName: 'checked' },
+      MyInput: {},
+    });
+
+    // 第一次 setup：自定义兜底协议
+    setupVbenForm({ config: { baseModelPropName: 'value' } });
+    expect(COMPONENT_BIND_EVENT_MAP.MyCheckbox).toBe('checked');
+    expect(COMPONENT_BIND_EVENT_MAP.MyInput).toBe('value');
+
+    // 第二次 setup：默认兜底协议，组件定义处挂载的协议不受影响，未挂载的组件回退默认
+    setupVbenForm({ config: { baseModelPropName: 'modelValue' } });
+    expect(COMPONENT_BIND_EVENT_MAP.MyCheckbox).toBe('checked');
+    expect(COMPONENT_BIND_EVENT_MAP.MyInput).toBeUndefined();
+  });
+});

--- a/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
@@ -287,7 +287,7 @@ describe('useVbenForm integration', () => {
     let latestSlotProps:
       | undefined
       | VbenFormFieldSlotProps<SlotFormValues, 'name'>;
-    const [Form, formApi] = useVbenForm<SlotFormValues>({
+    const [Form] = useVbenForm<SlotFormValues>({
       schema: [
         {
           component: TestInput,

--- a/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
@@ -269,9 +269,51 @@ describe('useVbenForm integration', () => {
     );
     expect(latestSlotProps.componentProps).not.toHaveProperty('formApi');
     expect(latestSlotProps.componentProps).not.toHaveProperty('values');
-    expect(latestSlotProps).not.toHaveProperty('onUpdate:modelValue');
+    // 自定义插槽 scope 顶层同样暴露写方向监听器，保证直接 v-bind 即可完成双向绑定
+    expect(latestSlotProps).toHaveProperty('onUpdate:modelValue');
 
     await wrapper.get('.slot-component').setValue('Grace');
+    await flushPromises();
+
+    expect(latestSlotProps.modelValue).toBe('Grace');
+    expect(latestSlotProps.values.name).toBe('Grace');
+  });
+
+  it('custom slot v-bind supports two-way modelValue binding', async () => {
+    interface SlotFormValues {
+      name: string;
+    }
+
+    let latestSlotProps:
+      | undefined
+      | VbenFormFieldSlotProps<SlotFormValues, 'name'>;
+    const [Form, formApi] = useVbenForm<SlotFormValues>({
+      schema: [
+        {
+          component: TestInput,
+          defaultValue: 'Ada',
+          fieldName: 'name',
+        },
+      ],
+    });
+    const wrapper = mount(Form, {
+      slots: {
+        // 模拟业务方直接 v-bind="slotProps" 的用法：顶层 modelValue + onUpdate:modelValue 需构成完整双向绑定
+        name(slotProps: VbenFormFieldSlotProps<SlotFormValues, 'name'>) {
+          latestSlotProps = slotProps;
+          return h(TestInput, slotProps);
+        },
+      },
+    });
+    wrappers.push(wrapper);
+    await flushPromises();
+
+    expect(latestSlotProps).toBeDefined();
+    if (!latestSlotProps) return;
+    expect(latestSlotProps.modelValue).toBe('Ada');
+    expect(latestSlotProps.values.name).toBe('Ada');
+
+    await wrapper.get('input').setValue('Grace');
     await flushPromises();
 
     expect(latestSlotProps.modelValue).toBe('Grace');

--- a/packages/@core/ui-kit/form-ui/src/config.ts
+++ b/packages/@core/ui-kit/form-ui/src/config.ts
@@ -77,15 +77,20 @@ export function setupVbenForm<
 
   for (const component of Object.keys(components)) {
     const key = component as BaseFormComponentType;
-    COMPONENT_MAP[key] = components[component as never];
+    const registeredComponent = components[component as never];
+    COMPONENT_MAP[key] = registeredComponent;
 
-    if (baseModelPropName !== DEFAULT_MODEL_PROP_NAME) {
-      COMPONENT_BIND_EVENT_MAP[key] = baseModelPropName;
-    }
+    // 优先级：组件定义处挂载的协议 > setup 配置的 modelPropNameMap > 全局默认协议
+    const componentModelPropName = (
+      registeredComponent as undefined | { modelPropName?: string }
+    )?.modelPropName;
 
-    // 覆盖特殊组件的modelPropName
-    if (modelPropNameMap && modelPropNameMap[key]) {
+    if (componentModelPropName) {
+      COMPONENT_BIND_EVENT_MAP[key] = componentModelPropName;
+    } else if (modelPropNameMap && modelPropNameMap[key]) {
       COMPONENT_BIND_EVENT_MAP[key] = modelPropNameMap[key];
+    } else if (baseModelPropName !== DEFAULT_MODEL_PROP_NAME) {
+      COMPONENT_BIND_EVENT_MAP[key] = baseModelPropName;
     }
   }
 }

--- a/packages/@core/ui-kit/form-ui/src/config.ts
+++ b/packages/@core/ui-kit/form-ui/src/config.ts
@@ -89,7 +89,10 @@ export function setupVbenForm<
       COMPONENT_BIND_EVENT_MAP[key] = componentModelPropName;
     } else if (modelPropNameMap && modelPropNameMap[key]) {
       COMPONENT_BIND_EVENT_MAP[key] = modelPropNameMap[key];
-    } else if (baseModelPropName !== DEFAULT_MODEL_PROP_NAME) {
+    } else if (baseModelPropName === DEFAULT_MODEL_PROP_NAME) {
+      // 当前配置未声明该组件的绑定协议（回退默认 modelValue）→ 删除上次 setup 遗留的旧条目，避免跨 setup 复用错误协议
+      Reflect.deleteProperty(COMPONENT_BIND_EVENT_MAP, key);
+    } else {
       COMPONENT_BIND_EVENT_MAP[key] = baseModelPropName;
     }
   }

--- a/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
+++ b/packages/@core/ui-kit/form-ui/src/form-render/form-field.vue
@@ -382,13 +382,17 @@ function createComponentProps(slotProps: RuntimeFieldSlotProps) {
 }
 
 function createFieldSlotScope(slotProps: RuntimeFieldSlotProps) {
+  const normalized = createFieldSlotProps(slotProps);
   return {
-    ...createFieldSlotProps(slotProps),
+    ...normalized,
     componentProps: createComponentProps(slotProps),
     disabled: shouldDisabled.value,
     isInValid: isInValid.value,
     modelValue: fieldValue.value,
     name: fieldName,
+    // 顶层固定暴露标准 v-model 写方向监听器：自定义插槽直接 v-bind 即可完成双向绑定。
+    // 非标准协议（value/checked 等）由 componentProps 按解析出的协议转换，顶层不重复做协议切换。
+    'onUpdate:modelValue': normalized.componentField['onUpdate:modelValue'],
   };
 }
 

--- a/packages/@core/ui-kit/form-ui/src/types.ts
+++ b/packages/@core/ui-kit/form-ui/src/types.ts
@@ -258,6 +258,8 @@ export interface VbenFormFieldSlotProps<
   isInValid: boolean;
   modelValue: FormFieldValue<TValues, TFieldName>;
   name: TFieldName;
+  /** 顶层写方向监听器：自定义插槽直接 v-bind 即可完成双向绑定 */
+  'onUpdate:modelValue'?: (value: FormFieldValue<TValues, TFieldName>) => void;
 }
 
 export type VbenFormResolvedComponentProps<


### PR DESCRIPTION
fix(form): 修正表单组件modelPropName优先级：组件定义处挂载的协议 > setup 配置的 modelPropNameMap > 默认协议baseModelPropName

原因：自定义组件或者markRaw的一次性组件，不可能跑到modelPropNameMap中来做配置，另外如果全部由modelPropNameMap管理，新加组件容易遗漏，更应该的方式应该是在加组件时，就显示指定好modelPropName

问题点：历史版本同步新版本时，一大半都死在这个点上，迁移完突然发现自定义组件等突然都无法通过表单赋值了...... 

话题延伸：modelValue才应该是vue3的主流， baseModelPropName 应该给到modelValue ； ant-vue等的就应该在表单定义组件时就配置好modelPropName：value；

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form data binding for registered components by honoring each component’s preferred model property and event.
  * Ensured component-specific binding settings take priority over broader configuration defaults.
  * Prevented outdated binding settings from persisting when form setup is repeated.
  * Enabled custom field slots to support direct two-way `modelValue` binding through `v-bind`.
  * Improved reactive form value updates when using custom slot properties and field components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->