### PR TITLE
feat(@vben/layouts): make user dropdown avatar dot configurable

### DIFF
--- a/.changeset/young-planes-avatar-dot.md
+++ b/.changeset/young-planes-avatar-dot.md
@@ -1,0 +1,5 @@
+---
+'@vben/layouts': patch
+---
+
+feat(@vben/layouts): make user dropdown avatar dot configurable via props

--- a/packages/effects/layouts/package.json
+++ b/packages/effects/layouts/package.json
@@ -30,6 +30,7 @@
     "@vben-core/shadcn-ui": "workspace:*",
     "@vben-core/shared": "workspace:*",
     "@vben-core/tabs-ui": "workspace:*",
+    "@vben-core/typings": "workspace:*",
     "@vben/constants": "workspace:*",
     "@vben/hooks": "workspace:*",
     "@vben/icons": "workspace:*",

--- a/packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue
+++ b/packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue
@@ -5,6 +5,8 @@ import type { LanguageOption } from '@vben/constants';
 import type { SupportedLanguagesType } from '@vben/locales';
 import type { AnyFunction } from '@vben/types';
 
+import type { ClassType } from '@vben-core/typings';
+
 import { computed, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 
 import { onSupportLanguagesChange } from '@vben/constants';
@@ -58,6 +60,15 @@ interface Props {
    */
   avatar?: string;
   /**
+   * 头像是否显示在线圆点
+   * @default true
+   */
+  avatarDot?: boolean;
+  /**
+   * 头像在线圆点样式
+   */
+  avatarDotClass?: ClassType;
+  /**
    * @zh_CN 描述
    */
   description?: string;
@@ -90,6 +101,8 @@ defineOptions({
 
 const props = withDefaults(defineProps<Props>(), {
   avatar: '',
+  avatarDot: true,
+  avatarDotClass: 'bottom-0 right-1 border-2 size-4 bg-green-500',
   description: '',
   menus: () => [],
   tagText: '',
@@ -370,7 +383,12 @@ if (preferences.shortcutKeys.enable) {
     <DropdownMenuTrigger ref="refTrigger" :disabled="props.trigger === 'hover'">
       <div class="mr-2 ml-1 cursor-pointer rounded-full p-1.5 hover:bg-accent">
         <div class="flex-center hover:text-accent-foreground">
-          <VbenAvatar :alt="text" :src="avatar" class="size-8" dot />
+          <VbenAvatar
+            :alt="text"
+            :src="avatar"
+            class="size-8"
+            :dot="avatarDot"
+          />
         </div>
       </div>
     </DropdownMenuTrigger>
@@ -381,8 +399,8 @@ if (preferences.shortcutKeys.enable) {
             :alt="text"
             :src="avatar"
             class="size-12"
-            dot
-            dot-class="bottom-0 right-1 border-2 size-4 bg-green-500"
+            :dot="avatarDot"
+            :dot-class="avatarDotClass"
           />
           <div class="ml-2 w-full">
             <div

--- a/packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue
+++ b/packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue
@@ -388,6 +388,7 @@ if (preferences.shortcutKeys.enable) {
             :src="avatar"
             class="size-8"
             :dot="avatarDot"
+            :dot-class="avatarDotClass"
           />
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1766,6 +1766,9 @@ importers:
       '@vben-core/tabs-ui':
         specifier: workspace:*
         version: link:../../@core/ui-kit/tabs-ui
+      '@vben-core/typings':
+        specifier: workspace:*
+        version: link:../../@core/base/typings
       '@vben/constants':
         specifier: workspace:*
         version: link:../../constants


### PR DESCRIPTION
Closes #8172

## Summary

The online-status dot on the `UserDropdown` avatar was hardcoded — both the small header avatar and the large dropdown avatar always rendered the green dot with a fixed `bg-green-500` style, with no way for apps to hide or restyle it (unlike the notification badge, which is configurable).

Add two props, defaulting to the previous behavior:

```vue
<UserDropdown
  :avatar-dot="false"                       <!-- hide the dot -->
  avatar-dot-class="bg-blue-500 size-3"     <!-- restyle it -->
/>
```

## Changes

- `packages/effects/layouts/src/widgets/user-dropdown/user-dropdown.vue`:
  - New `avatarDot?: boolean` prop (default `true`)
  - New `avatarDotClass?: ClassType` prop (default `'bottom-0 right-1 border-2 size-4 bg-green-500'`)
  - Both `VbenAvatar` instances (header trigger + dropdown content) now bind `:dot` / `:dot-class` from the props
- `packages/effects/layouts/package.json` + `pnpm-lock.yaml`: add `@vben-core/typings` dependency (for `ClassType`, same as used by `VbenAvatar`)
- `.changeset/young-planes-avatar-dot.md` — changeset (`patch`)

## Verification

- `pnpm exec vsh lint` — clean
- `vue-tsc --noEmit -p packages/effects/layouts/tsconfig.json` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable avatar status indicators to the user dropdown.
  - You can now control whether the avatar dot appears and customize its styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->