### PR TITLE
fix(@vben-core/shadcn-ui): preserve radio outlines in collapsible

### DIFF
--- a/.changeset/tidy-radios-collapsible.md
+++ b/.changeset/tidy-radios-collapsible.md
@@ -1,0 +1,5 @@
+---
+'@vben-core/shadcn-ui': patch
+---
+
+fix(@vben-core/shadcn-ui): preserve outlines inside collapsible content

--- a/packages/@core/ui-kit/shadcn-ui/src/components/collapsible/__tests__/collapsible.test.ts
+++ b/packages/@core/ui-kit/shadcn-ui/src/components/collapsible/__tests__/collapsible.test.ts
@@ -1,0 +1,47 @@
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import VbenCollapsible from '../collapsible.vue';
+
+let activeApp: ReturnType<typeof createApp> | undefined;
+
+afterEach(() => {
+  activeApp?.unmount();
+  activeApp = undefined;
+  document.body.innerHTML = '';
+});
+
+describe('VbenCollapsible', () => {
+  it('keeps a one-pixel paint buffer around animated content', async () => {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    const open = ref(true);
+    const Consumer = defineComponent(
+      () => () =>
+        h(
+          VbenCollapsible,
+          { open: open.value },
+          {
+            collapsibleContent: () => h('div', { class: 'content-probe' }),
+          },
+        ),
+    );
+
+    activeApp = createApp(Consumer);
+    activeApp.mount(host);
+    await nextTick();
+
+    const content = host.querySelector('[class~="-mx-px"]');
+    expect(content).toBeInstanceOf(HTMLElement);
+    if (!(content instanceof HTMLElement)) return;
+
+    expect(content.classList.contains('px-px')).toBe(true);
+    expect(content.classList.contains('overflow-hidden')).toBe(true);
+
+    open.value = false;
+    await nextTick();
+    expect(content.getAttribute('data-state')).toBe('closed');
+  });
+});

--- a/packages/@core/ui-kit/shadcn-ui/src/components/collapsible/collapsible.vue
+++ b/packages/@core/ui-kit/shadcn-ui/src/components/collapsible/collapsible.vue
@@ -71,7 +71,7 @@ defineExpose({
     <slot name="visibleContent" :open></slot>
 
     <CollapsibleContent
-      class="data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden justify-start"
+      class="data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up -mx-px overflow-hidden px-px justify-start"
     >
       <slot name="collapsibleContent" :open></slot>
     </CollapsibleContent>


### PR DESCRIPTION
## Summary\n- add a one-pixel horizontal paint buffer to CollapsibleContent\n- keep overflow-hidden and the existing open/close height animations\n- add a regression test covering the buffer and state transition\n\nFixes #8157\n\n## Validation\n- pnpm exec vitest run --dom packages/@core/ui-kit/shadcn-ui/src\n- pnpm check:type\n- pnpm lint (passes; existing warnings only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved visible outlines around content inside collapsible sections.
  - Maintained smooth collapsible animations and correct open/closed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->