### PR TITLE
fix(eslint-config): disable unsafe catalog autofixes

### DIFF
--- a/internal/lint-configs/eslint-config/src/configs/pnpm.test.ts
+++ b/internal/lint-configs/eslint-config/src/configs/pnpm.test.ts
@@ -1,5 +1,11 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { ESLint } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
+import { jsonc } from './jsonc';
 import { pnpm } from './pnpm';
 
 describe('pnpm eslint config', () => {
@@ -10,5 +16,55 @@ describe('pnpm eslint config', () => {
       'error',
       { autofix: false },
     ]);
+  });
+
+  it('does not change an invalid catalog during an ESLint autofix run', async () => {
+    const fixtureDirectory = await mkdtemp(
+      join(tmpdir(), 'vben-pnpm-catalog-'),
+    );
+    const packageJsonPath = join(fixtureDirectory, 'package.json');
+    const workspacePath = join(fixtureDirectory, 'pnpm-workspace.yaml');
+    const packageJson = `${JSON.stringify(
+      {
+        name: 'catalog-fixture',
+        private: true,
+        dependencies: {
+          'missing-catalog-package': 'catalog:missing',
+        },
+      },
+      null,
+    )}\n`;
+    const workspace = 'packages: []\ncatalog:\n  existing-package: ^1.0.0\n';
+
+    try {
+      await writeFile(packageJsonPath, packageJson);
+      await writeFile(workspacePath, workspace);
+
+      const eslint = new ESLint({
+        cwd: fixtureDirectory,
+        fix: true,
+        overrideConfig: [...(await jsonc()), ...(await pnpm())],
+        overrideConfigFile: true,
+      });
+      const [result] = await eslint.lintFiles(['package.json']);
+
+      expect(result?.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            ruleId: 'pnpm/json-valid-catalog',
+          }),
+        ]),
+      );
+      expect(result?.output).toBeUndefined();
+
+      // The rule queues workspace writes asynchronously when autofixes are enabled.
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      await expect(readFile(packageJsonPath, 'utf8')).resolves.toBe(
+        packageJson,
+      );
+      await expect(readFile(workspacePath, 'utf8')).resolves.toBe(workspace);
+    } finally {
+      await rm(fixtureDirectory, { force: true, recursive: true });
+    }
   });
 });

--- a/internal/lint-configs/eslint-config/src/configs/pnpm.test.ts
+++ b/internal/lint-configs/eslint-config/src/configs/pnpm.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { pnpm } from './pnpm';
+
+describe('pnpm eslint config', () => {
+  it('reports invalid catalog entries without applying autofixes', async () => {
+    const [packageJsonConfig] = await pnpm();
+
+    expect(packageJsonConfig?.rules?.['pnpm/json-valid-catalog']).toEqual([
+      'error',
+      { autofix: false },
+    ]);
+  });
+});

--- a/internal/lint-configs/eslint-config/src/configs/pnpm.ts
+++ b/internal/lint-configs/eslint-config/src/configs/pnpm.ts
@@ -18,7 +18,7 @@ export async function pnpm(): Promise<Linter.Config[]> {
       rules: {
         'pnpm/json-enforce-catalog': 'error',
         'pnpm/json-prefer-workspace-settings': 'error',
-        'pnpm/json-valid-catalog': 'error',
+        'pnpm/json-valid-catalog': ['error', { autofix: false }],
       },
     },
     {


### PR DESCRIPTION
## Summary

- keep `pnpm/json-valid-catalog` enabled as an error while disabling its automatic file writes
- prevent a stale cached workspace snapshot from replacing a newly checked-out catalog entry with `^0.0.0`
- add a config regression test for the non-mutating lint contract

Closes #8137

## Root cause

`eslint-plugin-pnpm` 1.8.0 caches the parsed workspace, while `json-valid-catalog` defaults both `autofix` and `autoInsert` to `true`. During a quick branch switch, the rule can inspect a new `package.json` through the old workspace snapshot and queue an asynchronous `pnpm-workspace.yaml` update using its default `^0.0.0` specifier.

This repository's ESLint config is private, so disabling this one rule's fixer is a narrow fail-safe: invalid catalog references are still reported, but lint can no longer overwrite the catalog with stale data.

## Reproduction

Using one ESLint instance against the current dependency versions:

1. linted a workspace snapshot containing only the existing `vue` catalog entry
2. replaced the on-disk workspace with a new `tinymce: 7.6.1` entry inside the plugin's cache window
3. linted a package that referenced `tinymce: catalog:`

Before this change, the queued fix overwrote the valid entry with `tinymce: ^0.0.0` after about 1.3 seconds and emitted an `ESLintCircularFixesWarning`. With `autofix: false`, ESLint still reports the stale-snapshot catalog error, but `tinymce: 7.6.1` remains unchanged.

## Verification

- `pnpm exec vitest run --dom internal/lint-configs/eslint-config/src/configs/pnpm.test.ts`
- `pnpm run test:unit` (71 files, 518 tests)
- `pnpm run lint` (0 errors)
- `pnpm run check:type` (6/6 packages)
- `pnpm --filter @vben/eslint-config run stub`
- `pnpm exec oxfmt --check internal/lint-configs/eslint-config/src/configs/pnpm.ts internal/lint-configs/eslint-config/src/configs/pnpm.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for pnpm catalog entries by reporting invalid values without automatically modifying them.
  * Added coverage to verify invalid catalog entries and preserve project files during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->