### PR TITLE
fix(@vben/layouts): keep notification dot circular

### DIFF
--- a/.changeset/gentle-bells-ring.md
+++ b/.changeset/gentle-bells-ring.md
@@ -1,0 +1,5 @@
+---
+'@vben/layouts': patch
+---
+
+fix(@vben/layouts): keep the notification status indicator circular across theme radii

--- a/packages/effects/layouts/src/widgets/notification/__tests__/notification.test.ts
+++ b/packages/effects/layouts/src/widgets/notification/__tests__/notification.test.ts
@@ -1,0 +1,33 @@
+import type { App } from 'vue';
+
+import { createApp, h } from 'vue';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import Notification from '../notification.vue';
+
+let activeApp: App | undefined;
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+});
+
+describe('notification popup', () => {
+  it('renders the notification status indicator as a circle', () => {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    activeApp = createApp({
+      render: () => h(Notification, { dot: true }),
+    });
+    activeApp.mount(host);
+
+    const indicator = host.querySelector<HTMLElement>('.bell-button > span');
+
+    expect(indicator).not.toBeNull();
+    expect(indicator?.classList).toContain('rounded-full');
+    expect(indicator?.classList).not.toContain('rounded-sm');
+  });
+});

--- a/packages/effects/layouts/src/widgets/notification/notification.vue
+++ b/packages/effects/layouts/src/widgets/notification/notification.vue
@@ -65,7 +65,7 @@ defineExpose({ toggle });
         <VbenIconButton class="bell-button relative text-foreground">
           <span
             v-if="dot"
-            class="absolute top-0.5 right-0.5 size-2 rounded-sm bg-primary"
+            class="absolute top-0.5 right-0.5 size-2 rounded-full bg-primary"
           ></span>
           <Bell class="size-4" />
         </VbenIconButton>


### PR DESCRIPTION
## Description

Fixes #8250.

The notification indicator is an 8px status dot, but it currently uses `rounded-sm`. That radius is theme-dependent and leaves the indicator visibly square in the light theme shown in the issue.

This change:

- uses `rounded-full` so the status indicator remains circular regardless of the configured small radius;
- adds a component regression test that mounts `Notification` through its public `dot` prop and locks the circular class;
- adds an `@vben/layouts` patch changeset.

The regression test was run against the baseline first and failed on `rounded-sm`, then passed with this fix.

## Verification

- `pnpm exec vitest run --dom packages/effects/layouts/src` - 2 files, 6 tests passed.
- Package Vue typecheck passed.
- Commit hooks passed: oxlint, oxfmt, ESLint, stylelint, workspace typecheck, and commitlint.
- `git diff --check` passed.

Two full `pnpm test` runs exposed the existing intermittent `form-integration.test.ts` failure (504/505 and 503/505); the failing case passed when rerun alone. The changed layouts package tests are consistently green.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [x] If you introduce new functionality, document it. Not applicable; this restores the existing status-dot appearance.
- [x] Run the tests with `pnpm test`.
- [x] Changes in changelog are generated from PR name. The patch changeset starts with `fix:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. No new non-obvious logic was added.
- [x] I have made corresponding changes to the documentation. Not applicable; no API or usage changed.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests in the affected package pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules. Not applicable; there are no dependent changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the notification status indicator so it consistently displays as a circle across different theme settings.

* **Tests**
  * Added coverage to verify the notification indicator uses the circular styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->