### PR TITLE
fix(@vben-core/shadcn-ui): fix tooltip arrow stroke & entry slide

### DIFF
--- a/packages/@core/ui-kit/shadcn-ui/src/components/tooltip/tooltip.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/components/tooltip/tooltip.vue
@@ -35,7 +35,7 @@ withDefaults(defineProps<Props>(), {
         :class="contentClass"
         :side="side"
         :style="contentStyle"
-        class="side-content bg-accent text-popover-foreground rounded-md"
+        class="bg-accent text-popover-foreground rounded-md"
       >
         <slot></slot>
       </TooltipContent>

--- a/packages/@core/ui-kit/shadcn-ui/src/ui/tooltip/TooltipContent.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/ui/tooltip/TooltipContent.vue
@@ -49,7 +49,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       "
     >
       <slot></slot>
-      <TooltipArrow class="fill-accent stroke-gray-200" />
+      <TooltipArrow class="fill-accent stroke-border" />
     </TooltipContent>
   </TooltipPortal>
 </template>


### PR DESCRIPTION
## Description

Two related tooltip polish fixes in `@vben-core/shadcn-ui`, both found while using tooltips with the pointing arrow enabled:

### 1. Entry animation: 50px slide is too large for a pointing tooltip

`VbenTooltip` (components/tooltip/tooltip.vue) passes `side-content` on the content, which maps to the global animation in `design/css/ui.css`:

```css
.side-content[data-side='top'] { animation-name: slide-up; }
@keyframes slide-up {
  from { opacity: 0; transform: translateY(-50px); }
  to   { opacity: 1; transform: translateY(0); }
}
.side-content { animation-duration: 0.3s; animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1); }
```

A tooltip's arrow is a *pointing semantic element*. With a 50px slide + a long ease-out tail (`cubic-bezier(0.16, 1, 0.3, 1)`), the arrow slowly "settles" toward the anchor during the last part of the animation, which reads as the arrow re-positioning / jittering after the bubble appeared. This is especially noticeable in dark mode where the arrow is clearly visible (see #2 below).

Note that the base `TooltipContent` already ships the standard shadcn entry animation (`animate-in fade-in-0 zoom-in-95 data-[side=top]:slide-in-from-bottom-2`), but it is fully overridden by `.side-content` — i.e. dead classes today.

**Fix**: drop `side-content` from VbenTooltip's content class so the tooltip falls back to the built-in 150ms fade + 8px slide. Popovers / hover-cards / context-menus (no arrow, larger surfaces) keep the global `.side-content` animation unchanged.

### 2. Arrow stroke is hard-coded light gray

```html
<TooltipArrow class="fill-accent stroke-gray-200" />
```

`stroke-gray-200` does not follow the theme. In dark mode the light gray outline around the arrow stands out harshly against the dark bubble/page. 

**Fix**: `stroke-gray-200` → `stroke-border` so the outline follows the theme border color (visually identical in light mode, correctly subtle in dark mode).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

- [x] The commit message follows our guidelines
- [x] My code follows the code style of the project (oxfmt/oxlint/eslint/stylelint passed via lefthook)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A - style-only change)
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tooltip styling to better align with the active theme.
  * Removed unnecessary side-content styling from tooltip content.
  * Updated tooltip arrow borders to use the theme’s border color instead of fixed gray.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->