### PR TITLE
fix(@vben/playground): 移除 authLogin 中重复的 setUserInfo 调用 (#8165)

### DIFF
--- a/playground/src/store/auth.ts
+++ b/playground/src/store/auth.ts
@@ -48,7 +48,6 @@ export const useAuthStore = defineStore('auth', () => {
 
         userInfo = fetchUserInfoResult;
 
-        userStore.setUserInfo(userInfo);
         accessStore.setAccessCodes(accessCodes);
 
         if (accessStore.loginExpired) {


### PR DESCRIPTION
Closes #8165

## 改动

`playground/src/store/auth.ts` 的 `authLogin` 中删除重复的 `userStore.setUserInfo(userInfo)` 调用。

## 理由

`authLogin` 已通过 `Promise.all` 调用 `fetchUserInfo()`，而 `fetchUserInfo` 内部已执行 `userStore.setUserInfo(userInfo)` 并返回同一对象引用；随后再次 `setUserInfo` 同一对象属重复调用，删除后行为不变（`userInfo` 变量仍用于 `homePath` 跳转与返回值）。

## 验证

- `pnpm check:type`：全绿（6/6 包）
- 本地 hook：oxlint / oxfmt / eslint / checkType / commitlint 全部通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined sign-in handling while preserving access token and permission updates.
  * User information continues to be retrieved and returned during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->