### PR TITLE
chore: remove duplicate oxc extension recommendation in vscode config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,8 +8,6 @@
     "oxc.oxc-vscode",
     // Visual Studio Code 的官方 Stylelint 扩展
     "stylelint.vscode-stylelint",
-    // 使用 oxfmt 的代码格式化程序
-    "oxc.oxc-vscode",
     // 支持 dotenv 文件语法
     "mikestead.dotenv",
     // YAML 语言支持，供 ESLint 校验 pnpm-workspace.yaml 等文件


### PR DESCRIPTION
Fixes #8241

Remove the duplicate `oxc.oxc-vscode` entry in `.vscode/extensions.json`. The extension was listed twice — once for oxlint integration and again (under a stale comment about the oxfmt formatter) right after `stylelint.vscode-stylelint`.

## Change

```diff
     stylelint.vscode-stylelint,
-    // 使用 oxfmt 的代码格式化程序
-    oxc.oxc-vscode,
     // 支持 dotenv 文件语法
     mikestead.dotenv,
```

## Verification

- `oxc.oxc-vscode` appears exactly once in `recommendations`
- `pnpm exec vsh lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a duplicate recommended editor extension entry.
  * Cleaned up the associated configuration comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->