### PR TITLE
fix: sync IconPicker selections with configured model

### DIFF
--- a/packages/effects/common-ui/src/components/icon-picker/__tests__/icon-picker.test.ts
+++ b/packages/effects/common-ui/src/components/icon-picker/__tests__/icon-picker.test.ts
@@ -173,4 +173,27 @@ describe('icon-picker.vue', () => {
 
     wrapper.unmount();
   });
+
+  it('updates the configured model value when selecting an icon', async () => {
+    const onUpdateValue = vi.fn();
+    const wrapper = mount(IconPicker, {
+      attachTo: document.body,
+      props: {
+        icons: STATIC_ICONS,
+        inputComponent: markRaw(AntdvNextLikeInput),
+        modelValueProp: 'value',
+        prefix: '',
+        'onUpdate:value': onUpdateValue,
+      },
+    });
+    await openIconPicker(wrapper);
+
+    const firstIcon = document.body.querySelector('.grid-cols-6 > button');
+    expect(firstIcon).toBeTruthy();
+    await new DOMWrapper(firstIcon as Element).trigger('click');
+
+    expect(onUpdateValue).toHaveBeenCalledWith('home');
+
+    wrapper.unmount();
+  });
 });

--- a/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
+++ b/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
@@ -111,8 +111,7 @@ watch(
 );
 
 const handleClick = (icon: string) => {
-  currentSelect.value = icon;
-  modelValue.value = icon;
+  updateCurrentSelect(icon);
   close();
 };
 


### PR DESCRIPTION
## Description

Fixes #8333.

When IconPicker used a custom model property such as value, selecting an icon only updated its internal modelValue. The form adapter's onUpdate:value callback was not invoked, so the selected icon did not reach the input or form state.

This change routes icon selection through the existing updateCurrentSelect function so both the default modelValue protocol and configured model protocols stay in sync. It also adds a regression test covering icon selection with value/onUpdate:value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] No changes to pnpm-lock.yaml

## Checklist

- [x] Documentation is not required for this behavior-only bug fix
- [x] Ran the full unit test suite with pnpm test:unit
- [x] The PR title clearly describes the change and uses the fix prefix
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The change is simple and does not require additional explanatory comments
- [x] My changes generate no new warnings
- [x] I have added a regression test that proves the fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] No dependent downstream changes are required

## Verification

- pnpm lint
- pnpm check:type
- pnpm test:unit (70 files, 518 tests passed)
- Manual verification in the playground VbenForm basic example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed icon picker selections so the chosen icon value is correctly synchronized and emitted through the configured update event.
  - Selecting an icon now reliably closes the picker after updating the value.

- **Tests**
  - Added coverage confirming that selecting the first icon updates the value to `home`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->