### PR TITLE
test(@vben-core/popup-ui): add alert dialog mouse and keyboard regression tests

### DIFF
--- a/packages/@core/ui-kit/popup-ui/src/alert/__tests__/alert.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/alert/__tests__/alert.test.ts
@@ -25,6 +25,9 @@ vi.mock('@vben-core/preferences', () => ({
 
 let activeApp: App | undefined;
 
+/**
+ * 挂载一个受控的 Alert 组件，用于验证鼠标点击与键盘交互后的关闭行为和事件副作用。
+ */
 async function mountAlert() {
   const state = ref(true);
   const onConfirm = vi.fn();

--- a/packages/@core/ui-kit/popup-ui/src/alert/__tests__/alert.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/alert/__tests__/alert.test.ts
@@ -1,0 +1,109 @@
+import type { App } from 'vue';
+
+import { computed, createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Alert from '../alert.vue';
+
+vi.mock('@vben-core/composables', () => ({
+  useScrollLock: () =>
+    computed({
+      get: () => false,
+      set: () => {},
+    }),
+  useSimpleLocale: () => ({
+    $t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@vben-core/preferences', () => ({
+  usePreferences: () => ({
+    globalEscapeShortcutKey: { value: true },
+  }),
+}));
+
+let activeApp: App | undefined;
+
+async function mountAlert() {
+  const state = ref(true);
+  const onConfirm = vi.fn();
+  const onUpdateOpen = vi.fn((value: boolean) => {
+    state.value = value;
+  });
+  const Consumer = defineComponent(
+    () => () =>
+      h(Alert, {
+        content: 'Alert content',
+        title: 'Alert title',
+        confirmText: 'Confirm',
+        cancelText: 'Cancel',
+        open: state.value,
+        showCancel: true,
+        onConfirm,
+        'onUpdate:open': onUpdateOpen,
+      }),
+  );
+  const host = document.createElement('div');
+  document.body.append(host);
+  activeApp = createApp(Consumer);
+  activeApp.mount(host);
+  await nextTick();
+  await nextTick();
+
+  return { onConfirm, onUpdateOpen, state };
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('vben alert', () => {
+  it('closes and emits confirm once when the confirm button is clicked', async () => {
+    const { onConfirm, onUpdateOpen, state } = await mountAlert();
+    const button = [...document.querySelectorAll('button')].find(
+      (element) => element.textContent?.trim() === 'Confirm',
+    );
+
+    expect(button).toBeInstanceOf(HTMLElement);
+    if (!(button instanceof HTMLElement)) return;
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextTick();
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onUpdateOpen).toHaveBeenCalledWith(false);
+    expect(state.value).toBe(false);
+  });
+
+  it('closes without confirming when the cancel button is clicked', async () => {
+    const { onConfirm, onUpdateOpen, state } = await mountAlert();
+    const button = [...document.querySelectorAll('button')].find(
+      (element) => element.textContent?.trim() === 'Cancel',
+    );
+
+    expect(button).toBeInstanceOf(HTMLElement);
+    if (!(button instanceof HTMLElement)) return;
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextTick();
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onUpdateOpen).toHaveBeenCalledWith(false);
+    expect(state.value).toBe(false);
+  });
+
+  it('closes when Escape is pressed', async () => {
+    const { onConfirm, onUpdateOpen, state } = await mountAlert();
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }),
+    );
+    await nextTick();
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onUpdateOpen).toHaveBeenCalledWith(false);
+    expect(state.value).toBe(false);
+  });
+});


### PR DESCRIPTION
## 变更说明

为 `@vben-core/popup-ui` 的 `Alert`（基于 `AlertDialog`）新增组件级回归测试，覆盖 3 条用户交互路径：

1. **鼠标确认**：点击 Confirm 按钮触发 `confirm` 事件一次，并关闭对话框。
2. **鼠标取消**：点击 Cancel 按钮不触发 `confirm`，但关闭对话框。
3. **键盘关闭**：按下 `Escape` 关闭对话框，且不触发 `confirm`。

鼠标路径使用 `MouseEvent('click', { bubbles: true })` 显式派发，避免依赖 `HTMLElement.click()` 的默认行为。

## 验证

- 聚焦测试：`pnpm exec vitest run --dom packages/@core/ui-kit/popup-ui/src/alert/__tests__/alert.test.ts` → 1 文件 / 3 测试全部通过
- `pnpm run lint` → 通过（0 warnings / 0 errors）
- `pnpm run check:type` → 通过
- `check:circular` / `check:dep`：仅有既有警告（shadcn-ui、plugins、vite-config 等存量文件，非本变更引入）
- `cspell`：0 issues
- 提交时 lefthook（oxlint、oxfmt、eslint、checkType、commitlint）全部通过

## 范围

仅新增 1 个测试文件 `packages/@core/ui-kit/popup-ui/src/alert/__tests__/alert.test.ts`，未修改任何生产代码与锁文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for alert interactions, including Confirm, Cancel, and Escape actions.
  * Verified that confirming triggers the expected confirmation event and closes the alert.
  * Verified that canceling or pressing Escape closes the alert without confirming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->