### PR TITLE
fix(@vben-core/layout-ui): guard sidebar hover handlers in mobile drawer mode (#8274)

### DIFF
--- a/.changeset/lucky-pandas-hover.md
+++ b/.changeset/lucky-pandas-hover.md
@@ -1,0 +1,7 @@
+---
+'@vben-core/layout-ui': patch
+---
+
+fix(@vben-core/layout-ui): guard sidebar hover handlers in mobile drawer mode
+
+移动端抽屉模式不存在 hover 语义。resize 跨断点时浏览器会对正在卸载/重排的侧栏派发合成 mouseenter/mouseleave，`handleMouseleave` 缺少 `isMobile` 守卫会把折叠态写入 `collapse` 并经 v-model 链持久化，导致窗口放大后侧栏保持折叠（#8274）。本次为 `handleMouseenter`/`handleMouseleave` 增加 `isMobile` 守卫，并附 4 项回归测试（移动端 mouseenter/mouseleave 不写状态、桌面端行为不变）。

--- a/packages/@core/ui-kit/layout-ui/src/__tests__/layout-sidebar-mobile-hover.test.ts
+++ b/packages/@core/ui-kit/layout-ui/src/__tests__/layout-sidebar-mobile-hover.test.ts
@@ -1,0 +1,138 @@
+import type { App } from 'vue';
+
+import { computed, createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import LayoutSidebar from '../components/layout-sidebar.vue';
+
+vi.mock('@vben-core/composables', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vben-core/composables')>();
+  return {
+    ...actual,
+    useScrollLock: () => computed({ get: () => false, set: () => {} }),
+  };
+});
+
+vi.mock('../../hooks/use-sidebar-drag', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../hooks/use-sidebar-drag')>();
+  return {
+    ...actual,
+    useSidebarDrag: () => ({ startDrag: vi.fn(), endDrag: vi.fn() }),
+  };
+});
+
+let activeApp: App | undefined;
+
+interface MountOptions {
+  collapse?: boolean;
+  isMobile?: boolean;
+}
+
+/**
+ * 挂载一个受控的 LayoutSidebar，验证移动端/桌面端 hover 事件对折叠状态的副作用（#8274）。
+ */
+function mountSidebar(options: MountOptions = {}) {
+  const collapse = ref(options.collapse ?? false);
+  const collapseWrites: boolean[] = [];
+  const onUpdateCollapse = vi.fn((value: boolean) => {
+    collapseWrites.push(value);
+    collapse.value = value;
+  });
+  const Consumer = defineComponent(
+    () => () =>
+      h(LayoutSidebar, {
+        collapse: collapse.value,
+        expandOnHover: false,
+        expandOnHovering: false,
+        extraCollapse: false,
+        extraVisible: false,
+        theme: 'dark',
+        themeSub: 'dark',
+        width: 180,
+        headerHeight: 50,
+        extraWidth: 60,
+        isMobile: options.isMobile ?? false,
+        'onUpdate:collapse': onUpdateCollapse,
+      }),
+  );
+  const host = document.createElement('div');
+  document.body.append(host);
+  activeApp = createApp(Consumer);
+  activeApp.mount(host);
+  return { collapseWrites, onUpdateCollapse };
+}
+
+function getAside(): HTMLElement {
+  const aside = document.querySelector('aside');
+  if (!(aside instanceof HTMLElement)) {
+    throw new TypeError('aside not rendered');
+  }
+  return aside;
+}
+
+async function fireMouse(type: 'mouseenter' | 'mouseleave') {
+  const event = new MouseEvent(type);
+  // jsdom 的合成事件 offsetX 恒为 0，会命中 handleMouseenter 的左边缘 10px 守卫；
+  // 注入 20 模拟真实悬停在菜单区
+  Object.defineProperty(event, 'offsetX', { value: 20 });
+  getAside().dispatchEvent(event);
+  await nextTick();
+  await nextTick();
+}
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('layout-sidebar mobile hover guard (#8274)', () => {
+  it('mobile: mouseleave must not write collapsed state', async () => {
+    const { collapseWrites, onUpdateCollapse } = await mountSidebar({
+      isMobile: true,
+    });
+
+    await fireMouse('mouseleave');
+
+    expect(collapseWrites).toHaveLength(0);
+    expect(onUpdateCollapse).not.toHaveBeenCalled();
+  });
+
+  it('mobile: mouseenter must not write collapsed state', async () => {
+    const { collapseWrites, onUpdateCollapse } = await mountSidebar({
+      isMobile: true,
+    });
+
+    await fireMouse('mouseenter');
+
+    expect(collapseWrites).toHaveLength(0);
+    expect(onUpdateCollapse).not.toHaveBeenCalled();
+  });
+
+  it('desktop: mouseleave still collapses the hover-expanded rail', async () => {
+    const { collapseWrites, onUpdateCollapse } = await mountSidebar({
+      isMobile: false,
+    });
+
+    await fireMouse('mouseleave');
+
+    expect(collapseWrites).toContain(true);
+    expect(onUpdateCollapse).toHaveBeenCalledWith(true);
+  });
+
+  it('desktop: mouseenter expands a collapsed rail (collapse=false)', async () => {
+    const { collapseWrites, onUpdateCollapse } = await mountSidebar({
+      isMobile: false,
+      collapse: true,
+    });
+
+    await fireMouse('mouseenter');
+
+    expect(collapseWrites).toContain(false);
+    expect(onUpdateCollapse).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/@core/ui-kit/layout-ui/src/__tests__/layout-sidebar-mobile-hover.test.ts
+++ b/packages/@core/ui-kit/layout-ui/src/__tests__/layout-sidebar-mobile-hover.test.ts
@@ -15,9 +15,9 @@ vi.mock('@vben-core/composables', async (importOriginal) => {
   };
 });
 
-vi.mock('../../hooks/use-sidebar-drag', async (importOriginal) => {
+vi.mock('../hooks/use-sidebar-drag', async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import('../../hooks/use-sidebar-drag')>();
+    await importOriginal<typeof import('../hooks/use-sidebar-drag')>();
   return {
     ...actual,
     useSidebarDrag: () => ({ startDrag: vi.fn(), endDrag: vi.fn() }),

--- a/packages/@core/ui-kit/layout-ui/src/components/layout-sidebar.vue
+++ b/packages/@core/ui-kit/layout-ui/src/components/layout-sidebar.vue
@@ -283,6 +283,11 @@ function calcMenuWidthStyle(): CSSProperties {
 }
 
 function handleMouseenter(e: MouseEvent) {
+  // 移动端抽屉模式不存在 hover 语义：合成 mouse 事件不得改写折叠状态
+  // （resize 跨断点时浏览器会对正在卸载/重排的侧栏派发 mouseenter/mouseleave）
+  if (props.isMobile) {
+    return;
+  }
   if (e?.offsetX < 10) {
     return;
   }
@@ -305,7 +310,8 @@ function handleMouseleave() {
   if (props.isSidebarMixed) {
     isLocked.value = false;
   }
-  if (expandOnHover.value) {
+  // isMobile 守卫：防止断点切换窗口期的合成 mouseleave 把折叠态写入并持久化（#8274）
+  if (expandOnHover.value || props.isMobile) {
     return;
   }
 


### PR DESCRIPTION
## Description

Fixes #8274

V5 布局在「窗口缩小（跨过 md 断点）→ 再最大化」后左侧菜单保持折叠不还原。当前 `main`（5.8.0-dev）上两组受控实验定位到根因：

## Root Cause

`layout-sidebar.vue` 的 hover 处理器缺少移动端守卫：

1. **纯 resize 流程不可复现**：受控窗口宽度序列 695 → 1600 → 700 → 1600，全程无任何指针交互，`preferences.sidebar.collapsed` 始终保持 `false`，最大化后侧栏 224px 全宽正常展开——bug 需要指针恰在侧栏区域上时才触发。
2. **触发路径**：跨断点切换时侧栏 `<aside>` 处于 `Transition`（mobile-sidebar）卸载/重排窗口，浏览器会对其派发合成 `mouseenter`/`mouseleave`。`handleMouseleave()` 没有 `isMobile` 守卫，在该窗口以 `isMobile=false` 旧值执行到桌面分支，写 `collapse.value = true`，经 `vben-layout.vue` 的 `activeSidebarCollapse` → `layout.vue` 的 `@update:sidebar-collapse` 最终 `updatePreferences({ sidebar: { collapsed: true } })` **落入持久化缓存**。已实测一次合成 mouseleave 即写盘成功。窗口放大回桌面后读到持久化的 `collapsed: true`，表现为「左侧菜单自动折叠、不还原」。

## Fix

为 `handleMouseenter`/`handleMouseleave` 增加 `isMobile` 守卫：移动端抽屉模式不存在 hover 语义，合成鼠标事件不得改写折叠状态。移动端抽屉的关闭由遮罩点击（`handleClickMask`）与头部按钮承担，不依赖 `mouseleave`，守卫不影响现有移动端交互；桌面端 hover 展开折叠轨道的行为保持不变。

桌面端 hover-leave 会把折叠态持久化到 preferences 属既有设计，本次不改。

## Test

- 新增 `packages/@core/ui-kit/layout-ui/src/__tests__/layout-sidebar-mobile-hover.test.ts`：移动端 mouseenter/mouseleave 不写折叠状态、桌面端 mouseleave 折叠与 mouseenter 展开行为不变，共 4 项。
- `pnpm exec vitest run packages/@core/ui-kit/layout-ui` 全绿；`pnpm exec eslint` 通过。
- playground 复现验证：695→1600→700→1600 受控 resize + 指针悬于侧栏，放大后侧栏恢复全宽展开，`preferences.sidebar.collapsed` 保持 `false`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar behavior when switching between mobile and desktop layouts.
  * Prevented mobile drawer hover events from incorrectly persisting a collapsed sidebar state.
  * Preserved expected hover expansion and collapse behavior on desktop.

* **Tests**
  * Added regression coverage for mobile and desktop sidebar hover interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->