### PR TITLE
test(@vben/common-ui): add icon-picker keyword filter regression tests

### DIFF
--- a/packages/effects/common-ui/src/components/icon-picker/__tests__/icon-picker.test.ts
+++ b/packages/effects/common-ui/src/components/icon-picker/__tests__/icon-picker.test.ts
@@ -1,0 +1,176 @@
+import { DOMWrapper, mount } from '@vue/test-utils';
+import { defineComponent, h, markRaw, nextTick } from 'vue';
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import IconPicker from '../icon-picker.vue';
+
+// VbenIcon renders through @iconify/vue's Icon, which lazily fetches icon data
+// from api.iconify.design at render time. Isolate it in tests: we only care
+// about which icon names are rendered into the grid, not the SVG bodies.
+vi.mock('@iconify/vue', () => ({
+  Icon: defineComponent({
+    name: 'IconifyIconMock',
+    props: { icon: { type: String, default: '' } },
+    setup() {
+      return () => h('span', { class: 'mock-icon' });
+    },
+  }),
+  addCollection: vi.fn(),
+  addIcon: vi.fn(),
+  listIcons: vi.fn(() => []),
+}));
+
+vi.mock('../icons', () => ({
+  ICONS_MAP: {},
+  fetchIconsData: vi.fn(async (prefix: string) =>
+    prefix === 'carbon'
+      ? [
+          'carbon:home',
+          'carbon:search',
+          'carbon:settings',
+          'carbon:user-profile',
+        ]
+      : [],
+  ),
+}));
+
+// Belt and braces: log + block any remaining network access.
+beforeAll(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: unknown) => {
+      console.log('[icon-picker test] blocked fetch:', String(url));
+      return new Response('{}', { status: 200 });
+    }),
+  );
+});
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const gridIconCount = () =>
+  document.body.querySelector('.grid-cols-6')?.childElementCount ?? 0;
+
+async function openIconPicker(wrapper: ReturnType<typeof mount>) {
+  await wrapper.find('input').trigger('click');
+  await nextTick();
+  await vi.waitFor(() => {
+    expect(document.body.querySelector('.grid-cols-6')).toBeTruthy();
+  });
+}
+
+async function searchAndExpect(keyword: string, expectedCount: number) {
+  const inputs = [...document.body.querySelectorAll('input')];
+  const el = inputs.at(-1);
+  if (!el) {
+    throw new Error('search input not found in popover');
+  }
+  await new DOMWrapper(el).setValue(keyword);
+  // keyword debounce is 300ms; waitFor polls until the grid settles.
+  await vi.waitFor(() => {
+    expect(gridIconCount()).toBe(expectedCount);
+  });
+}
+
+// Mimics the antdv-next adapter registration:
+//   IconPicker: withDefaultPlaceholder(IconPicker, 'select', {
+//     iconSlot: 'addonAfter',
+//     inputComponent: Input,
+//     modelValueProp: 'value',
+//   })
+const AntdvNextLikeInput = defineComponent({
+  name: 'AntdvNextLikeInput',
+  props: {
+    value: { type: String, default: '' },
+  },
+  emits: ['update:value'],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h('input', {
+        ...attrs,
+        class: ['antdv-next-like-input', attrs.class as string],
+        value: props.value,
+        onInput: (event: Event) => {
+          const target = event.target as HTMLInputElement;
+          emit('update:value', target.value);
+        },
+      });
+  },
+});
+
+const STATIC_ICONS = ['home', 'search', 'settings', 'user-profile'];
+
+describe('icon-picker.vue', () => {
+  it('filters icons with the search input (static icons)', async () => {
+    const wrapper = mount(IconPicker, {
+      attachTo: document.body,
+      props: {
+        icons: STATIC_ICONS,
+        prefix: '',
+      },
+    });
+    await openIconPicker(wrapper);
+    expect(gridIconCount()).toBe(4);
+
+    // 'ho' matches only 'home'
+    await searchAndExpect('ho', 1);
+
+    await searchAndExpect('zzz', 0); // empty result
+
+    wrapper.unmount();
+  });
+
+  it('filters icons with the search input (prefix + fetched icons)', async () => {
+    const wrapper = mount(IconPicker, {
+      attachTo: document.body,
+      props: {
+        prefix: 'carbon',
+      },
+    });
+    // watchDebounced: immediate + 500ms debounce before fetchIconsData
+    await sleep(700);
+    await openIconPicker(wrapper);
+    expect(gridIconCount()).toBe(4);
+
+    // 'user' matches only 'carbon:user-profile'
+    await searchAndExpect('user', 1);
+
+    wrapper.unmount();
+  });
+
+  it('filters icons through inputComponent using the value/onUpdate:value protocol', async () => {
+    const wrapper = mount(IconPicker, {
+      attachTo: document.body,
+      props: {
+        icons: STATIC_ICONS,
+        inputComponent: markRaw(AntdvNextLikeInput),
+        modelValueProp: 'value',
+        prefix: '',
+      },
+    });
+    await openIconPicker(wrapper);
+    expect(gridIconCount()).toBe(4);
+
+    // 'se' matches 'search', 'settings' and 'user-profile' (u-s-e-r)
+    await searchAndExpect('se', 3);
+
+    await searchAndExpect('zzz', 0);
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## 变更说明

为 `@vben/common-ui` 的 `IconPicker` 组件新增组件级回归测试（此前该组件没有任何测试），覆盖搜索过滤的三条渲染路径：

1. **默认渲染**（vben `Input`、`prefix: ''`、静态 `icons`）：关键词过滤（`'ho'` → 仅 `home`）与空结果（`'zzz'` → 0，覆盖 noData 分支）。
2. **`prefix` + 远程图标**：mock `fetchIconsData('carbon')`，验证 `watchDebounced` 防抖加载完成后的过滤（`'user'` → 仅 `user-profile`）。
3. **`inputComponent` + `modelValueProp: 'value'` 协议**（即 antdv-next 适配器 `withDefaultPlaceholder(IconPicker, 'select', { iconSlot: 'addonAfter', inputComponent: Input, modelValueProp: 'value' })` 的形状）：验证 `value` / `onUpdate:value` 双向绑定下过滤正常（`'se'` → 3 个，`user-profile` 本身包含子串 `se`）。

测试实现说明：

- mock `@iconify/vue`，隔离 `VbenIcon` 渲染时对 `api.iconify.design` 的懒加载网络请求，保证 CI 无网络依赖；
- 用 `vi.waitFor` 断言 300ms 关键词防抖后的稳定状态，不依赖固定 sleep。

## 与 #8087 的关系

调查 #8087（antdv-next 中 IconPicker 搜索框无法搜索）时发现：在当前 main 上，上述三条路径的过滤逻辑均验证通过；对比 v5.7.0 与 main，`icon-picker.vue` 的搜索相关代码（`keyword → refDebounced(300ms) → showList 过滤 → usePagination`）逐行一致。本 PR 不修改任何生产代码，仅将现有行为固化为回归测试，为该 issue 的后续定位（疑似网络/环境因素）提供行为基线。

## 验证

- `pnpm exec vitest run src/components/icon-picker`（packages/effects/common-ui）→ 3/3 通过
- lefthook pre-commit：oxlint（0 errors）/ oxfmt / eslint（0 errors）/ checkType 全部通过
- `pnpm run check:type` → 6 successful

Ref: #8087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for icon search filtering with static and fetched icons.
  * Added coverage for custom input components using value update events.
  * Improved test reliability by isolating external icon and network dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->