### PR TITLE
feat: add menu mode to CellOperation renderer

### DIFF
--- a/packages/locales/src/langs/en-US/common.json
+++ b/packages/locales/src/langs/en-US/common.json
@@ -22,5 +22,6 @@
   "no": "No",
   "showSearchPanel": "Show search panel",
   "hideSearchPanel": "Hide search panel",
-  "notShow": "Don't Show"
+  "notShow": "Don't Show",
+  "more": "More"
 }

--- a/packages/locales/src/langs/zh-CN/common.json
+++ b/packages/locales/src/langs/zh-CN/common.json
@@ -22,5 +22,6 @@
   "no": "否",
   "showSearchPanel": "显示搜索面板",
   "hideSearchPanel": "隐藏搜索面板",
-  "notShow": "不显示"
+  "notShow": "不显示",
+  "more": "更多"
 }

--- a/packages/locales/src/langs/zh-TW/common.json
+++ b/packages/locales/src/langs/zh-TW/common.json
@@ -22,5 +22,6 @@
   "no": "否",
   "showSearchPanel": "顯示搜尋面板",
   "hideSearchPanel": "隱藏搜尋面板",
-  "notShow": "不顯示"
+  "notShow": "不顯示",
+  "more": "更多"
 }

--- a/playground/src/adapter/vxe-table.ts
+++ b/playground/src/adapter/vxe-table.ts
@@ -17,7 +17,7 @@ import {
 import { get, isFunction, isString } from '@vben/utils';
 
 import { objectOmit } from '@vueuse/core';
-import { Button, Image, Popconfirm, Switch, Tag } from 'antdv-next';
+import { Button, Dropdown, Image, Popconfirm, Switch, Tag } from 'antdv-next';
 
 import { $t } from '#/locales';
 
@@ -134,7 +134,16 @@ setupVbenVxeTable({
      * 注册表格的操作按钮渲染器
      */
     vxeUI.renderer.add('CellOperation', {
-      renderTableDefault({ attrs, options, props }, { column, row }) {
+      renderTableDefault({ attrs, options, props: rawProps }, { column, row }) {
+        const {
+          dropdownProps,
+          menuButtonProps,
+          menuIcon = 'ant-design:more-outlined',
+          menuText = $t('common.more'),
+          mode,
+          renderMode,
+          ...props
+        } = rawProps ?? {};
         const defaultProps = { size: 'small', type: 'link', ...props };
         let align: string;
         switch (column.align) {
@@ -271,13 +280,91 @@ setupVbenVxeTable({
         const btns = operations.map((opt) =>
           opt.code === 'delete' ? renderConfirm(opt) : renderBtn(opt),
         );
+
+        function renderMenuTrigger() {
+          return h(
+            Button,
+            {
+              size: defaultProps.size,
+              type: defaultProps.type,
+              ...menuButtonProps,
+            },
+            {
+              default: () => {
+                const content = [];
+                if (menuIcon) {
+                  content.push(
+                    h(IconifyIcon, { class: 'size-5', icon: menuIcon }),
+                  );
+                }
+                if (menuText) {
+                  content.push(h('span', menuText));
+                }
+                return h(
+                  'div',
+                  { class: 'inline-flex items-center gap-1 leading-none' },
+                  content,
+                );
+              },
+            },
+          );
+        }
+
+        const operationRenderStrategies: Recordable<() => any[]> = {
+          button: () => btns,
+          menu: () => [
+            h(
+              Dropdown,
+              {
+                getPopupContainer: () => document.body,
+                placement:
+                  column.align === 'left'
+                    ? 'bottomLeft'
+                    : 'bottomRight',
+                trigger: ['click'],
+                ...dropdownProps,
+              },
+              {
+                default: () =>
+                  h(
+                    'span',
+                    {
+                      class: 'inline-flex cursor-pointer',
+                    },
+                    [renderMenuTrigger()],
+                  ),
+
+                popupRender: () =>
+                  h(
+                    'div',
+                    {
+                      class:
+                        'ant-dropdown-menu flex flex-col gap-1 p-1',
+
+                      onClick: (event: MouseEvent) =>
+                        event.stopPropagation(),
+
+                      style: {
+                        minWidth: '80px',
+                      },
+                    },
+                    btns,
+                  ),
+              },
+            ),
+          ],
+        };
+        const renderOperations =
+          operationRenderStrategies[renderMode ?? mode] ??
+          operationRenderStrategies.button;
+
         return h(
           'div',
           {
             class: 'flex table-operations',
             style: { justifyContent: align },
           },
-          btns,
+          renderOperations(),
         );
       },
     });

--- a/playground/src/adapter/vxe-table.ts
+++ b/playground/src/adapter/vxe-table.ts
@@ -356,7 +356,7 @@ setupVbenVxeTable({
         };
         const renderOperations =
           operationRenderStrategies[renderMode ?? mode] ??
-          operationRenderStrategies.button;
+          operationRenderStrategies.button!;
 
         return h(
           'div',

--- a/playground/src/views/examples/vxe-table/viewed.vue
+++ b/playground/src/views/examples/vxe-table/viewed.vue
@@ -35,6 +35,9 @@ const gridOptions: VxeGridProps<RowType> = {
     {
       align: 'center',
       cellRender: {
+        props: {
+          renderMode: 'menu',
+        },
         attrs: {
           nameField: 'category',
           onClick: onActionClick,
@@ -53,7 +56,7 @@ const gridOptions: VxeGridProps<RowType> = {
       headerAlign: 'center',
       showOverflow: false,
       title: $t('system.menu.operation'),
-      width: 200,
+      width: 100,
     },
   ],
   exportConfig: {},


### PR DESCRIPTION
## Description

Description

Add an optional menu render mode to the CellOperation renderer for cases with many row actions.

In the existing button mode, all actions are displayed directly in the operation column, which can require a wider column when there are many actions.

This change adds a menu mode that groups actions into a dropdown menu, while keeping the existing button mode as the default.

Main changes:

Add menu render mode
Keep button as the default render mode
Support switching modes via renderMode / mode
Support menuText, menuIcon, and menuButtonProps
Support custom dropdown configuration via dropdownProps
Reuse the existing action and delete confirmation logic in menu mode
Update Dropdown usage for the antdv-next API
Keep existing CellOperation usage and behavior unchanged when menu mode is not enabled

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
