### PR TITLE
fix(@vben/common-ui): bridge custom ApiComponent model props (#8268)

### DIFF
--- a/.changeset/calm-apes-select.md
+++ b/.changeset/calm-apes-select.md
@@ -1,0 +1,5 @@
+---
+'@vben/common-ui': patch
+---
+
+fix: forward ApiComponent updates for custom model value props

--- a/packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts
+++ b/packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, markRaw, nextTick, ref } from 'vue';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import ApiComponent from '../api-component.vue';
+
+const ValueInput = defineComponent({
+  name: 'ValueInput',
+  props: {
+    value: { type: String, default: undefined },
+  },
+  emits: ['update:value'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'button',
+        { onClick: () => emit('update:value', 'selected') },
+        props.value,
+      );
+  },
+});
+
+const ModelValueInput = defineComponent({
+  name: 'ModelValueInput',
+  props: {
+    modelValue: { type: String, default: undefined },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'button',
+        { onClick: () => emit('update:modelValue', 'selected') },
+        props.modelValue,
+      );
+  },
+});
+
+const KebabModelInput = defineComponent({
+  name: 'KebabModelInput',
+  props: {
+    modelValue: { type: String, default: undefined },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'button',
+        { onClick: () => emit('update:modelValue', 'selected') },
+        props.modelValue,
+      );
+  },
+});
+
+describe('api-component.vue', () => {
+  it('bridges a custom model prop in both directions', async () => {
+    const outerValue = ref('initial');
+    const handleUpdate = vi.fn((value: string) => {
+      outerValue.value = value;
+    });
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h(ApiComponent, {
+            component: markRaw(ValueInput),
+            modelPropName: 'value',
+            value: outerValue.value,
+            'onUpdate:value': handleUpdate,
+          });
+      },
+    });
+    const wrapper = mount(Harness);
+    const input = wrapper.findComponent(ValueInput);
+
+    expect(input.props('value')).toBe('initial');
+
+    await input.trigger('click');
+    await nextTick();
+    expect(handleUpdate).toHaveBeenCalledWith('selected');
+    expect(input.props('value')).toBe('selected');
+
+    outerValue.value = 'external';
+    await nextTick();
+    expect(input.props('value')).toBe('external');
+  });
+
+  it('preserves the default modelValue protocol', async () => {
+    const wrapper = mount(ApiComponent, {
+      props: {
+        component: markRaw(ModelValueInput),
+        modelValue: 'initial',
+      },
+    });
+    const input = wrapper.findComponent(ModelValueInput);
+
+    expect(input.props('modelValue')).toBe('initial');
+
+    await input.trigger('click');
+    await nextTick();
+    expect(wrapper.emitted('update:modelValue')).toEqual([['selected']]);
+    expect(input.props('modelValue')).toBe('selected');
+  });
+
+  it('bridges a kebab-case custom model prop', async () => {
+    const outerValue = ref('initial');
+    const handleUpdate = vi.fn((value: string) => {
+      outerValue.value = value;
+    });
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h(ApiComponent, {
+            component: markRaw(KebabModelInput),
+            modelPropName: 'model-value',
+            'model-value': outerValue.value,
+            'onUpdate:model-value': handleUpdate,
+          });
+      },
+    });
+    const wrapper = mount(Harness);
+    const input = wrapper.findComponent(KebabModelInput);
+
+    expect(input.props('modelValue')).toBe('initial');
+
+    await input.trigger('click');
+    await nextTick();
+    expect(handleUpdate).toHaveBeenCalledWith('selected');
+    expect(input.props('modelValue')).toBe('selected');
+  });
+});

--- a/packages/effects/common-ui/src/components/api-component/api-component.vue
+++ b/packages/effects/common-ui/src/components/api-component/api-component.vue
@@ -44,6 +44,14 @@ const emit = defineEmits<{
 const modelValue = defineModel<any>({ default: undefined });
 
 const attrs = useAttrs();
+const usesDefaultModelValue = computed(() => {
+  return ['model-value', 'modelValue'].includes(props.modelPropName);
+});
+const currentModelValue = computed(() => {
+  return usesDefaultModelValue.value
+    ? modelValue.value
+    : attrs[props.modelPropName];
+});
 const innerParams = ref({});
 const refOptions = ref<OptionsItem[]>([]);
 const loading = ref(false);
@@ -89,13 +97,14 @@ const getOptions = computed(() => {
 });
 
 const bindProps = computed(() => {
+  const updateEvent = `onUpdate:${props.modelPropName}`;
   return {
-    [props.modelPropName]: unref(modelValue),
+    [props.modelPropName]: unref(currentModelValue),
     [props.optionsPropName]: unref(getOptions),
-    [`onUpdate:${props.modelPropName}`]: (val: string) => {
-      modelValue.value = val;
+    [updateEvent]: (val: string) => {
+      updateModelValue(val);
     },
-    ...objectOmit(attrs, [`onUpdate:${props.modelPropName}`]),
+    ...objectOmit(attrs, [props.modelPropName, updateEvent]),
     ...(props.visibleEvent
       ? {
           [props.visibleEvent]: handleFetchForVisible,
@@ -103,6 +112,17 @@ const bindProps = computed(() => {
       : {}),
   };
 });
+
+function updateModelValue(value: any) {
+  if (usesDefaultModelValue.value) {
+    modelValue.value = value;
+    return;
+  }
+  const updateHandler = attrs[`onUpdate:${props.modelPropName}`];
+  if (isFunction(updateHandler)) {
+    updateHandler(value);
+  }
+}
 
 async function fetchApi() {
   const { api, beforeFetch, shouldFetch, afterFetch, resultField } = props;
@@ -192,7 +212,7 @@ watch(
 
 function emitChange() {
   if (
-    modelValue.value === undefined &&
+    currentModelValue.value === undefined &&
     props.autoSelect &&
     unref(getOptions).length > 0
   ) {
@@ -218,7 +238,7 @@ function emitChange() {
       }
     }
 
-    if (firstOption) modelValue.value = firstOption.value;
+    if (firstOption) updateModelValue(firstOption.value);
   }
   emit('optionsChange', unref(getOptions));
 }
@@ -227,7 +247,7 @@ defineExpose({
   /** 获取options数据 */
   getOptions: () => unref(getOptions),
   /** 获取当前值 */
-  getValue: () => unref(modelValue),
+  getValue: () => unref(currentModelValue),
   /** 获取被包装的组件实例 */
   getComponentRef: <T = any>() => componentRef.value as T,
   /** 更新Api参数 */


### PR DESCRIPTION
## Description

Fixes #8268.

ApiComponent bound its internal model value and update handler before spreading $attrs. For adapters that use a custom model prop such as Naive UI's value, the stale outer value attribute overwrote a new selection and the outer onUpdate:value handler was omitted, so selecting an option did not update the form.

This change:

- resolves the current value from modelValue/model-value or the configured custom model attribute;
- forwards custom model updates to the corresponding outer update handler;
- omits the handled value and update attributes before forwarding the remaining attributes;
- uses the same bridge for autoSelect and the exposed getValue();
- adds regression coverage for value, modelValue, and kebab-case model-value protocols.

The regression test fails on main because onUpdate:value is never called, then passes with this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] No changes to pnpm-lock.yaml

## Checklist

- [x] No new functionality or documentation change is required
- [x] pnpm test:unit packages/effects/common-ui/src/components/api-component packages/effects/common-ui/src/components/icon-picker/__tests__/icon-picker.test.ts
- [x] pnpm exec oxfmt --check on all changed files
- [x] pnpm exec oxlint --type-aware on the changed source and test files
- [x] pnpm --filter @vben/web-naive typecheck
- [x] pnpm --filter @vben/web-ele typecheck
- [x] The changeset uses a fix: prefix
- [x] I performed a self-review
- [x] Tests prove the fix and existing related component tests pass
- [x] No dependent downstream change is required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ApiComponent` support for custom model-value property names.
  * Ensured value updates are correctly forwarded in both directions for custom, default, and kebab-case model bindings.
  * Improved value handling for automatic selection and exposed value retrieval.

* **Tests**
  * Added coverage for custom model properties, default `modelValue`, and kebab-case bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->