### PR TITLE
fix(@vben/preferences): expose full copyright fields in appCopyrightPreferences

### DIFF
--- a/.changeset/tidy-pandas-copyright-fields.md
+++ b/.changeset/tidy-pandas-copyright-fields.md
@@ -1,0 +1,5 @@
+---
+'@vben/preferences': patch
+---
+
+fix(@vben/preferences): expose full copyright fields in appCopyrightPreferences

--- a/packages/preferences/src/index.ts
+++ b/packages/preferences/src/index.ts
@@ -22,10 +22,15 @@ function definePreferencesExtension<
   return extension;
 }
 
-/** 应用级 ICP 备案配置，供各 app 的 preferences 覆盖使用 */
+/** 应用级版权配置，供各 app 的 preferences 覆盖使用 */
 const appCopyrightPreferences = {
+  companyName: 'Vben',
+  companySiteLink: 'https://www.vben.pro',
+  date: '2024',
+  enable: true,
   icp: '闽ICP备19024351号',
   icpLink: 'https://beian.miit.gov.cn/',
+  settingShow: true,
 } satisfies DeepPartial<Preferences>['copyright'];
 
 export {


### PR DESCRIPTION
Fixes #8275

## Summary

`appCopyrightPreferences` in `packages/preferences/src/index.ts` only exposed `icp` and `icpLink`, but the full `CopyrightPreferences` shape (as rendered by the preferences settings panel and the footer copyright component) also includes `companyName`, `companySiteLink`, `date`, `enable`, and `settingShow`.

Apps spread this exported default into their `preferences.copyright`, so with only the two ICP fields they could not override the company name/site/date at the app level — the footer and settings panel fell back to core defaults instead.

## Change

Add the missing fields to the exported default, matching the values in `packages/@core/preferences/src/config.ts`:

```ts
const appCopyrightPreferences = {
  companyName: 'Vben',
  companySiteLink: 'https://www.vben.pro',
  date: '2024',
  enable: true,
  icp: '闽ICP备19024351号',
  icpLink: 'https://beian.miit.gov.cn/',
  settingShow: true,
} satisfies DeepPartial<Preferences>['copyright'];
```

All five apps (`web-antd`, `web-antdv-next`, `web-ele`, `web-naive`, `web-tdesign`) keep their `copyright: appCopyrightPreferences` binding unchanged — behavior is preserved, and each app now receives the full set of fields it can override.

## Verification

- `pnpm exec vsh lint` — clean
- `vue-tsc --noEmit -p packages/preferences/tsconfig.json` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded application copyright settings to support company name, website link, date, enablement, and display controls.
  * Continued support for existing ICP filing information and links.
  * Improved configuration coverage for displaying complete application copyright details across supported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->