### PR TITLE
fix(@vben-core/layout-ui): preserve content sizing across footer modes

### DIFF
--- a/packages/@core/ui-kit/layout-ui/src/components/layout-footer.vue
+++ b/packages/@core/ui-kit/layout-ui/src/components/layout-footer.vue
@@ -38,6 +38,7 @@ const style = computed((): CSSProperties => {
 <template>
   <footer
     :style="style"
+    data-layout-region="footer"
     class="bottom-0 w-full shrink-0 bg-background-deep transition-all duration-200"
   >
     <slot></slot>

--- a/packages/@core/ui-kit/layout-ui/src/vben-layout.vue
+++ b/packages/@core/ui-kit/layout-ui/src/vben-layout.vue
@@ -373,6 +373,7 @@ const layoutScrollStyle = computed((): CSSProperties => {
 const contentStyle = computed((): CSSProperties => {
   const { footerEnable, footerFixed, footerHeight } = props;
   return {
+    minHeight: footerEnable && !footerFixed ? undefined : 0,
     paddingBottom: `${footerEnable && footerFixed ? footerHeight : 0}px`,
   };
 });

--- a/playground/__tests__/e2e/common/layout.ts
+++ b/playground/__tests__/e2e/common/layout.ts
@@ -89,6 +89,7 @@ async function updateLayoutPreferences(page: Page, updates: PreferenceUpdates) {
 async function getLayoutMetrics(page: Page): Promise<LayoutMetrics> {
   return page.evaluate(() => {
     const selectors = {
+      footer: '[data-layout-region="footer"]',
       header: '[data-layout-region="header"]',
       layout: '[data-layout-region="layout"]',
       main: '[data-layout-region="main"]',

--- a/playground/__tests__/e2e/layout-system.spec.ts
+++ b/playground/__tests__/e2e/layout-system.spec.ts
@@ -47,7 +47,7 @@ async function configureDesktopRolePage(page: Page) {
   await page.setViewportSize({ height: 900, width: 1440 });
   await updateLayoutPreferences(page, {
     app: { layout: 'sidebar-nav' },
-    footer: { enable: false },
+    footer: { enable: false, fixed: false },
     header: { enable: true, hidden: false, mode: 'fixed' },
     sidebar: {
       collapsed: false,
@@ -58,6 +58,14 @@ async function configureDesktopRolePage(page: Page) {
     tabbar: { enable: true },
     widget: { sidebarToggle: true },
   });
+}
+
+async function navigateToLayoutPage(page: Page, path: string) {
+  await page.goto(path);
+  await page
+    .locator('[data-layout-region="layout"]')
+    .waitFor({ state: 'visible' });
+  await page.waitForFunction(() => Boolean(window.__VBEN_LAYOUT_TEST__));
 }
 
 async function getSidebarTransitionDuration(
@@ -144,6 +152,203 @@ test('keeps the layout background continuous while content scrolls', async ({
   expect(result.mainBackground).toBe('rgba(0, 0, 0, 0)');
   expect(result.mainBottomAtScrollEnd).toBeLessThanOrEqual(1);
   expect(result.scrollBottom).toBeGreaterThan(0);
+});
+
+test('preserves content sizing across footer modes in short viewports', async ({
+  layoutPage,
+}) => {
+  await configureDesktopRolePage(layoutPage);
+  await layoutPage.setViewportSize({ height: 600, width: 1365 });
+  await waitForLayoutSettled(layoutPage);
+
+  try {
+    for (const mode of [
+      { enable: false, fixed: false, name: 'disabled' },
+      { enable: true, fixed: true, name: 'fixed' },
+      { enable: true, fixed: false, name: 'non-fixed' },
+    ] as const) {
+      await test.step(mode.name, async () => {
+        if (mode.name === 'non-fixed') {
+          await navigateToLayoutPage(layoutPage, '/dashboard/analytics');
+          await layoutPage
+            .locator('#__vben_main_content .page-route-container > *')
+            .waitFor({ state: 'visible' });
+        }
+        await updateLayoutPreferences(layoutPage, {
+          footer: { enable: mode.enable, fixed: mode.fixed },
+        });
+
+        const metrics = await getLayoutMetrics(layoutPage);
+        const sizing = await layoutPage.evaluate(() => {
+          const footer = document.querySelector(
+            '[data-layout-region="footer"]',
+          );
+          const main = document.querySelector('#__vben_main_content');
+          const pageContent = document.querySelector(
+            '[data-layout-region="page-content"]',
+          );
+          const scroll = document.querySelector('#__vben_layout_scroll');
+          const routeContainer = document.querySelector(
+            '#__vben_main_content .page-route-container',
+          );
+          const routeContent = routeContainer?.firstElementChild;
+          if (
+            !(main instanceof HTMLElement) ||
+            !(scroll instanceof HTMLElement)
+          ) {
+            throw new Error('Layout content regions are missing');
+          }
+
+          const footerRect = footer?.getBoundingClientRect();
+          return {
+            footerPosition:
+              footer instanceof HTMLElement
+                ? getComputedStyle(footer).position
+                : undefined,
+            footerTop: footerRect?.top,
+            layoutClientHeight: scroll.clientHeight,
+            layoutScrollHeight: scroll.scrollHeight,
+            mainMinHeight: getComputedStyle(main).minHeight,
+            mainPaddingBottom: getComputedStyle(main).paddingBottom,
+            pageContentBottom:
+              pageContent instanceof HTMLElement
+                ? pageContent.getBoundingClientRect().bottom
+                : 0,
+            routeContentBottom: routeContent?.getBoundingClientRect().bottom,
+          };
+        });
+
+        expectNoViewportOverflow(metrics);
+        expect(sizing.mainMinHeight).toBe(
+          mode.name === 'non-fixed' ? 'auto' : '0px',
+        );
+        expect(Number.parseFloat(sizing.mainPaddingBottom)).toBe(
+          mode.name === 'fixed' ? requireRegion(metrics, 'footer').height : 0,
+        );
+
+        if (mode.name === 'disabled') {
+          expect(metrics.regions.footer).toBeNull();
+          expect(sizing.layoutScrollHeight).toBeLessThanOrEqual(
+            sizing.layoutClientHeight + 1,
+          );
+        } else if (mode.name === 'fixed') {
+          const footer = requireRegion(metrics, 'footer');
+          expect(sizing.footerPosition).toBe('fixed');
+          expect(Math.abs(footer.bottom - 600)).toBeLessThanOrEqual(1);
+          expect(sizing.pageContentBottom).toBeLessThanOrEqual(footer.top + 1);
+          expect(sizing.layoutScrollHeight).toBeLessThanOrEqual(
+            sizing.layoutClientHeight + 1,
+          );
+        } else {
+          expect(sizing.footerPosition).toBe('static');
+          expect(sizing.layoutScrollHeight).toBeGreaterThan(
+            sizing.layoutClientHeight,
+          );
+          expect(sizing.footerTop).toBeGreaterThanOrEqual(
+            (sizing.routeContentBottom ?? 0) - 1,
+          );
+        }
+
+        await layoutPage.evaluate(() => {
+          document.querySelector('#__vben_layout_scroll')?.scrollTo({ top: 0 });
+        });
+      });
+    }
+  } finally {
+    await updateLayoutPreferences(layoutPage, {
+      footer: { enable: false, fixed: false },
+    });
+    await layoutPage.setViewportSize({ height: 900, width: 1440 });
+    await navigateToLayoutPage(layoutPage, '/system/role');
+  }
+});
+
+test('keeps appendToMain drawers within the available content height', async ({
+  layoutPage,
+}) => {
+  await configureDesktopRolePage(layoutPage);
+  await layoutPage.setViewportSize({ height: 600, width: 1365 });
+  await navigateToLayoutPage(layoutPage, '/examples/drawer');
+
+  try {
+    const card = layoutPage
+      .getByText('在内容区域打开', { exact: true })
+      .locator('xpath=ancestor::*[.//button][1]');
+    await card
+      .getByRole('button', { exact: true, name: '右侧打开' })
+      .dispatchEvent('click');
+
+    const main = layoutPage.locator('#__vben_main_content');
+    const drawer = main.getByRole('dialog');
+    await expect(drawer).toBeVisible();
+    await drawer.evaluate((element) => {
+      for (const animation of element.getAnimations({ subtree: true })) {
+        if (Number.isFinite(animation.effect?.getComputedTiming().endTime)) {
+          animation.finish();
+        }
+      }
+    });
+    await waitForLayoutSettled(layoutPage);
+
+    const metrics = await getLayoutMetrics(layoutPage);
+    const geometry = await drawer.evaluate((element) => {
+      const main = document.querySelector('#__vben_main_content');
+      const scroll = document.querySelector('#__vben_layout_scroll');
+      const drawerBody = [...element.querySelectorAll('div')].find(
+        (child) => getComputedStyle(child).overflowY === 'auto',
+      );
+      if (
+        !(drawerBody instanceof HTMLElement) ||
+        !(main instanceof HTMLElement) ||
+        !(scroll instanceof HTMLElement)
+      ) {
+        throw new Error('Drawer layout regions are missing');
+      }
+
+      const spacer = document.createElement('div');
+      spacer.dataset.layoutTestSpacer = 'drawer';
+      spacer.style.height = '1200px';
+      drawerBody.append(spacer);
+
+      const drawerRect = element.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
+      return {
+        drawerBodyClientHeight: drawerBody.clientHeight,
+        drawerBodyScrollHeight: drawerBody.scrollHeight,
+        drawerBottom: drawerRect.bottom,
+        drawerHeight: drawerRect.height,
+        drawerTop: drawerRect.top,
+        layoutClientHeight: scroll.clientHeight,
+        layoutScrollHeight: scroll.scrollHeight,
+        mainBottom: mainRect.bottom,
+        mainHeight: mainRect.height,
+        mainTop: mainRect.top,
+        parentId: element.parentElement?.id,
+      };
+    });
+
+    expectNoViewportOverflow(metrics);
+    expect(geometry.parentId).toBe('__vben_main_content');
+    expect(Math.abs(geometry.mainTop - 88)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.drawerTop - geometry.mainTop)).toBeLessThanOrEqual(
+      1,
+    );
+    expect(
+      Math.abs(geometry.drawerBottom - geometry.mainBottom),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(geometry.drawerHeight - geometry.mainHeight),
+    ).toBeLessThanOrEqual(1);
+    expect(geometry.drawerBodyScrollHeight).toBeGreaterThan(
+      geometry.drawerBodyClientHeight,
+    );
+    expect(geometry.layoutScrollHeight).toBeLessThanOrEqual(
+      geometry.layoutClientHeight + 1,
+    );
+  } finally {
+    await layoutPage.setViewportSize({ height: 900, width: 1440 });
+    await navigateToLayoutPage(layoutPage, '/system/role');
+  }
 });
 
 test('uses the same deliberate duration for both sidebar controls', async ({


### PR DESCRIPTION
## Description

Follow up on #8283. Its removal of `LayoutContent`'s unconditional `min-height: 0` keeps non-fixed footers below naturally growing content, but it also lets full-height pages expand the layout scroll container in short viewports.

This change keeps the two behaviors compatible by applying the shrink constraint at `VbenLayout.contentStyle`, where both footer states are available:

- Footer disabled or fixed: `min-height: 0` allows `Page auto-content-height` descendants to keep scrolling internally.
- Footer enabled and non-fixed: the default `min-height: auto` keeps the footer after the full content height.
- Fixed footer padding remains unchanged.

The regression coverage includes short-viewpoint footer modes and `appendToMain` drawers with fixed header and tabbar geometry. No changeset is included, per request.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Verification

- `pnpm -F @vben/playground exec playwright test __tests__/e2e/layout-system.spec.ts --project=chromium --workers=1 --reporter=line --grep "preserves content sizing|keeps appendToMain drawers"` -> 2 passed
- `pnpm -F @vben/playground test:e2e:layout` -> 9 passed
- `pnpm -F @vben/playground typecheck` -> passed
- `pnpm run test:unit` -> 59 files, 459 tests passed
- `pnpm check:type` -> 45 packages passed
- Pre-commit `oxlint`, `oxfmt`, `eslint`, `stylelint`, and `commitlint` -> passed

The local full `pnpm run lint` command was blocked only by the user-owned untracked `playground/layout-content-height-regression-analysis.md`, which is not part of this PR; all affected files passed the same lint tools and the commit hook passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved layout sizing when the footer is enabled and not fixed, preventing unnecessary minimum-height constraints.
  - Added clearer footer region identification for more reliable layout behavior.
  - Ensured content and drawer areas size correctly without unwanted overflow across footer configurations.

- **Tests**
  - Expanded end-to-end coverage for disabled, fixed, and non-fixed footers, including layout sizing and content overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->