### PR TITLE
fix(@vben-core/preferences): type custom preference updates

### DIFF
--- a/.changeset/typed-custom-preferences-update.md
+++ b/.changeset/typed-custom-preferences-update.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/preferences': patch
+---
+
+fix(@vben-core/preferences): type custom preference updates

--- a/packages/@core/preferences/__tests__/preferences-types.test.ts
+++ b/packages/@core/preferences/__tests__/preferences-types.test.ts
@@ -1,6 +1,6 @@
-import { describe, expectTypeOf, it } from 'vitest';
-
 import type { DeepPartial } from '@vben-core/typings';
+
+import { describe, expectTypeOf, it } from 'vitest';
 
 import { updateCustomPreferences } from '../src';
 

--- a/packages/@core/preferences/__tests__/preferences-types.test.ts
+++ b/packages/@core/preferences/__tests__/preferences-types.test.ts
@@ -1,0 +1,21 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { DeepPartial } from '@vben-core/typings';
+
+import { updateCustomPreferences } from '../src';
+
+interface ProjectPreferences {
+  defaultTableSize: number;
+  tenantMode: 'multi' | 'single';
+}
+
+describe('custom preferences types', () => {
+  it('accepts a typed partial update', () => {
+    const updateProjectPreferences =
+      updateCustomPreferences<ProjectPreferences>;
+
+    expectTypeOf(updateProjectPreferences)
+      .parameter(0)
+      .toEqualTypeOf<DeepPartial<ProjectPreferences>>();
+  });
+});

--- a/packages/@core/preferences/src/preferences.ts
+++ b/packages/@core/preferences/src/preferences.ts
@@ -188,7 +188,11 @@ class PreferenceManager {
    * 更新扩展偏好设置
    * @param updates - 要更新的扩展偏好设置
    */
-  updateCustomPreferences = (updates: DeepPartial<object>) => {
+  updateCustomPreferences = <
+    TCustomPreferences extends object = CustomPreferencesRecord,
+  >(
+    updates: DeepPartial<TCustomPreferences>,
+  ) => {
     if (!this.customPreferencesExtension) {
       return;
     }


### PR DESCRIPTION
## Summary
- expose `updateCustomPreferences` as a generic API, matching the documented usage
- add a type regression test for typed partial custom-preference updates
- add a patch changeset for `@vben-core/preferences`

## Problem
The preferences guide calls `updateCustomPreferences<ProjectPreferencesExtension>(...)`, but the implementation was declared as a non-generic `(updates: DeepPartial<object>)` function. Consumers following the guide received `TS2558: Expected 0 type arguments` and lost the key-level type checking for their extension preferences.

## Verification
- `pnpm exec vitest run packages/@core/preferences/__tests__/preferences-types.test.ts packages/@core/preferences/__tests__/preferences.test.ts`
- `pnpm --filter @vben-core/preferences run "#build"`
- `pnpm exec oxfmt --check packages/@core/preferences/src/preferences.ts packages/@core/preferences/__tests__/preferences-types.test.ts .changeset/typed-custom-preferences-update.md`
- `pnpm exec oxlint packages/@core/preferences/src/preferences.ts packages/@core/preferences/__tests__/preferences-types.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved custom preference updates with stronger type support, allowing projects to provide their own preference definitions while applying partial updates safely.
  - Existing preference update behavior remains compatible while offering more precise type checking for customized settings.

- **Tests**
  - Added coverage verifying that custom preference definitions and partial preference updates are accepted correctly.
  - This helps detect invalid preference update shapes earlier during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->