### PR TITLE
fix(apps): pass withCredentials as request config for refresh/logout

### DIFF
--- a/.changeset/calm-otters-refresh-credentials.md
+++ b/.changeset/calm-otters-refresh-credentials.md
@@ -1,0 +1,9 @@
+---
+'@vben/web-antd': patch
+'@vben/web-antdv-next': patch
+'@vben/web-ele': patch
+'@vben/web-naive': patch
+'@vben/web-tdesign': patch
+---
+
+fix(apps): pass withCredentials as request config for refresh/logout

--- a/apps/web-antd/src/api/core/auth.ts
+++ b/apps/web-antd/src/api/core/auth.ts
@@ -29,16 +29,20 @@ export async function loginApi(data: AuthApi.LoginParams) {
  * 刷新accessToken
  */
 export async function refreshTokenApi() {
-  return baseRequestClient.post<AuthApi.RefreshTokenResult>('/auth/refresh', {
-    withCredentials: true,
-  });
+  return baseRequestClient.post<AuthApi.RefreshTokenResult>(
+    '/auth/refresh',
+    undefined,
+    {
+      withCredentials: true,
+    },
+  );
 }
 
 /**
  * 退出登录
  */
 export async function logoutApi() {
-  return baseRequestClient.post('/auth/logout', {
+  return baseRequestClient.post('/auth/logout', undefined, {
     withCredentials: true,
   });
 }

--- a/apps/web-antdv-next/src/api/core/auth.ts
+++ b/apps/web-antdv-next/src/api/core/auth.ts
@@ -29,16 +29,20 @@ export async function loginApi(data: AuthApi.LoginParams) {
  * 刷新accessToken
  */
 export async function refreshTokenApi() {
-  return baseRequestClient.post<AuthApi.RefreshTokenResult>('/auth/refresh', {
-    withCredentials: true,
-  });
+  return baseRequestClient.post<AuthApi.RefreshTokenResult>(
+    '/auth/refresh',
+    undefined,
+    {
+      withCredentials: true,
+    },
+  );
 }
 
 /**
  * 退出登录
  */
 export async function logoutApi() {
-  return baseRequestClient.post('/auth/logout', {
+  return baseRequestClient.post('/auth/logout', undefined, {
     withCredentials: true,
   });
 }

--- a/apps/web-ele/src/api/core/auth.ts
+++ b/apps/web-ele/src/api/core/auth.ts
@@ -29,16 +29,20 @@ export async function loginApi(data: AuthApi.LoginParams) {
  * 刷新accessToken
  */
 export async function refreshTokenApi() {
-  return baseRequestClient.post<AuthApi.RefreshTokenResult>('/auth/refresh', {
-    withCredentials: true,
-  });
+  return baseRequestClient.post<AuthApi.RefreshTokenResult>(
+    '/auth/refresh',
+    undefined,
+    {
+      withCredentials: true,
+    },
+  );
 }
 
 /**
  * 退出登录
  */
 export async function logoutApi() {
-  return baseRequestClient.post('/auth/logout', {
+  return baseRequestClient.post('/auth/logout', undefined, {
     withCredentials: true,
   });
 }

--- a/apps/web-naive/src/api/core/auth.ts
+++ b/apps/web-naive/src/api/core/auth.ts
@@ -29,16 +29,20 @@ export async function loginApi(data: AuthApi.LoginParams) {
  * 刷新accessToken
  */
 export async function refreshTokenApi() {
-  return baseRequestClient.post<AuthApi.RefreshTokenResult>('/auth/refresh', {
-    withCredentials: true,
-  });
+  return baseRequestClient.post<AuthApi.RefreshTokenResult>(
+    '/auth/refresh',
+    undefined,
+    {
+      withCredentials: true,
+    },
+  );
 }
 
 /**
  * 退出登录
  */
 export async function logoutApi() {
-  return baseRequestClient.post('/auth/logout', {
+  return baseRequestClient.post('/auth/logout', undefined, {
     withCredentials: true,
   });
 }

--- a/apps/web-tdesign/src/api/core/auth.ts
+++ b/apps/web-tdesign/src/api/core/auth.ts
@@ -29,16 +29,20 @@ export async function loginApi(data: AuthApi.LoginParams) {
  * 刷新accessToken
  */
 export async function refreshTokenApi() {
-  return baseRequestClient.post<AuthApi.RefreshTokenResult>('/auth/refresh', {
-    withCredentials: true,
-  });
+  return baseRequestClient.post<AuthApi.RefreshTokenResult>(
+    '/auth/refresh',
+    undefined,
+    {
+      withCredentials: true,
+    },
+  );
 }
 
 /**
  * 退出登录
  */
 export async function logoutApi() {
-  return baseRequestClient.post('/auth/logout', {
+  return baseRequestClient.post('/auth/logout', undefined, {
     withCredentials: true,
   });
 }


### PR DESCRIPTION
Fixes #8220

## Summary

In every app under `apps/`, `refreshTokenApi` and `logoutApi` called:

```ts
baseRequestClient.post('/auth/refresh', { withCredentials: true })
```

but `RequestClient.post(url, data?, config?)` treats the **second argument as the request body**, not the config. So `withCredentials: true` was serialized into the POST payload (e.g. `{"withCredentials": true}`) and never applied as an axios request option — cookie-based token refresh/logout silently lacked credentials.

## Change

Move `withCredentials` to the **config** argument in all five apps:

- `apps/web-antd/src/api/core/auth.ts`
- `apps/web-antdv-next/src/api/core/auth.ts`
- `apps/web-ele/src/api/core/auth.ts`
- `apps/web-naive/src/api/core/auth.ts`
- `apps/web-tdesign/src/api/core/auth.ts`

```ts
// before
baseRequestClient.post('/auth/refresh', { withCredentials: true })

// after
baseRequestClient.post('/auth/refresh', undefined, { withCredentials: true })
```

## Verification

- `pnpm exec vsh lint` — clean (after `--format`)
- `vue-tsc --noEmit -p apps/web-ele/tsconfig.json` — clean
- No other `post`/`put` call sites in `apps/` pass config-like keys as body (swept).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token refresh and logout requests across supported web applications.
  * Ensured credential settings are handled correctly without being included in request bodies.
  * Maintained authenticated session behavior for refresh and logout operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->