### PR TITLE
style: fix oxfmt 0.65 format drift on main

### DIFF
--- a/packages/@core/composables/src/use-layout-style.ts
+++ b/packages/@core/composables/src/use-layout-style.ts
@@ -15,9 +15,11 @@ import { useCssVar } from '@vueuse/core';
 export function useLayoutContentStyle() {
   const contentElement = ref<HTMLDivElement | null>(null);
 
-  const overlayStyle = computed(
-    (): CSSProperties => ({ inset: 0, position: 'absolute', zIndex: 150 }),
-  );
+  const overlayStyle = computed((): CSSProperties => ({
+    inset: 0,
+    position: 'absolute',
+    zIndex: 150,
+  }));
 
   return { contentElement, overlayStyle };
 }

--- a/packages/@core/preferences/src/types.ts
+++ b/packages/@core/preferences/src/types.ts
@@ -76,10 +76,9 @@ type CustomPreferencesField<
   string extends Extract<keyof TCustomPreferences, string>
     ? AnyCustomPreferencesField
     : {
-        [K in Extract<
-          keyof TCustomPreferences,
-          string
-        >]: TCustomPreferences[K] extends boolean
+        [
+          K in Extract<keyof TCustomPreferences, string>
+        ]: TCustomPreferences[K] extends boolean
           ? CustomPreferencesSwitchField<K>
           : TCustomPreferences[K] extends number
             ? CustomPreferencesNumberField<K>

--- a/packages/effects/plugins/src/vxe-table/use-vxe-grid.ts
+++ b/packages/effects/plugins/src/vxe-table/use-vxe-grid.ts
@@ -14,9 +14,9 @@ import { VxeGridApi } from './api';
 import VxeGrid from './use-vxe-grid.vue';
 
 type FilteredSlots<T> = {
-  [K in keyof VxeGridSlots<T> as K extends 'form'
-    ? never
-    : K]: VxeGridSlots<T>[K];
+  [
+    K in keyof VxeGridSlots<T> as K extends 'form' ? never : K
+  ]: VxeGridSlots<T>[K];
 };
 
 export function useVbenVxeGrid<


### PR DESCRIPTION
## Description

`vsh lint` 的 `oxfmt --check`（oxfmt 0.65.0）在当前 main（38b84fdc0）上报出 3 个文件的格式漂移，导致所有基于 main 的 PR（如 #8326）Lint 必挂：

- packages/@core/composables/src/use-layout-style.ts
- packages/@core/preferences/src/types.ts
- packages/effects/plugins/src/vxe-table/use-vxe-grid.ts

实证：CI job 99103397995（Lint ubuntu-latest，12:54:39Z）输出 "Format issues found in above 3 files"，3 个文件均不在 #8326 改动范围内。

## Fix

仅对上述 3 个文件跑 `oxfmt` 自动格式化，无任何语义改动。

## Test

- `pnpm exec oxfmt --check` 对 3 文件通过
- `pnpm exec vitest run packages/@core/composables packages/@core/preferences` 全绿（如有）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and consistency across layout styling, preference definitions, and grid slot handling.
  * No user-facing behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->