### PR TITLE
fix(@vben/request): preserve response metadata on errors

### DIFF
--- a/.changeset/gentle-requests-return.md
+++ b/.changeset/gentle-requests-return.md
@@ -1,0 +1,5 @@
+---
+'@vben/request': patch
+---
+
+fix: preserve response metadata when requests fail

--- a/packages/effects/request/src/request-client/request-client.test.ts
+++ b/packages/effects/request/src/request-client/request-client.test.ts
@@ -2,11 +2,11 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { RequestClient } from './request-client';
 import {
   defaultResponseInterceptor,
   errorMessageResponseInterceptor,
 } from './preset-interceptors';
+import { RequestClient } from './request-client';
 
 describe('requestClient', () => {
   let mock: MockAdapter;

--- a/packages/effects/request/src/request-client/request-client.test.ts
+++ b/packages/effects/request/src/request-client/request-client.test.ts
@@ -3,6 +3,10 @@ import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { RequestClient } from './request-client';
+import {
+  defaultResponseInterceptor,
+  errorMessageResponseInterceptor,
+} from './preset-interceptors';
 
 describe('requestClient', () => {
   let mock: MockAdapter;
@@ -61,6 +65,38 @@ describe('requestClient', () => {
     await expect(requestClient.get('/test/timeout')).rejects.toMatchObject({
       isAxiosError: true,
       code: 'ECONNABORTED',
+    });
+  });
+
+  it('should preserve response metadata when an interceptor rejects', async () => {
+    requestClient.addResponseInterceptor(
+      defaultResponseInterceptor({
+        codeField: 'code',
+        dataField: 'data',
+        successCode: 0,
+      }),
+    );
+    requestClient.addResponseInterceptor(errorMessageResponseInterceptor());
+    mock.onGet('/test/interceptor-error').reply(200, {
+      code: 1001,
+      data: null,
+      message: 'request failed',
+    });
+
+    await expect(
+      requestClient.get('/test/interceptor-error', {
+        responseReturn: 'data',
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        data: {
+          code: 1001,
+          data: null,
+          message: 'request failed',
+        },
+        status: 200,
+      },
+      status: 200,
     });
   });
 

--- a/packages/effects/request/src/request-client/request-client.ts
+++ b/packages/effects/request/src/request-client/request-client.ts
@@ -146,18 +146,14 @@ class RequestClient {
     url: string,
     config: RequestClientConfig,
   ): Promise<T> {
-    try {
-      const response: AxiosResponse<T> = await this.instance({
-        url,
-        ...config,
-        ...(config.paramsSerializer
-          ? { paramsSerializer: getParamsSerializer(config.paramsSerializer) }
-          : {}),
-      });
-      return response as T;
-    } catch (error: any) {
-      throw error.response ? error.response.data : error;
-    }
+    const response: AxiosResponse<T> = await this.instance({
+      url,
+      ...config,
+      ...(config.paramsSerializer
+        ? { paramsSerializer: getParamsSerializer(config.paramsSerializer) }
+        : {}),
+    });
+    return response as T;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #8196. `RequestClient.request` previously unwrapped every rejected Axios response to `error.response.data`, which discarded HTTP metadata such as `response.status` before callers could inspect it. This also made the request client inconsistent with the response interceptor contract.

The request method now lets the original error propagate unchanged. Added a regression test covering a business-level rejection from `defaultResponseInterceptor` and verifying both the response body and HTTP status remain available.

## Validation

- `pnpm exec vitest run packages/effects/request/src/request-client/request-client.test.ts` (9 passed)
- `pnpm exec oxfmt --check packages/effects/request/src/request-client/request-client.ts packages/effects/request/src/request-client/request-client.test.ts`
- `pnpm exec oxlint packages/effects/request/src/request-client/request-client.ts packages/effects/request/src/request-client/request-client.test.ts`
- `git diff --check`

The package TypeScript check still reports two pre-existing errors in `packages/utils` outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Request failures now preserve complete response details, including HTTP status and response data.
  - Errors are propagated without losing metadata, enabling applications to handle failed requests more accurately.
  - Applications can reliably inspect the original failure response when request processing or response handling encounters an error.

- **Tests**
  - Added coverage verifying that response information remains available when response processing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->