### PR TITLE
fix(@vben/common-ui): fetch ApiComponent options after late API binding

### DIFF
--- a/.changeset/calm-api-selects-load.md
+++ b/.changeset/calm-api-selects-load.md
@@ -1,0 +1,5 @@
+---
+'@vben/common-ui': patch
+---
+
+fix(@vben/common-ui): fetch ApiComponent options when an API is provided after mount

--- a/packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts
+++ b/packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts
@@ -146,12 +146,21 @@ describe('api-component.vue', () => {
       },
     });
 
-    mount(Harness);
+    const wrapper = mount(Harness);
     expect(api).not.toHaveBeenCalled();
 
     apiRef.value = api;
     await nextTick();
 
     expect(api).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      const events = wrapper
+        .findComponent(ApiComponent)
+        .emitted('optionsChange');
+      const lastEvent = events?.at(-1)?.[0];
+      expect(lastEvent).toEqual([
+        expect.objectContaining({ label: 'Loaded', value: 'loaded' }),
+      ]);
+    });
   });
 });

--- a/packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts
+++ b/packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts
@@ -1,3 +1,5 @@
+import type { ApiComponentProps } from '../types';
+
 import { mount } from '@vue/test-utils';
 import { defineComponent, h, markRaw, nextTick, ref } from 'vue';
 
@@ -127,5 +129,29 @@ describe('api-component.vue', () => {
     await nextTick();
     expect(handleUpdate).toHaveBeenCalledWith('selected');
     expect(input.props('modelValue')).toBe('selected');
+  });
+
+  it('fetches when the api is provided after mount', async () => {
+    const api = vi
+      .fn()
+      .mockResolvedValue([{ label: 'Loaded', value: 'loaded' }]);
+    const apiRef = ref<ApiComponentProps['api']>();
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h(ApiComponent, {
+            api: apiRef.value,
+            component: markRaw(ModelValueInput),
+          });
+      },
+    });
+
+    mount(Harness);
+    expect(api).not.toHaveBeenCalled();
+
+    apiRef.value = api;
+    await nextTick();
+
+    expect(api).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/effects/common-ui/src/components/api-component/api-component.vue
+++ b/packages/effects/common-ui/src/components/api-component/api-component.vue
@@ -200,9 +200,9 @@ const mergedParams = computed(() => {
 });
 
 watch(
-  mergedParams,
-  (value, oldValue) => {
-    if (isEqual(value, oldValue)) {
+  [() => props.api, mergedParams],
+  ([api, value], [oldApi, oldValue]) => {
+    if (api === oldApi && isEqual(value, oldValue)) {
       return;
     }
     fetchApi();


### PR DESCRIPTION
## Summary

Fixes #8350. ApiComponent only watched merged params, so when a form dependency resolver supplied componentProps.api after the component mounted, the API was never called and options stayed empty.

The watcher now also tracks the API function reference and refetches when it becomes available or changes.

## Verification

- Added regression coverage for an API provided after mount.
- pnpm exec vitest run packages/effects/common-ui/src/components/api-component/__tests__/api-component.test.ts packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts (31 passed)
- pnpm --filter @vben/web-antd typecheck
- Targeted oxfmt, ESLint, oxlint, and git diff --check

<!-- contributor note: no changes to pnpm-lock.yaml -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - API-backed component options now load when an API is provided after the component is mounted.
  - Options refresh correctly when the configured API or its parameters change.
  - Unchanged API settings no longer trigger unnecessary requests.

- **Tests**
  - Added coverage for deferred API loading, option updates, and request behavior when relevant values remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->