### PR TITLE
fix(@vben-core/preferences): sync theme before reset persistence

### DIFF
--- a/.changeset/calm-themes-reset.md
+++ b/.changeset/calm-themes-reset.md
@@ -1,5 +1,5 @@
 ---
-"@vben-core/preferences": patch
+'@vben-core/preferences': patch
 ---
 
 fix: apply preference reset theme updates before cache persistence

--- a/.changeset/calm-themes-reset.md
+++ b/.changeset/calm-themes-reset.md
@@ -1,0 +1,5 @@
+---
+"@vben-core/preferences": patch
+---
+
+fix: apply preference reset theme updates before cache persistence

--- a/packages/@core/preferences/__tests__/preferences.test.ts
+++ b/packages/@core/preferences/__tests__/preferences.test.ts
@@ -157,6 +157,22 @@ describe('preferences', () => {
     expect(preferenceManager.getPreferences()).toEqual(defaultPreferences);
   });
 
+  it('applies reset side effects before persisting preferences', async () => {
+    preferenceManager.updatePreferences({
+      theme: {
+        mode: 'light',
+      },
+    });
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    const resetPromise = preferenceManager.resetPreferences();
+
+    expect(preferenceManager.getPreferences().theme.mode).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    await resetPromise;
+  });
+
   it('updates isMobile correctly', () => {
     // 模拟移动端状态
     vi.stubGlobal(

--- a/packages/@core/preferences/src/preferences.ts
+++ b/packages/@core/preferences/src/preferences.ts
@@ -177,11 +177,11 @@ class PreferenceManager {
     Object.assign(this.state, this.initialPreferences);
     this.replaceCustomPreferences(this.initialCustomPreferences);
 
-    // 保存偏好设置至缓存
-    await this.saveToCache();
-
     // 直接触发 UI 更新
     this.handleUpdates(this.state);
+
+    // 保存偏好设置至缓存
+    await this.saveToCache();
   };
 
   /**


### PR DESCRIPTION
## Description

Fixes #8209.

`resetPreferences()` updated the reactive preference state, awaited cache persistence, and only then applied the HTML class and CSS-variable side effects. Vue theme adapter watchers could run during that await window and read the previous light CSS variables into their component-library tokens. The later dark-class update did not retrigger those watchers, leaving Ant Design components light inside a dark shell.

This change applies reset side effects before the first await, so the DOM theme and CSS variables are consistent with the new preference state before reactive watchers flush.

The regression test asserts that both the state and `html.dark` are restored immediately when reset starts, before its persistence promise resolves. A browser verification on the Ant Design demo also confirmed that, with the logout request held pending, Button and Card backgrounds return from the light values to their original dark values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] No changes to pnpm-lock.yaml

## Checklist

- [x] No new functionality or documentation change is required
- [x] `pnpm vitest run --dom packages/@core/preferences/__tests__/preferences.test.ts` (27/27)
- [x] `pnpm exec oxfmt --check` on all changed files
- [x] `pnpm exec oxlint --type-aware` on the changed source and test files
- [x] `pnpm exec eslint` on the changed source and test files
- [x] `pnpm exec changeset status`
- [x] The changeset uses a `fix:` prefix
- [x] I performed a self-review
- [x] Tests prove the fix and the targeted tests pass locally
- [x] The original Ant Design browser scenario passes with logout held pending
- [x] No dependent downstream change is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preference resets now update the theme immediately, before settings persistence completes.
  * Resetting preferences correctly applies the selected theme and dark-mode styling without delay.

* **Tests**
  * Added coverage to verify immediate theme updates during preference resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->