### PR TITLE
fix: reserve space for antdv-next textarea count

### DIFF
--- a/packages/styles/src/antdv-next/index.css
+++ b/packages/styles/src/antdv-next/index.css
@@ -7,6 +7,11 @@
   color: inherit;
 }
 
+/* Reserve the counter's line below the textarea inside clipped form controls. */
+.ant-input-textarea-show-count {
+  margin-block-end: calc(var(--ant-font-size) * var(--ant-line-height));
+}
+
 .ant-btn {
   .anticon {
     display: inline-flex;


### PR DESCRIPTION
## Description

Fixes #8394.

`antdv-next` positions the textarea count one font line below the control using `fontSize * lineHeight`. The counter renders and updates, but Vben's form content has two clipping ancestors, so the count falls outside their bounds.

Reserve the same line height as a bottom margin on `.ant-input-textarea-show-count` in the existing antdv-next style overrides. This keeps the shared form clipping and collapse implementation unchanged, follows the library's font tokens rather than a hard-coded pixel size, and does not match textareas without the count class.

### Reproduction

In `web-antdv-next`, render this schema through the normal form adapter:

```ts
{
  component: 'Textarea',
  componentProps: { rows: 3, showCount: true, maxlength: 200 },
  fieldName: 'remark',
  formItemClass: 'items-start',
  label: 'Remark',
}
```

Before the change, typing `hello` creates `5 / 200` below the control, but it is clipped. After this change the form reserves space for that line.

### Validation

- Local browser regression harness using the actual application component registry, form adapter and styles in headless Edge on Windows. A geometry assertion checking the counter against overflow-clipping ancestors fails before the change and passes after it. DOM text / `isVisible()` alone do not detect this bug.
- On the actual fix worktree, 14 browser cases passed: 1280x800 and 390x844, each with small/default/large size, 20px theme font size, allowClear enabled, autoSize enabled, and showCount disabled. Screenshots were inspected. These are local diagnostic tests, not new committed CI tests; full collapse interaction coverage was not performed.
- `pnpm test:unit`: 80 files / 571 tests passed, exit 0. Teardown emitted AbortError and an icon-picker worker/network timeout warning.
- `pnpm --filter @vben/web-antdv-next build`: passed, with dependency BigInt target warnings.
- `pnpm exec oxfmt --check packages/styles/src/antdv-next/index.css`, `pnpm exec stylelint packages/styles/src/antdv-next/index.css`, and `git diff --check`: passed.
- Full `oxlint --deny-warnings` and `oxfmt --check .` are not green: unchanged `playground/src/adapter/vxe-table.ts:359` has a forbidden non-null assertion and that file has formatting errors. No unrelated files were changed to address these.

## Type of change

- [x] Bug fix
- [x] No lockfile changes

## Checklist

- [x] Existing unit tests pass locally
- [x] Changed stylesheet passes formatting and Stylelint
- [x] Self-reviewed; explanation included for reserved space
- [x] Local browser regression fails before and passes after
- [ ] Committed automated browser regression (local harness only)
- [ ] Full repository lint green (unrelated failures listed above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing below counted textareas within clipped form controls to keep the character count visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->