### PR TITLE
fix(@vben-core/form-ui): support native Zod string format defaults

### DIFF
--- a/.changeset/bright-zebras-default.md
+++ b/.changeset/bright-zebras-default.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/form-ui': patch
+---
+
+fix(@vben-core/form-ui): initialize native Zod string formats with empty values

--- a/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
@@ -104,6 +104,37 @@ describe('useVbenForm integration', () => {
     });
   });
 
+  it('filters native zod formats from nested default extraction', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const [Form, formApi] = useVbenForm({
+      schema: [
+        {
+          component: TestInput,
+          fieldName: 'profile',
+          rules: z.object({
+            email: z.email(),
+            address: z.object({
+              ip: z.ipv4(),
+              backup: z.email().default('backup@example.com'),
+            }),
+          }),
+        },
+      ],
+      showDefaultActions: false,
+    });
+    const wrapper = mount(Form);
+    wrappers.push(wrapper);
+    await flushPromises();
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(await formApi.getValues()).toEqual({
+      profile: {
+        address: { backup: 'backup@example.com', ip: '' },
+        email: '',
+      },
+    });
+  });
+
   it('uses model updates as the primary channel and preserves empty strings', async () => {
     const validateValue = vi.fn();
     const [Form, formApi] = useVbenForm({

--- a/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
+++ b/packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts
@@ -78,6 +78,32 @@ afterEach(() => {
 });
 
 describe('useVbenForm integration', () => {
+  it('provides empty defaults for native zod string formats', async () => {
+    const [Form, formApi] = useVbenForm({
+      schema: [
+        {
+          component: TestInput,
+          fieldName: 'email',
+          rules: z.email(),
+        },
+        {
+          component: TestInput,
+          fieldName: 'address',
+          rules: z.ipv4(),
+        },
+      ],
+      showDefaultActions: false,
+    });
+    const wrapper = mount(Form);
+    wrappers.push(wrapper);
+    await flushPromises();
+
+    expect(await formApi.getValues()).toEqual({
+      address: '',
+      email: '',
+    });
+  });
+
   it('uses model updates as the primary channel and preserves empty strings', async () => {
     const validateValue = vi.fn();
     const [Form, formApi] = useVbenForm({

--- a/packages/@core/ui-kit/form-ui/src/use-form-context.ts
+++ b/packages/@core/ui-kit/form-ui/src/use-form-context.ts
@@ -9,7 +9,14 @@ import { computed, toRaw, unref, useSlots } from 'vue';
 import { createContext } from '@vben-core/shadcn-ui';
 import { isString, mergeWithArrayOverride, set } from '@vben-core/shared/utils';
 
-import { object, ZodIntersection, ZodNumber, ZodObject, ZodString } from 'zod';
+import {
+  object,
+  ZodIntersection,
+  ZodNumber,
+  ZodObject,
+  ZodString,
+  ZodStringFormat,
+} from 'zod';
 import { getDefaultsForSchema } from 'zod-defaults';
 
 import { useFormRuntime } from './form-runtime';
@@ -74,8 +81,8 @@ export function useFormInitial(
   // 自定义默认值提取逻辑
   function getCustomDefaultValue(rule: any): any {
     rule = toRaw(rule);
-    if (rule instanceof ZodString) {
-      return ''; // 默认为空字符串
+    if (rule instanceof ZodString || rule instanceof ZodStringFormat) {
+      return ''; // 字符串及其格式校验默认为空字符串
     } else if (rule instanceof ZodNumber) {
       return null; // 默认为 null（避免显示 0）
     } else if (rule instanceof ZodObject) {

--- a/packages/@core/ui-kit/form-ui/src/use-form-context.ts
+++ b/packages/@core/ui-kit/form-ui/src/use-form-context.ts
@@ -34,6 +34,10 @@ export const [injectFormProps, provideFormProps] =
 export const [injectComponentRefMap, provideComponentRefMap] =
   createContext<Map<string, unknown>>('ComponentRefMap');
 
+/**
+ * Rebuild the schema used by zod-defaults, replacing native format nodes that
+ * zod-defaults does not recognise while retaining supported wrappers.
+ */
 function normalizeSchemaForDefaults(rule: ZodType): ZodType {
   const rawRule = toRaw(rule) as any;
 

--- a/packages/@core/ui-kit/form-ui/src/use-form-context.ts
+++ b/packages/@core/ui-kit/form-ui/src/use-form-context.ts
@@ -15,6 +15,7 @@ import {
   ZodNumber,
   ZodObject,
   ZodString,
+  string as zodString,
   ZodStringFormat,
 } from 'zod';
 import { getDefaultsForSchema } from 'zod-defaults';
@@ -32,6 +33,42 @@ export const [injectFormProps, provideFormProps] =
 
 export const [injectComponentRefMap, provideComponentRefMap] =
   createContext<Map<string, unknown>>('ComponentRefMap');
+
+function normalizeSchemaForDefaults(rule: ZodType): ZodType {
+  const rawRule = toRaw(rule) as any;
+
+  if (rawRule instanceof ZodStringFormat) {
+    return zodString();
+  }
+
+  if (rawRule instanceof ZodObject) {
+    const shape = Object.fromEntries(
+      Object.entries(rawRule.shape).map(([key, value]) => [
+        key,
+        normalizeSchemaForDefaults(value as ZodType),
+      ]),
+    );
+    return object(shape);
+  }
+
+  if (rawRule instanceof ZodIntersection) {
+    const { left, right } = (rawRule as any).def;
+    return normalizeSchemaForDefaults(left as ZodType).and(
+      normalizeSchemaForDefaults(right as ZodType),
+    );
+  }
+
+  if (rawRule.constructor.name === 'ZodDefault') {
+    const inner = normalizeSchemaForDefaults(rawRule.unwrap());
+    return inner.default(rawRule.def.defaultValue);
+  }
+
+  if (rawRule.constructor.name === 'ZodPipe') {
+    return normalizeSchemaForDefaults(rawRule.in).pipe(rawRule.out);
+  }
+
+  return rawRule;
+}
 
 export function useFormInitial(
   props: ComputedRef<VbenFormProps> | VbenFormProps,
@@ -63,7 +100,7 @@ export function useFormInitial(
         // 检查规则是否适合提取默认值
         const rawRules = toRaw(item.rules);
         const customDefaultValue = getCustomDefaultValue(rawRules);
-        zodObject[item.fieldName] = rawRules;
+        zodObject[item.fieldName] = normalizeSchemaForDefaults(rawRules);
         if (customDefaultValue !== undefined) {
           initialValues[item.fieldName] = customDefaultValue;
         }
@@ -93,7 +130,7 @@ export function useFormInitial(
       }
       return defaultValues;
     } else if (rule instanceof ZodIntersection) {
-      return getDefaultsForSchema(rule);
+      return getDefaultsForSchema(normalizeSchemaForDefaults(rule) as any);
     } else {
       return undefined; // 其他类型不提供默认值
     }


### PR DESCRIPTION
## Summary

Fixes #8359. With Zod 4, native string formats such as z.email() and z.ipv4() use ZodStringFormat subclasses rather than ZodString. The form's custom default extraction did not recognize them, so zod-defaults logged Unhandled type ZodEmail / Unhandled type ZodIPv4 and initial form values were missing.

Treating ZodStringFormat like ZodString initializes these fields to an empty string while preserving existing defaults and validation behavior.

## Verification

- Added a form integration regression covering z.email() and z.ipv4().
- Before the fix: the regression failed with {} and emitted the reported unhandled-type warnings.
- After the fix: pnpm exec vitest run packages/@core/ui-kit/form-ui/__tests__/form-integration.test.ts packages/@core/ui-kit/form-ui/__tests__/zod-v4-schema.test.ts (35 passed).
- pnpm --filter @vben/web-antd typecheck
- pnpm --filter @vben/web-antdv-next typecheck
- Targeted ESLint, oxfmt, and git diff --check passed.

<!-- contributor note: no changes to pnpm-lock.yaml -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Form fields using native Zod string formats, including email, IP address, or UUID validation, now initialize with empty string values.
  - Improved consistency of form values returned before users interact with these fields.
  - Existing schema wrappers and validation behavior remain supported while defaults are initialized.

- **Tests**
  - Added integration coverage verifying empty defaults for fields using native Zod string format rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->