### PR TITLE
fix: make bug report envinfo command cross-platform

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
     id: system-info
     attributes:
       label: System Info
-      description: Output of `npx envinfo --system --npmPackages '{vue}' --binaries --browsers`
+      description: Output of `npx envinfo --system --npmPackages vue --binaries --browsers`
       render: shell
       placeholder: System, Binaries, Browsers
     validations:


### PR DESCRIPTION
## Summary

Fixes #8390.

The bug report template wraps the single `vue` package name in a brace pattern and POSIX-style single quotes:

```shell
npx envinfo --system --npmPackages '{vue}' --binaries --browsers
```

On Windows, this exits successfully but omits the entire `npmPackages` section. `cmd.exe` also does not treat single quotes as quoting characters.

Use the direct package name instead. It is accepted by both Windows shells and still requests exactly the Vue information needed by the template.

## Verification

Environment: Windows 11, Node.js 24.12.0, envinfo 7.21.0.

- Reproduced the current command omitting `npmPackages`.
- Verified the updated command in PowerShell and `cmd.exe`; both report `vue: catalog: => 3.5.41`.
- `pnpm exec eslint --stdin --stdin-filename .github/ISSUE_TEMPLATE/bug-report.yml --no-ignore --max-warnings=0`
- `pnpm exec oxfmt --check .github/ISSUE_TEMPLATE/bug-report.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the bug report template’s system information instructions to use the correct Vue package name when collecting environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->