### PR TITLE
feat(@vben-core/shadcn-ui): add Progress primitive with progressbar semantics

### DIFF
--- a/.changeset/olive-foxes-progress-meter.md
+++ b/.changeset/olive-foxes-progress-meter.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/shadcn-ui': minor
+---
+
+feat(@vben-core/shadcn-ui): add Progress primitive with progressbar semantics

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/index.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/index.ts
@@ -16,6 +16,7 @@ export * from './number-field';
 export * from './pagination';
 export * from './pin-input';
 export * from './popover';
+export * from './progress';
 export * from './radio-group';
 export * from './resizable';
 export * from './scroll-area';

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
@@ -30,7 +30,9 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
  */
 const normalizedMax = computed(() => {
   const { max } = props;
-  return Number.isFinite(max) && max > 0 ? max : DEFAULT_MAX;
+  return typeof max === 'number' && Number.isFinite(max) && max > 0
+    ? max
+    : DEFAULT_MAX;
 });
 </script>
 

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
@@ -3,6 +3,8 @@ import type { ProgressRootEmits, ProgressRootProps } from 'reka-ui';
 
 import type { HTMLAttributes } from 'vue';
 
+import { computed } from 'vue';
+
 import { cn } from '@vben-core/shared/utils';
 
 import { reactiveOmit } from '@vueuse/core';
@@ -14,9 +16,23 @@ const props = defineProps<
 
 const emits = defineEmits<ProgressRootEmits>();
 
+/** ProgressRoot 对非法 max 的回退值（max 必须为正数）。 */
+const DEFAULT_MAX = 100;
+
 const delegatedProps = reactiveOmit(props, 'class');
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
+
+/**
+ * ProgressRoot 会把非法 max（0、负数、NaN）回退为 100；这里用同一规则
+ * 归一化后同时用于 root 与指示条 transform，避免 max=0 产生无穷百分比。
+ */
+const normalizedMax = computed(() => {
+  const { max } = props;
+  return typeof max === 'number' && !Number.isNaN(max) && max > 0
+    ? max
+    : DEFAULT_MAX;
+});
 </script>
 
 <template>
@@ -24,6 +40,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
     v-slot="slotProps"
     data-slot="progress"
     v-bind="forwarded"
+    :max="normalizedMax"
     :class="
       cn(
         'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
@@ -34,7 +51,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
     <ProgressIndicator
       data-slot="progress-indicator"
       :class="cn('bg-primary h-full w-full flex-1 transition-all')"
-      :style="`transform: translateX(-${100 - ((slotProps.modelValue || 0) / (props.max ?? 100)) * 100}%)`"
+      :style="`transform: translateX(-${100 - ((slotProps.modelValue || 0) / normalizedMax) * 100}%)`"
     />
   </ProgressRoot>
 </template>

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
@@ -24,14 +24,13 @@ const delegatedProps = reactiveOmit(props, 'class');
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 
 /**
- * ProgressRoot 会把非法 max（0、负数、NaN）回退为 100；这里用同一规则
- * 归一化后同时用于 root 与指示条 transform，避免 max=0 产生无穷百分比。
+ * ProgressRoot 会把非法 max（0、负数、NaN、Infinity）回退为 100；这里用
+ * 同一规则归一化后同时用于 root 与指示条 transform，避免 max=0 产生无穷
+ * 百分比，也避免 max=Infinity 让指示条除以无穷而退化为空填充。
  */
 const normalizedMax = computed(() => {
   const { max } = props;
-  return typeof max === 'number' && !Number.isNaN(max) && max > 0
-    ? max
-    : DEFAULT_MAX;
+  return Number.isFinite(max) && max > 0 ? max : DEFAULT_MAX;
 });
 </script>
 

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
     <ProgressIndicator
       data-slot="progress-indicator"
       :class="cn('bg-primary h-full w-full flex-1 transition-all')"
-      :style="`transform: translateX(-${100 - (slotProps.modelValue || 0)}%)`"
+      :style="`transform: translateX(-${100 - ((slotProps.modelValue || 0) / (props.max ?? 100)) * 100}%)`"
     />
   </ProgressRoot>
 </template>

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { ProgressRootEmits, ProgressRootProps } from 'reka-ui';
+
+import type { HTMLAttributes } from 'vue';
+
+import { cn } from '@vben-core/shared/utils';
+
+import { reactiveOmit } from '@vueuse/core';
+import { ProgressIndicator, ProgressRoot, useForwardPropsEmits } from 'reka-ui';
+
+const props = defineProps<
+  ProgressRootProps & { class?: HTMLAttributes['class'] }
+>();
+
+const emits = defineEmits<ProgressRootEmits>();
+
+const delegatedProps = reactiveOmit(props, 'class');
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits);
+</script>
+
+<template>
+  <ProgressRoot
+    v-slot="slotProps"
+    data-slot="progress"
+    v-bind="forwarded"
+    :class="
+      cn(
+        'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
+        props.class,
+      )
+    "
+  >
+    <ProgressIndicator
+      data-slot="progress-indicator"
+      :class="cn('bg-primary h-full w-full flex-1 transition-all')"
+      :style="`transform: translateX(-${100 - (slotProps.modelValue || 0)}%)`"
+    />
+  </ProgressRoot>
+</template>

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
@@ -92,21 +92,6 @@ describe('vben progress', () => {
     expect(root.getAttribute('data-state')).toBe('indeterminate');
   });
 
-  it('falls back to the default max when max is invalid and normalizes the fill', async () => {
-    const { indicator, root } = await mountProgress(30, 0);
-
-    expect(root).toBeInstanceOf(HTMLElement);
-    if (!(root instanceof HTMLElement)) return;
-    // reka-ui 将非法 max（<=0）回退为默认 100。
-    expect(root.getAttribute('aria-valuemax')).toBe('100');
-    expect(root.getAttribute('aria-valuenow')).toBe('30');
-
-    // 30 / 100 = 30% → translateX(-70%)，避免除零产生非法 transform。
-    expect(indicator).toBeInstanceOf(HTMLElement);
-    if (!(indicator instanceof HTMLElement)) return;
-    expect(indicator.style.transform).toBe('translateX(-70%)');
-  });
-
   it('hides the indicator fill when value is zero', async () => {
     const { indicator } = await mountProgress(0);
 

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
@@ -1,0 +1,84 @@
+import type { App } from 'vue';
+
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import Progress from '../Progress.vue';
+
+let activeApp: App | undefined;
+
+const HOST_DEFAULT_MAX = 100;
+
+/**
+ * 挂载受控 Progress，验证 reka-ui 原语暴露的 ARIA 订单与确定/不确定状态语义。
+ */
+async function mountProgress(
+  modelValue: null | number,
+  max = HOST_DEFAULT_MAX,
+) {
+  const value = ref(modelValue);
+  const Consumer = defineComponent(
+    () => () =>
+      h(Progress, {
+        max,
+        modelValue: value.value,
+      }),
+  );
+  const host = document.createElement('div');
+  document.body.append(host);
+  activeApp = createApp(Consumer);
+  activeApp.mount(host);
+  await nextTick();
+
+  const root = host.querySelector('[data-slot="progress"]');
+  const indicator = host.querySelector('[data-slot="progress-indicator"]');
+
+  return { indicator, root, value };
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+});
+
+describe('vben progress', () => {
+  it('renders progressbar semantics with bounded value', async () => {
+    const { root } = await mountProgress(42);
+
+    expect(root).toBeInstanceOf(HTMLElement);
+    if (!(root instanceof HTMLElement)) return;
+    expect(root.getAttribute('role')).toBe('progressbar');
+    expect(root.getAttribute('aria-valuemin')).toBe('0');
+    expect(root.getAttribute('aria-valuemax')).toBe('100');
+    expect(root.getAttribute('aria-valuenow')).toBe('42');
+  });
+
+  it('respects a custom max when reporting value', async () => {
+    const { root } = await mountProgress(30, 50);
+
+    expect(root).toBeInstanceOf(HTMLElement);
+    if (!(root instanceof HTMLElement)) return;
+    expect(root.getAttribute('aria-valuemax')).toBe('50');
+    expect(root.getAttribute('aria-valuenow')).toBe('30');
+  });
+
+  it('omits aria-valuenow and marks indeterminate state when value is null', async () => {
+    const { root } = await mountProgress(null);
+
+    expect(root).toBeInstanceOf(HTMLElement);
+    if (!(root instanceof HTMLElement)) return;
+    expect(root.getAttribute('role')).toBe('progressbar');
+    expect(root.getAttribute('aria-valuenow')).toBeNull();
+    expect(root.getAttribute('data-state')).toBe('indeterminate');
+  });
+
+  it('hides the indicator fill when value is zero', async () => {
+    const { indicator } = await mountProgress(0);
+
+    expect(indicator).toBeInstanceOf(HTMLElement);
+    if (!(indicator instanceof HTMLElement)) return;
+    expect(indicator.style.transform).toBe('translateX(-100%)');
+  });
+});

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
@@ -56,12 +56,17 @@ describe('vben progress', () => {
   });
 
   it('respects a custom max when reporting value', async () => {
-    const { root } = await mountProgress(30, 50);
+    const { indicator, root } = await mountProgress(30, 50);
 
     expect(root).toBeInstanceOf(HTMLElement);
     if (!(root instanceof HTMLElement)) return;
     expect(root.getAttribute('aria-valuemax')).toBe('50');
     expect(root.getAttribute('aria-valuenow')).toBe('30');
+
+    // 30 / 50 应按自定义 max 归一化为 60%，而不是 30%。
+    expect(indicator).toBeInstanceOf(HTMLElement);
+    if (!(indicator instanceof HTMLElement)) return;
+    expect(indicator.style.transform).toBe('translateX(-40%)');
   });
 
   it('omits aria-valuenow and marks indeterminate state when value is null', async () => {

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
@@ -69,14 +69,14 @@ describe('vben progress', () => {
     expect(indicator.style.transform).toBe('translateX(-40%)');
   });
 
-  it('falls back to max 100 when a non-positive max is provided', async () => {
-    const { indicator, root } = await mountProgress(30, 0);
+  it('falls back to max 100 when a NaN max is provided', async () => {
+    const { indicator, root } = await mountProgress(30, Number.NaN);
 
     expect(root).toBeInstanceOf(HTMLElement);
     if (!(root instanceof HTMLElement)) return;
     expect(root.getAttribute('aria-valuemax')).toBe('100');
 
-    // max=0 不得产生无穷 transform：30 / 100 → 30% 填充。
+    // max=NaN 不得产生无穷 transform：30 / 100 → 30% 填充。
     expect(indicator).toBeInstanceOf(HTMLElement);
     if (!(indicator instanceof HTMLElement)) return;
     expect(indicator.style.transform).toBe('translateX(-70%)');

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
@@ -69,6 +69,19 @@ describe('vben progress', () => {
     expect(indicator.style.transform).toBe('translateX(-40%)');
   });
 
+  it('falls back to max 100 when a non-positive max is provided', async () => {
+    const { indicator, root } = await mountProgress(30, 0);
+
+    expect(root).toBeInstanceOf(HTMLElement);
+    if (!(root instanceof HTMLElement)) return;
+    expect(root.getAttribute('aria-valuemax')).toBe('100');
+
+    // max=0 不得产生无穷 transform：30 / 100 → 30% 填充。
+    expect(indicator).toBeInstanceOf(HTMLElement);
+    if (!(indicator instanceof HTMLElement)) return;
+    expect(indicator.style.transform).toBe('translateX(-70%)');
+  });
+
   it('omits aria-valuenow and marks indeterminate state when value is null', async () => {
     const { root } = await mountProgress(null);
 
@@ -77,6 +90,21 @@ describe('vben progress', () => {
     expect(root.getAttribute('role')).toBe('progressbar');
     expect(root.getAttribute('aria-valuenow')).toBeNull();
     expect(root.getAttribute('data-state')).toBe('indeterminate');
+  });
+
+  it('falls back to the default max when max is invalid and normalizes the fill', async () => {
+    const { indicator, root } = await mountProgress(30, 0);
+
+    expect(root).toBeInstanceOf(HTMLElement);
+    if (!(root instanceof HTMLElement)) return;
+    // reka-ui 将非法 max（<=0）回退为默认 100。
+    expect(root.getAttribute('aria-valuemax')).toBe('100');
+    expect(root.getAttribute('aria-valuenow')).toBe('30');
+
+    // 30 / 100 = 30% → translateX(-70%)，避免除零产生非法 transform。
+    expect(indicator).toBeInstanceOf(HTMLElement);
+    if (!(indicator instanceof HTMLElement)) return;
+    expect(indicator.style.transform).toBe('translateX(-70%)');
   });
 
   it('hides the indicator fill when value is zero', async () => {

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts
@@ -69,14 +69,17 @@ describe('vben progress', () => {
     expect(indicator.style.transform).toBe('translateX(-40%)');
   });
 
-  it('falls back to max 100 when a NaN max is provided', async () => {
-    const { indicator, root } = await mountProgress(30, Number.NaN);
+  it.each([
+    ['NaN', Number.NaN],
+    ['infinite', Number.POSITIVE_INFINITY],
+  ])('falls back to max 100 when a %s max is provided', async (_label, max) => {
+    const { indicator, root } = await mountProgress(30, max);
 
     expect(root).toBeInstanceOf(HTMLElement);
     if (!(root instanceof HTMLElement)) return;
     expect(root.getAttribute('aria-valuemax')).toBe('100');
 
-    // max=NaN 不得产生无穷 transform：30 / 100 → 30% 填充。
+    // 非有限 max 不得产生无穷 transform：30 / 100 → 30% 填充。
     expect(indicator).toBeInstanceOf(HTMLElement);
     if (!(indicator instanceof HTMLElement)) return;
     expect(indicator.style.transform).toBe('translateX(-70%)');

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/progress/index.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/progress/index.ts
@@ -1,0 +1,1 @@
+export { default as Progress } from './Progress.vue';


### PR DESCRIPTION
## Summary

Add a new `Progress` primitive to `@vben-core/shadcn-ui`, modeled on the existing reka-ui wrapper pattern used by `Switch` and `Separator`.

The primitive exposes proper progressbar ARIA semantics via `reka-ui`'s `ProgressRoot`:
- `role="progressbar"` with `aria-valuemin`, `aria-valuemax`, `aria-valuenow`
- custom `max` support
- non-finite / non-positive `max` values safely fall back to `100` (shared `normalizedMax` computed drives both `ProgressRoot` and the indicator transform)
- indeterminate state (`data-state="indeterminate"`, `aria-valuenow` omitted) when `modelValue` is `null`

## Changes

- `packages/@core/ui-kit/shadcn-ui/src/ui/progress/Progress.vue` — new primitive
- `packages/@core/ui-kit/shadcn-ui/src/ui/progress/index.ts` — export
- `packages/@core/ui-kit/shadcn-ui/src/ui/index.ts` — aggregating export
- `packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts` — unit tests covering value, custom max, NaN/Infinity fallback, indeterminate, and zero-value rendering
- `.changeset/olive-foxes-progress-meter.md` — changeset (`minor`)

## Verification

- Unit tests (`packages/@core/ui-kit/shadcn-ui/src/ui/progress/__tests__/progress.test.ts`): 6 cases — bounded value, custom max, NaN fallback, Infinity fallback, indeterminate, zero value — all passing locally and in CI (`Test` × ubuntu/windows)
- `vsh lint` — clean (CI `Lint` × ubuntu/windows pass)
- Typecheck — clean (CI `Check` × ubuntu/windows pass)
- CodeQL + `post-update` — pass

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
