### PR TITLE
feat(@vben/layouts): support activePath breadcrumb hierarchy

### DIFF
--- a/.changeset/kind-cats-breadcrumb.md
+++ b/.changeset/kind-cats-breadcrumb.md
@@ -1,0 +1,6 @@
+---
+'@vben-core/typings': minor
+'@vben/layouts': minor
+---
+
+feat: support using the activePath route hierarchy in breadcrumbs

--- a/docs/src/en/guide/essentials/route.md
+++ b/docs/src/en/guide/essentials/route.md
@@ -315,6 +315,11 @@ interface RouteMeta {
    */
   activePath?: string;
   /**
+   * Whether to use the route hierarchy resolved from activePath in breadcrumbs
+   * @default false
+   */
+  breadcrumbUseActivePath?: boolean;
+  /**
    * Whether to fix the tab
    * @default false
    */
@@ -507,6 +512,13 @@ Used to configure the badge color of the page.
 - Default: `''`
 
 Used to configure the currently active menu. Sometimes the page is not displayed in the menu, and this is used to activate the parent menu.
+
+### breadcrumbUseActivePath
+
+- Type: `boolean`
+- Default: `false`
+
+When set to `true`, the breadcrumb supplements the current route matches with the route hierarchy resolved from `activePath`. This is useful for detail pages and other routes that are not nested under the target menu route but still need to display the complete breadcrumb hierarchy.
 
 ### affixTab
 

--- a/docs/src/guide/essentials/route.md
+++ b/docs/src/guide/essentials/route.md
@@ -308,6 +308,11 @@ interface RouteMeta {
    */
   activePath?: string;
   /**
+   * 是否使用 activePath 对应的路由层级生成面包屑
+   * @default false
+   */
+  breadcrumbUseActivePath?: boolean;
+  /**
    * 是否固定标签页
    * @default false
    */
@@ -515,6 +520,13 @@ interface RouteMeta {
 - 默认值：`''`
 
 用于配置当前激活的菜单，有时候页面没有显示在菜单内，需要激活父级菜单时使用。
+
+### breadcrumbUseActivePath
+
+- 类型：`boolean`
+- 默认值：`false`
+
+设置为 `true` 时，面包屑会使用 `activePath` 对应的路由层级补充当前路由的匹配记录。适用于详情页等未嵌套在目标菜单路由下，但仍需要展示完整面包屑层级的页面。
 
 ### affixTab
 

--- a/packages/@core/base/typings/src/vue-router.d.ts
+++ b/packages/@core/base/typings/src/vue-router.d.ts
@@ -11,6 +11,11 @@ interface RouteMeta {
    */
   activePath?: string;
   /**
+   * 是否使用 activePath 对应的路由层级生成面包屑
+   * @default false
+   */
+  breadcrumbUseActivePath?: boolean;
+  /**
    * 是否固定标签页
    * @default false
    */

--- a/packages/effects/layouts/src/widgets/__tests__/breadcrumb-routes.test.ts
+++ b/packages/effects/layouts/src/widgets/__tests__/breadcrumb-routes.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { resolveBreadcrumbMatches } from '../breadcrumb-routes';
 
-function createMatch(name: string, path: string): RouteLocationMatched {
+function createMatch(
+  name: RouteLocationMatched['name'],
+  path: string,
+): RouteLocationMatched {
   return { name, path } as RouteLocationMatched;
 }
 
@@ -65,5 +68,26 @@ describe('resolveBreadcrumbMatches', () => {
         () => ({ matched: [root, list] }),
       ),
     ).toEqual([root, list, detail]);
+  });
+
+  it('keeps distinct unnamed matches with the same normalized path', () => {
+    const parent = createMatch(undefined, '/list');
+    const defaultChild = createMatch(undefined, '/list');
+
+    const result = resolveBreadcrumbMatches(
+      {
+        matched: [parent, defaultChild],
+        meta: {
+          activePath: '/list',
+          breadcrumbUseActivePath: true,
+          title: 'List',
+        },
+      },
+      () => ({ matched: [parent] }),
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(parent);
+    expect(result[1]).toBe(defaultChild);
   });
 });

--- a/packages/effects/layouts/src/widgets/__tests__/breadcrumb-routes.test.ts
+++ b/packages/effects/layouts/src/widgets/__tests__/breadcrumb-routes.test.ts
@@ -1,0 +1,69 @@
+import type { RouteLocationMatched } from 'vue-router';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveBreadcrumbMatches } from '../breadcrumb-routes';
+
+function createMatch(name: string, path: string): RouteLocationMatched {
+  return { name, path } as RouteLocationMatched;
+}
+
+describe('resolveBreadcrumbMatches', () => {
+  it('preserves the current matches when activePath breadcrumbs are disabled', () => {
+    const matches = [createMatch('Detail', '/detail')];
+    const resolveRoute = vi.fn();
+
+    expect(
+      resolveBreadcrumbMatches(
+        {
+          matched: matches,
+          meta: {
+            activePath: '/list',
+            breadcrumbUseActivePath: false,
+            title: 'Detail',
+          },
+        },
+        resolveRoute,
+      ),
+    ).toBe(matches);
+    expect(resolveRoute).not.toHaveBeenCalled();
+  });
+
+  it('preserves the current matches when activePath cannot be resolved', () => {
+    const matches = [createMatch('Detail', '/detail')];
+
+    expect(
+      resolveBreadcrumbMatches(
+        {
+          matched: matches,
+          meta: {
+            activePath: '/missing',
+            breadcrumbUseActivePath: true,
+            title: 'Detail',
+          },
+        },
+        () => ({ matched: [] }),
+      ),
+    ).toBe(matches);
+  });
+
+  it('prepends activePath matches and removes duplicate route records', () => {
+    const root = createMatch('Root', '/');
+    const list = createMatch('List', '/list');
+    const detail = createMatch('Detail', '/detail');
+
+    expect(
+      resolveBreadcrumbMatches(
+        {
+          matched: [root, detail],
+          meta: {
+            activePath: '/list',
+            breadcrumbUseActivePath: true,
+            title: 'Detail',
+          },
+        },
+        () => ({ matched: [root, list] }),
+      ),
+    ).toEqual([root, list, detail]);
+  });
+});

--- a/packages/effects/layouts/src/widgets/breadcrumb-routes.ts
+++ b/packages/effects/layouts/src/widgets/breadcrumb-routes.ts
@@ -27,9 +27,9 @@ export function resolveBreadcrumbMatches(
     return route.matched;
   }
 
-  const seen = new Set(activeMatches.map((match) => match.name ?? match.path));
+  const seen = new Set(activeMatches.map((match) => match.name ?? match));
   const currentMatches = route.matched.filter((match) => {
-    const key = match.name ?? match.path;
+    const key = match.name ?? match;
     if (seen.has(key)) {
       return false;
     }

--- a/packages/effects/layouts/src/widgets/breadcrumb-routes.ts
+++ b/packages/effects/layouts/src/widgets/breadcrumb-routes.ts
@@ -1,0 +1,41 @@
+import type { RouteLocationNormalizedLoaded } from 'vue-router';
+
+type MatchedRoutes = RouteLocationNormalizedLoaded['matched'];
+
+interface BreadcrumbRoute {
+  matched: MatchedRoutes;
+  meta: RouteLocationNormalizedLoaded['meta'];
+}
+
+type BreadcrumbRouteResolver = (path: string) => { matched: MatchedRoutes };
+
+/**
+ * 解析用于渲染当前面包屑的路由匹配记录。
+ */
+export function resolveBreadcrumbMatches(
+  route: BreadcrumbRoute,
+  resolveRoute: BreadcrumbRouteResolver,
+): MatchedRoutes {
+  const { activePath, breadcrumbUseActivePath } = route.meta;
+
+  if (!breadcrumbUseActivePath || !activePath) {
+    return route.matched;
+  }
+
+  const activeMatches = resolveRoute(activePath).matched;
+  if (activeMatches.length === 0) {
+    return route.matched;
+  }
+
+  const seen = new Set(activeMatches.map((match) => match.name ?? match.path));
+  const currentMatches = route.matched.filter((match) => {
+    const key = match.name ?? match.path;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+
+  return [...activeMatches, ...currentMatches];
+}

--- a/packages/effects/layouts/src/widgets/breadcrumb.vue
+++ b/packages/effects/layouts/src/widgets/breadcrumb.vue
@@ -10,6 +10,8 @@ import { $t } from '@vben/locales';
 
 import { VbenBreadcrumbView } from '@vben-core/shadcn-ui';
 
+import { resolveBreadcrumbMatches } from './breadcrumb-routes';
+
 interface Props {
   hideWhenOnlyOne?: boolean;
   showHome?: boolean;
@@ -27,7 +29,9 @@ const route = useRoute();
 const router = useRouter();
 
 const breadcrumbs = computed((): IBreadcrumb[] => {
-  const matched = route.matched;
+  const matched = resolveBreadcrumbMatches(route, (path) =>
+    router.resolve(path),
+  );
 
   const resultBreadcrumb: IBreadcrumb[] = [];
 


### PR DESCRIPTION
## Description

Routes such as detail pages often use `activePath` to keep the related menu item active, but breadcrumbs currently rely only on the current route's `matched` records. When those routes are not nested under the menu route, the breadcrumb loses the menu hierarchy.

This PR adds an opt-in `breadcrumbUseActivePath` route meta option. When enabled, breadcrumbs resolve the `activePath` hierarchy, merge it with the current route matches, and remove duplicate route records. The default remains `false`, so existing breadcrumb behavior is unchanged.

The route matching logic is extracted into a pure function with a general-purpose comment, and is covered by tests for opt-out behavior, unresolved paths, hierarchy merging, and deduplication. Chinese and English route documentation and a changeset are included.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] `pnpm-lock.yaml` is unchanged

## Validation

- [x] `pnpm check:type`
- [x] `pnpm lint`
- [x] `pnpm test:unit` — 74 files, 530 tests passed
- [x] `pnpm build:docs`
- [x] Targeted breadcrumb tests — 3 tests passed
- [x] Targeted CSpell check for changed TypeScript and changeset files

The repository-wide CSpell check still reports two existing `Unwrappable` findings in `packages/@core/ui-kit/form-ui/src/form-render/helper.ts`; this PR does not modify that file.

## Checklist

- [x] If you introduce new functionality, document it.
- [x] Run the tests.
- [x] The PR title and changeset message use the required conventional prefix.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] No dependent downstream changes are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating breadcrumbs from an active route hierarchy.
  * Breadcrumbs can include parent routes for detail pages not directly nested under the selected menu route.
  * Added the `breadcrumbUseActivePath` route option, disabled by default.

* **Bug Fixes**
  * Prevented duplicate routes from appearing in breadcrumbs while preserving distinct route entries.

* **Documentation**
  * Documented the new route option and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->