### PR TITLE
feat(@vben-core/popup-ui): add extra header slot to modal

### DIFF
--- a/.changeset/gold-donkeys-modal-extra.md
+++ b/.changeset/gold-donkeys-modal-extra.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/popup-ui': minor
+---
+
+feat(@vben-core/popup-ui): support custom content in modal header via extra slot

--- a/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
+++ b/packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts
@@ -106,6 +106,43 @@ describe('vben modal', () => {
     document.dispatchEvent(new MouseEvent('mouseup'));
   });
 
+  it('renders custom content in the extra header slot', async () => {
+    const mainContent = document.createElement('main');
+    mainContent.id = ELEMENT_ID_MAIN_CONTENT;
+    mainContent.innerHTML = '<div><div></div></div>';
+    document.body.append(mainContent);
+
+    const Consumer = defineComponent(() => {
+      const [Modal, modalApi] = useVbenModal({
+        appendToMain: true,
+        fullscreenButton: true,
+        title: 'Slot modal',
+      });
+      onMounted(() => {
+        modalApi.open();
+      });
+      return () =>
+        h(Modal, null, {
+          extra: () => h('span', { class: 'extra-slot-marker' }, 'Custom'),
+        });
+    });
+    const host = document.createElement('div');
+    document.body.append(host);
+    activeApp = createApp(() => h(Consumer));
+    activeApp.mount(host);
+    await nextTick();
+    await nextTick();
+
+    const marker = document.querySelector('.extra-slot-marker');
+    expect(marker).toBeInstanceOf(HTMLElement);
+    if (!(marker instanceof HTMLElement)) return;
+    expect(marker.textContent?.trim()).toBe('Custom');
+    // extra slot 应渲染在 fullscreen 按钮容器内，与全屏按钮同排
+    const container = marker.closest('.absolute');
+    expect(container).toBeInstanceOf(HTMLElement);
+    expect(mainContent.contains(container)).toBe(true);
+  });
+
   it('fires onClosed via the fallback when no animation event arrives', async () => {
     vi.useFakeTimers({
       toFake: [

--- a/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
+++ b/packages/@core/ui-kit/popup-ui/src/modal/modal.vue
@@ -319,14 +319,20 @@ function handleClosed() {
         <slot></slot>
       </div>
       <VbenLoading v-if="showLoading || submitting" spinning />
-      <VbenIconButton
-        v-if="fullscreenButton"
-        class="absolute top-3 right-10 flex-center size-6 rounded-full px-1 text-lg text-foreground/80 opacity-70 transition-opacity hover:bg-accent hover:text-accent-foreground hover:opacity-100 focus:outline-hidden disabled:pointer-events-none"
-        @click="handleFullscreen"
+      <div
+        v-if="fullscreenButton || $slots.extra"
+        class="absolute top-3 right-10 flex items-center gap-1"
       >
-        <Shrink v-if="fullscreen" class="size-3.5" />
-        <Expand v-else class="size-3.5" />
-      </VbenIconButton>
+        <slot name="extra"></slot>
+        <VbenIconButton
+          v-if="fullscreenButton"
+          class="flex-center size-6 rounded-full px-1 text-lg text-foreground/80 opacity-70 transition-opacity hover:bg-accent hover:text-accent-foreground hover:opacity-100 focus:outline-hidden disabled:pointer-events-none"
+          @click="handleFullscreen"
+        >
+          <Shrink v-if="fullscreen" class="size-3.5" />
+          <Expand v-else class="size-3.5" />
+        </VbenIconButton>
+      </div>
 
       <DialogFooter
         ref="footerRef"


### PR DESCRIPTION
Closes #8246

## Summary

Adds an `extra` slot to `VbenModal`, mirroring the existing `extra` slot already available on the drawer component. Custom content placed in this slot renders in the modal header, immediately to the left of the fullscreen toggle button (and left of the close button).

## Changes

- `packages/@core/ui-kit/popup-ui/src/modal/modal.vue` — wrap the fullscreen button and the new `extra` slot in a flex container positioned at the header's right side; the container only renders when the slot is used or the fullscreen button is enabled
- `packages/@core/ui-kit/popup-ui/src/modal/__tests__/modal.test.ts` — new test asserting the extra slot content renders inside the header container
- `.changeset/gold-donkeys-modal-extra.md` — changeset (`minor`)

## Usage

```vue
<Modal title="...">
  <template #extra>
    <VbenIconButton>...</VbenIconButton>
  </template>
</Modal>
```

## Verification

- `pnpm vitest run --dom packages/@core/ui-kit/popup-ui` — 9 files / 44 tests pass
- `pnpm exec vsh lint` — clean
- `vue-tsc --noEmit -p packages/@core/ui-kit/popup-ui/tsconfig.json` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom content in the modal header through an extra slot.
  - Custom header content can now appear alongside the fullscreen toggle button.

- **Bug Fixes**
  - Improved modal header layout when using fullscreen controls and custom content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->