### PR TITLE
docs: update global loading plugin references

### DIFF
--- a/docs/src/en/guide/in-depth/loading.md
+++ b/docs/src/en/guide/in-depth/loading.md
@@ -6,7 +6,7 @@ Global loading refers to the loading effect that appears when the page is refres
 
 ## Principle
 
-Implemented by the `vite-plugin-inject-app-loading` plugin, the plugin injects a global `loading html` into each application.
+The built-in `inject-app-loading` plugin implements this behavior. Its source is in `internal/vite-config/src/plugins/inject-app-loading`, and it injects global loading HTML into each application.
 
 ## Disable
 
@@ -19,6 +19,8 @@ VITE_INJECT_APP_LOADING=false
 ## Customization
 
 If you want to customize the global loading, you can create a `loading.html` file in the application directory, at the same level as `index.html`. The plugin will automatically read and inject this HTML. You can define the style and animation of this HTML as you wish.
+
+The built-in default template is available at `internal/vite-config/src/plugins/inject-app-loading/default-loading.html` for reference.
 
 ::: tip
 

--- a/docs/src/guide/in-depth/loading.md
+++ b/docs/src/guide/in-depth/loading.md
@@ -6,7 +6,7 @@
 
 ## 原理
 
-由 `vite-plugin-inject-app-loading` 插件实现，插件会在每个应用都注入一个全局的 `loading html`。
+由项目内置的 `inject-app-loading` 插件实现。源码位于 `internal/vite-config/src/plugins/inject-app-loading`，插件会在每个应用中注入全局 `loading HTML`。
 
 ## 关闭
 
@@ -19,6 +19,8 @@ VITE_INJECT_APP_LOADING=false
 ## 自定义
 
 如果你想要自定义全局 loading，可以在应用目录下，与`index.html`同级，创建一个`loading.html`文件，插件会自动读取并注入。这个html可以自行定义样式和动画。
+
+项目内置的默认模板位于 `internal/vite-config/src/plugins/inject-app-loading/default-loading.html`，可作为自定义参考。
 
 ::: tip
 


### PR DESCRIPTION
## Description

The global loading guides still refer to `vite-plugin-inject-app-loading`, although the implementation is now the repository's built-in `inject-app-loading` plugin.

This change:

- uses the current plugin name in both the Chinese and English guides;
- points readers to `internal/vite-config/src/plugins/inject-app-loading`;
- documents the built-in `default-loading.html` as the reference for custom templates.

Closes #8225.

## Verification

- `pnpm exec oxfmt --check docs/src/guide/in-depth/loading.md docs/src/en/guide/in-depth/loading.md`
- `pnpm build:docs`
- `pnpm lint` (0 errors; 7 pre-existing warnings in unrelated test files)
- pre-commit typecheck (6/6 tasks passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the loading guide to describe the built-in global loading plugin.
  * Added guidance on locating the default loading template for customization.
  * Applied the updates consistently across English documentation versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->