### PR TITLE
docs(@vben/docs): fix setUserInfo store reference in access guide

### DIFF
--- a/docs/src/en/guide/in-depth/access.md
+++ b/docs/src/en/guide/in-depth/access.md
@@ -53,7 +53,7 @@ You can look under `src/store/auth` in the application to find the following cod
 ```ts
 // Set the login user information, ensuring that userInfo.roles is an array and contains permissions from the route table
 // For example: userInfo.roles=['super', 'admin']
-authStore.setUserInfo(userInfo);
+userStore.setUserInfo(userInfo);
 ```
 
 At this point, the configuration is complete. You need to ensure that the roles returned by the interface after login match the permissions in the route table; otherwise, access will not be possible.
@@ -204,7 +204,7 @@ const [fetchUserInfoResult, accessCodes] = await Promise.all([
 ]);
 
 userInfo = fetchUserInfoResult;
-authStore.setUserInfo(userInfo);
+userStore.setUserInfo(userInfo);
 accessStore.setAccessCodes(accessCodes);
 ```
 

--- a/docs/src/guide/in-depth/access.md
+++ b/docs/src/guide/in-depth/access.md
@@ -53,7 +53,7 @@ export const overridesPreferences = defineOverridesPreferences({
 ```ts
 // 设置登录用户信息，需要确保 userInfo.roles 是一个数组，且包含路由表中的权限
 // 例如：userInfo.roles=['super', 'admin']
-authStore.setUserInfo(userInfo);
+userStore.setUserInfo(userInfo);
 ```
 
 到这里，就已经配置完成，你需要确保登录后，接口返回的角色和路由表的权限匹配，否则无法访问。
@@ -212,7 +212,7 @@ const [fetchUserInfoResult, accessCodes] = await Promise.all([
 ]);
 
 userInfo = fetchUserInfoResult;
-authStore.setUserInfo(userInfo);
+userStore.setUserInfo(userInfo);
 accessStore.setAccessCodes(accessCodes);
 ```
 


### PR DESCRIPTION
Fixes #8164

## Summary

The access-control guide referenced `authStore.setUserInfo(userInfo)` in both the Chinese and English docs, but the current code exposes `setUserInfo` on the user store (`useUserStore`, see `packages/stores/src/modules/user.ts`). The `authStore` has no such method.

## Change

Replace `authStore.setUserInfo` with `userStore.setUserInfo` in:

- `docs/src/guide/in-depth/access.md` (2 occurrences)
- `docs/src/en/guide/in-depth/access.md` (2 occurrences)

## Verification

- `grep -rn "authStore.setUserInfo" docs/` → no matches
- `pnpm exec vsh lint` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated access-control examples to use the current user information store after login.
  * Corrected examples for both route-permission and permission-code workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->