### PR TITLE
fix: report Vue version in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
     id: system-info
     attributes:
       label: System Info
-      description: Output of `npx envinfo --system --npmPackages '{vue}' --binaries --browsers`
+      description: Output of `npx envinfo --system --npmPackages vue --binaries --browsers`
       render: shell
       placeholder: System, Binaries, Browsers
     validations:


### PR DESCRIPTION
## Description

Fixes #8390.

The bug-report issue form currently passes `'{vue}'` as the npm package matcher. On Windows, `envinfo` exits successfully but omits the `npmPackages` section, so reports do not include the Vue version the template asks for.

Use the literal `vue` package name instead. This is shell-independent and keeps the command scoped to the package the form needs.

### Reproduction

On Windows 11 with Node 24.12.0 and envinfo 7.21.0:

- `npx envinfo --system --npmPackages '{vue}' --binaries --browsers` prints no `npmPackages` section.
- `npx envinfo --system --npmPackages vue --binaries --browsers` prints `vue: catalog: => 3.5.41`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] No changes to `pnpm-lock.yaml`

## Checklist

- [x] The PR title uses the repository's conventional prefix.
- [x] My change follows the project's formatting rules.
- [x] I performed a self-review of the diff.
- [x] The change generates no new warnings.
- [x] No dependent changes are required.

## Validation

- Repository `oxfmt --check` passed for `.github/ISSUE_TEMPLATE/bug-report.yml`.
- `git diff --check` passed.
- The original and corrected commands were run side by side on Windows as shown above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bug report template’s system information command to improve Vue package detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->