### PR TITLE
fix(@vben-core/preferences): avoid unscoped storage before init

### DIFF
--- a/.changeset/quiet-caches-wait.md
+++ b/.changeset/quiet-caches-wait.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/preferences': patch
+---
+
+fix(@vben-core/preferences): avoid unscoped localStorage before initialization

--- a/packages/@core/preferences/__tests__/preferences.test.ts
+++ b/packages/@core/preferences/__tests__/preferences.test.ts
@@ -61,6 +61,44 @@ describe('preferences', () => {
     expect(preferences).toEqual(defaultPreferences);
   });
 
+  it('uses memory storage until preferences are initialized', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    try {
+      const manager = new PreferenceManager();
+      manager.updatePreferences({ app: { locale: 'en-US' } });
+      await vi.advanceTimersByTimeAsync(151);
+
+      expect(localStorage.setItem).not.toHaveBeenCalled();
+
+      await manager.initPreferences({
+        namespace: 'testNamespace',
+      });
+      vi.mocked(localStorage.setItem).mockClear();
+
+      manager.updatePreferences({ app: { locale: 'en-US' } });
+      await vi.advanceTimersByTimeAsync(151);
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'testNamespace-preferences',
+        expect.any(String),
+      );
+      expect(
+        vi
+          .mocked(localStorage.setItem)
+          .mock.calls.every(([key]) => key.startsWith('testNamespace-')),
+      ).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('empty prefix'),
+      );
+    } finally {
+      vi.clearAllTimers();
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('initializes preferences with overrides', async () => {
     const overrides: any = {
       app: {

--- a/packages/@core/preferences/src/preferences.ts
+++ b/packages/@core/preferences/src/preferences.ts
@@ -10,7 +10,7 @@ import type {
 
 import { markRaw, reactive, readonly, watch } from 'vue';
 
-import { StorageManager } from '@vben-core/shared/cache';
+import { MemoryStorageDriver, StorageManager } from '@vben-core/shared/cache';
 import {
   isMacOs,
   merge,
@@ -44,7 +44,7 @@ class PreferenceManager {
   private state: Preferences;
 
   constructor() {
-    this.cache = new StorageManager();
+    this.cache = new StorageManager({ driver: new MemoryStorageDriver() });
     // 构造函数不再同步读取缓存，使用默认值初始化
     // 真正的缓存加载在 initPreferences 中完成（已经是 async）
     this.state = reactive<Preferences>({ ...defaultPreferences });


### PR DESCRIPTION
## Description

`PreferenceManager` constructed a default `StorageManager` before the application namespace was available. In browsers this selected `LocalStorageDriver` with an empty prefix, which emitted a warning on every startup and allowed pre-initialization debounced updates to target unscoped keys.

This change keeps the placeholder cache in memory until `initPreferences()` replaces it with the existing namespaced persistent storage. The regression test covers the full lifecycle: no empty-prefix warning or localStorage writes before initialization, followed by namespaced writes after initialization.

This addresses only the StorageManager warning reported in #8328. It does not claim to resolve the separate `startTime` exception from an anonymous Chrome DevTools script.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Does not modify `pnpm-lock.yaml`

## Verification

- `pnpm exec vitest run packages/@core/preferences/__tests__/preferences.test.ts --reporter=verbose`
- `pnpm exec oxfmt --check packages/@core/preferences/src/preferences.ts packages/@core/preferences/__tests__/preferences.test.ts .changeset/quiet-caches-wait.md`
- `pnpm exec oxlint packages/@core/preferences/src/preferences.ts packages/@core/preferences/__tests__/preferences.test.ts`
- `pnpm exec turbo run typecheck --filter=@vben/playground --force`
- Verified in a clean Playwright Chromium session that the startup warning is gone

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No documentation changes are required
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing targeted unit tests pass locally
- [x] No dependent changes are required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preference updates occurring before initialization so they remain safely in memory.
  * Prevented unscoped local storage access and unnecessary warnings during startup.
  * Ensured preferences persist correctly after initialization using the configured namespace.

* **Tests**
  * Added coverage for pre-initialization updates, persistence behavior, and warning suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->