### PR TITLE
fix(form): bind VbenTiptap through modelValue

### DIFF
--- a/.changeset/fresh-tiptap-model.md
+++ b/.changeset/fresh-tiptap-model.md
@@ -1,0 +1,6 @@
+---
+'@vben/web-antdv-next': patch
+'@vben/playground': patch
+---
+
+fix: bind VbenTiptap through the standard Vue model protocol

--- a/apps/web-antdv-next/src/adapter/form.test.ts
+++ b/apps/web-antdv-next/src/adapter/form.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { initSetupVbenForm } from './form';
+
+const mocks = vi.hoisted(() => ({
+  setupVbenForm: vi.fn(),
+}));
+
+vi.mock('@vben/common-ui', () => ({
+  setupVbenForm: mocks.setupVbenForm,
+  useVbenForm: vi.fn(),
+  z: {},
+}));
+
+vi.mock('@vben/locales', () => ({
+  $t: (key: string) => key,
+}));
+
+describe('antdv-next form adapter', () => {
+  it('keeps VbenTiptap on the standard Vue model protocol', async () => {
+    await initSetupVbenForm();
+
+    expect(mocks.setupVbenForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          modelPropNameMap: expect.objectContaining({
+            RichEditor: 'modelValue',
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web-antdv-next/src/adapter/form.ts
+++ b/apps/web-antdv-next/src/adapter/form.ts
@@ -19,6 +19,8 @@ async function initSetupVbenForm() {
       modelPropNameMap: {
         Checkbox: 'checked',
         Radio: 'checked',
+        // VbenTiptap uses Vue's standard modelValue/update:modelValue pair.
+        RichEditor: 'modelValue',
         Switch: 'checked',
         Upload: 'fileList',
       },

--- a/playground/src/adapter/form.ts
+++ b/playground/src/adapter/form.ts
@@ -18,6 +18,8 @@ async function initSetupVbenForm() {
       modelPropNameMap: {
         Checkbox: 'checked',
         Radio: 'checked',
+        // VbenTiptap uses Vue's standard modelValue/update:modelValue pair.
+        RichEditor: 'modelValue',
         Switch: 'checked',
         Upload: 'fileList',
       },


### PR DESCRIPTION
## Summary

- map the registered `RichEditor` component to Vue's `modelValue` protocol in the antdv-next and playground form adapters
- add an adapter regression test and a patch changeset

Fixes #8345

## Root cause

`VbenTiptap` uses `modelValue` / `update:modelValue`, while these adapters default all components to the antdv-next `value` / `update:value` protocol. As a result, rich-editor changes were not written back to VbenForm state.

## Validation

- `pnpm exec vitest run --dom apps/web-antdv-next/src/adapter/form.test.ts packages/@core/ui-kit/form-ui/__tests__/config.test.ts`
- `pnpm --filter @vben/web-antdv-next typecheck`
- `pnpm --filter @vben/playground typecheck`
- targeted `oxfmt --check`, `oxlint`, and `git diff --check`
- verified in a real playground Chromium session that typing in VbenTiptap emits the form change marker for `richEditor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rich text editor form binding to use Vue’s standard `modelValue` protocol.
  * Improved compatibility with form components in the Ant Design Vue Next adapter and playground.

* **Tests**
  * Added coverage verifying the rich text editor’s `modelValue` binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->