### PR TITLE
chore(eslint-config): 关闭 perfectionist 语义排序相关规则

### DIFF
--- a/internal/lint-configs/eslint-config/src/configs/perfectionist.ts
+++ b/internal/lint-configs/eslint-config/src/configs/perfectionist.ts
@@ -11,6 +11,9 @@ export async function perfectionist(): Promise<Linter.Config[]> {
     perfectionistPlugin.configs['recommended-natural'],
     {
       rules: {
+        'perfectionist/sort-enums': 'off',
+        'perfectionist/sort-interfaces': 'off',
+        'perfectionist/sort-switch-case': 'off',
         'perfectionist/sort-exports': [
           'error',
           {
@@ -85,6 +88,7 @@ export async function perfectionist(): Promise<Linter.Config[]> {
             type: 'natural',
           },
         ],
+        'perfectionist/sort-object-types': 'off',
         'perfectionist/sort-objects': [
           'off',
           {


### PR DESCRIPTION
关闭 sort-enums、sort-interfaces、sort-switch-case 和
sort-object-types，允许枚举成员、interface/type 成员及 switch 分支 按语义或数值顺序（如状态码按码值）排列，而非强制字母序。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal linting configuration to disable several automatic sorting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->