### PR TITLE
fix(@vben/common-ui): keep auto-height Page from clamping outer flex layout

### DIFF
--- a/packages/effects/common-ui/src/components/page/page.vue
+++ b/packages/effects/common-ui/src/components/page/page.vue
@@ -24,6 +24,12 @@ const contentStyle = computed<StyleValue>(() => {
 
   return {
     '--page-content-height-offset': `${heightOffset}px`,
+    // In auto-content-height mode the content region manages its own scrolling.
+    // Size containment prevents the inner content's min-content height from
+    // feeding back into the outer flex layout, which would clamp the content
+    // region taller than the available space and push the layout footer below
+    // the viewport (see https://github.com/vbenjs/vue-vben-admin/issues/5677).
+    contain: 'size',
     marginBlockEnd: 'var(--page-content-height-offset)',
   };
 });


### PR DESCRIPTION
## Description

Fixes #5677

开启「显示底栏」且底栏为**非固定**模式时，首屏渲染的高度自适应计算存在错误：内容区比可用空间高出约 19px，布局页脚被推出视口底部，同时 Page 自身该出现的滚动条要等切换一次页签后才出现。

## Root Cause

`VbenLayout` 的 `contentStyle` 在 `footerEnable && !footerFixed` 时给 `LayoutContent`（滚动容器的 flex 子项）留下 `min-height: auto`（其余分支均为 `0`）。

`auto-content-height` 模式下的 `Page` 内容区（`flex-1 min-h-0 overflow-y-auto`）会把内部内容的 min-content 高度反馈进这条 automatic minimum size：首帧布局被钳制在 min-content 高度（实测 708px，而可用空间 689px，视口 809px、页脚 32px）。于是：

- 内容区比可用空间高 19px，页脚被推出视口（footer bottom 828 > 视口 809，滚动容器 scrollHeight 740 > clientHeight 721）；
- 内容区自身高度恰好等于内容高度，内部滚动条"消失"；
- 切换页签后 KeepAlive 重挂载打破了反馈环，高度才收敛为正确值（688px）——这正是 issue 中"切到其他页再切回来才出现滚动条"的现象。

复现数据（playground `/system/role`，1600×809 视口，开启底栏 + 非固定）：

| 状态 | 内容区高度 | 页脚底边 | 滚动容器 scrollHeight/clientHeight |
| --- | --- | --- | --- |
| 首渲染（修复前） | 708 | 828（溢出 19px） | 740 / 721 |
| 切页签往返后（修复前） | 688 | 808 | 720 / 720 |
| 首渲染（修复后） | 689.33 | 809.33（= 视口底） | 721 / 721 |

双向实验确认机制：对内容区手动 `min-height: 0` 或 `contain: size` 均能让首帧布局立即归位；还原 `min-height: auto` 立即复发。

## Fix

在 `Page` 的 `autoContentHeight` 分支给内容区加 `contain: 'size'`：自适应高度模式本就由内容区自己管理滚动，size containment 隔断 min-content 反馈即可。

作用域仅限 `autoContentHeight` 页面，不影响「footer 随内容滚动」等既有语义（非固定 footer + 非 Page 常规长页仍靠外层滚动）。

## Test

- playground `/system/role`：开启底栏（非固定）后整页刷新，首帧内容区 689.33、页脚贴视口底、`page-content` 内部滚动条正常出现；切页签往返前后布局一致（不再有 708→688 跳变）。
- `pnpm exec eslint` 通过。

> 浏览器实测基于 Chromium，`contain: size` 基线详见 [caniuse](https://caniuse.com/css-containment)。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page layouts using automatic content-height mode.
  * Prevented content from expanding beyond the available viewport and pushing the footer out of view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->